### PR TITLE
[Chore] 로컬 개발 환경 구성을 위한 Docker 기반의 PostgreSQL, MinIO 실행 방법 정의

### DIFF
--- a/infra/local/.env.example
+++ b/infra/local/.env.example
@@ -1,0 +1,8 @@
+# MinIO
+MINIO_ROOT_USER=admin
+MINIO_ROOT_PASSWORD=my-very-secure-pw
+
+# PostgreSQL
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=my-very-secure-pw
+POSTGRES_DB=joka

--- a/infra/local/docker-compose.yaml
+++ b/infra/local/docker-compose.yaml
@@ -1,0 +1,31 @@
+services:
+  minio:
+    image: minio/minio:latest
+    container_name: joka-minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    volumes:
+      - minio_data:/data
+    command: 'server /data --console-address ":9001"'
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:17
+    container_name: joka-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+volumes:
+  minio_data:
+  pg_data:


### PR DESCRIPTION
## 📌 관련 이슈

* #20 

Closed: #20 

<br>

## ✨ 작업 개요

* [x] docker-compose.yaml 작성
* [x] docker compose up / down 명령어로 로컬 환경 저장소 실행 및 종료가 가능
* [x] .env.example 작성

<br>

## 🧹 작업 상세 내용

### 1️⃣ Docker Compose 설정

하나의 서비스에 Docker 컨테이너를 둘 이상 사용하는 경우, Docker Compose를 사용하면 관리가 편리합니다.
이에 따라 `docker-compose.yaml` 파일을 작성하였으며, 로컬 개발 환경에서도 보안에 신경쓸 수 있도록 환경 변수 처리를 완료하였습니다.
실행 방법은 하단의 2️⃣를 참고해주시기 바랍니다!

---

### 2️⃣ 로컬 개발 환경 구성 방법

아래의 플로우에 따라 진행합니다.
1. 터미널을 열어준 후, infra/local 폴더로 이동합니다. (`cd infra/local`)
2. .env.example을 .env로 복사합니다. (`cp .env.example .env`)
3. .env의 내용을 원하는대로 수정합니다. (`vi .env`) - 귀찮다면 수정 안해도 무방합니다!
4. 컨테이너를 실행합니다. (`docker compose up -d`)
5. 컨테이너가 실행된 경우, 로그를 확인합니다. (`docker compose logs -f`)
6. 로그 상 이상이 없어보이는 경우, MinIO 콘솔에 접속합니다. (브라우저로 http://localhost:9001에 접속 후 `.env`에 작성한 내용으로 로그인)
7. Datagrip 등을 통해 PostgreSQL에 연결해봅니다.

참고: 로컬 개발이 완료된 후, 컨테이너를 종료하고 싶다면 infra/local 폴더에서 `docker compose down`을 입력합니다.

---

## 🔍 고민 / 결정 사항

* 개발 환경에서는 Cloudflare R2를 사용할 예정이나, 해당 기술은 Dockerize되지 않았기에 대체제로 MinIO를 사용하였습니다. 
  * 코드 단의 수정 없이 두 저장소에 각각 연결 가능한지 확인이 필요합니다.
* PostgreSQL은 Supabase를 사용할 예정인데, IaC를 어떻게 적용해야할지 판단이 서질 않습니다.

---

## 💬 참고 사항

* 상술한 내용은 로컬 맥북에 `Docker`가 설치되어 있는 것을 가정합니다.
* 상술한 플로우에 따라 로컬 개발 환경 구성에 성공했다면, `docker compose down` 명령어를 반드시 입력할 필요는 없습니다! 
  * `docker compose up`만 하고 `down`하지 않았다면, 맥북이 재시동될 때마다 알아서 켜지므로 바로 개발할 수 있습니다. (=맥북이 힘들어 할지도?)
  * `docker compose down`을 입력했다면, 맥북 재시동 시마다 infra/local 경로에서 `docker compose up` 명령어를 입력해주어야 합니다.
