### PR TITLE
[Feat] 인증 플로우 — 로그인/AuthGuard/권한 분기/TopBar (#60)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^10.3.6",

--- a/apps/web/src/app/providers/auth-guard.tsx
+++ b/apps/web/src/app/providers/auth-guard.tsx
@@ -48,25 +48,24 @@ export function AuthGuard() {
   const isPublic = PUBLIC_PATHS.has(location.pathname);
 
   const isCheckingSession = status === 'idle' && meQuery.isPending;
-  const isBlockedFromPrivate = status === 'unauthenticated' && !isPublic;
-  const isAlreadyLoggedIn = status === 'authenticated' && isPublic;
-  const lacksUploadPermission =
-    status === 'authenticated' &&
-    isEditorOnly(location.pathname) &&
-    !canUpload(user?.role);
-
   if (isCheckingSession) {
     return <GuardFallback />;
   }
 
+  const isBlockedFromPrivate = status === 'unauthenticated' && !isPublic;
   if (isBlockedFromPrivate) {
     return <Navigate to="/login" replace state={{ from: location.pathname }} />;
   }
 
+  const isAlreadyLoggedIn = status === 'authenticated' && isPublic;
   if (isAlreadyLoggedIn) {
     return <Navigate to="/photos" replace />;
   }
 
+  const lacksUploadPermission =
+    status === 'authenticated' &&
+    isEditorOnly(location.pathname) &&
+    !canUpload(user?.role);
   if (lacksUploadPermission) {
     return <Navigate to="/photos" replace />;
   }

--- a/apps/web/src/app/providers/auth-guard.tsx
+++ b/apps/web/src/app/providers/auth-guard.tsx
@@ -1,2 +1,84 @@
-// role 기반 라우트 가드 / redirect 정책
-export {};
+import { useEffect } from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+import { useAuthStore, useMe, canUpload } from '@/features/auth';
+import { authTokenStore } from '@/shared/api/auth-token';
+import { readCookie } from '@/shared/api/cookie';
+import { Skeleton } from '@/shared/ui/skeleton';
+
+const PUBLIC_PATHS = new Set(['/login']);
+const EDITOR_ONLY_PATHS: Array<string | RegExp> = ['/upload'];
+
+function bootstrapAccessToken() {
+  if (authTokenStore.get()) return;
+
+  const cookieToken = readCookie('accessToken');
+  if (cookieToken) {
+    authTokenStore.set(cookieToken);
+  }
+}
+
+function isEditorOnly(path: string): boolean {
+  return EDITOR_ONLY_PATHS.some((pattern) =>
+    typeof pattern === 'string' ? path.startsWith(pattern) : pattern.test(path),
+  );
+}
+
+export function AuthGuard() {
+  const location = useLocation();
+
+  const setUser = useAuthStore((s) => s.setUser);
+  const status = useAuthStore((s) => s.status);
+  const user = useAuthStore((s) => s.user);
+
+  useEffect(() => {
+    bootstrapAccessToken();
+  }, []);
+
+  const meQuery = useMe();
+
+  useEffect(() => {
+    if (meQuery.isSuccess) {
+      setUser(meQuery.data);
+    } else if (meQuery.isError) {
+      setUser(null);
+    }
+  }, [meQuery.isSuccess, meQuery.isError, meQuery.data, setUser]);
+
+  const isPublic = PUBLIC_PATHS.has(location.pathname);
+
+  const isCheckingSession = status === 'idle' && meQuery.isPending;
+  const isBlockedFromPrivate = status === 'unauthenticated' && !isPublic;
+  const isAlreadyLoggedIn = status === 'authenticated' && isPublic;
+  const lacksUploadPermission =
+    status === 'authenticated' &&
+    isEditorOnly(location.pathname) &&
+    !canUpload(user?.role);
+
+  if (isCheckingSession) {
+    return <GuardFallback />;
+  }
+
+  if (isBlockedFromPrivate) {
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+  }
+
+  if (isAlreadyLoggedIn) {
+    return <Navigate to="/photos" replace />;
+  }
+
+  if (lacksUploadPermission) {
+    return <Navigate to="/photos" replace />;
+  }
+
+  return <Outlet />;
+}
+
+function GuardFallback() {
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <Skeleton className="h-8 w-40" />
+      <Skeleton className="mt-4 h-64 w-full" />
+    </div>
+  );
+}

--- a/apps/web/src/app/providers/router.tsx
+++ b/apps/web/src/app/providers/router.tsx
@@ -9,16 +9,19 @@ import { AuthPage } from '@/pages/auth';
 import { PhotoDetailPage } from '@/pages/photo-detail';
 import { PhotoListPage } from '@/pages/photo-list';
 import { UploadPage } from '@/pages/upload';
+import { TopBar } from '@/widgets/top-bar';
 
+import { AuthGuard } from './auth-guard';
 import { RouteErrorFallback } from './route-error-fallback';
 
 /**
  * 모든 라우트 위에 항상 마운트되는 레이아웃.
- * 후속 PR에서 TopBar 위젯이 위치할 자리.
+ * - TopBar는 인증 여부와 무관하게 유지되고, AuthGuard는 Outlet 위에 들어와 분기한다.
  */
 function RootLayout() {
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <TopBar />
       <Outlet />
     </div>
   );
@@ -41,30 +44,35 @@ const router = createBrowserRouter([
     errorElement: <RouteErrorFallback />,
     children: [
       {
-        index: true,
-        element: <Navigate to="/photos" replace />,
+        element: <AuthGuard />,
+        children: [
+          {
+            index: true,
+            element: <Navigate to="/photos" replace />,
+          },
+          {
+            path: '/login',
+            element: <AuthPage />,
+            errorElement: <RouteErrorFallback backTo="/login" />,
+          },
+          {
+            path: '/upload',
+            element: <UploadPage />,
+            errorElement: <RouteErrorFallback backTo="/photos" />,
+          },
+          {
+            path: '/photos',
+            element: <PhotoListPage />,
+            errorElement: <RouteErrorFallback backTo="/photos" />,
+          },
+          {
+            path: '/photos/:id',
+            element: <PhotoDetailPage />,
+            errorElement: <RouteErrorFallback backTo="/photos" />,
+          },
+          { path: '*', element: <NotFoundPage /> },
+        ],
       },
-      {
-        path: '/login',
-        element: <AuthPage />,
-        errorElement: <RouteErrorFallback backTo="/login" />,
-      },
-      {
-        path: '/upload',
-        element: <UploadPage />,
-        errorElement: <RouteErrorFallback backTo="/photos" />,
-      },
-      {
-        path: '/photos',
-        element: <PhotoListPage />,
-        errorElement: <RouteErrorFallback backTo="/photos" />,
-      },
-      {
-        path: '/photos/:id',
-        element: <PhotoDetailPage />,
-        errorElement: <RouteErrorFallback backTo="/photos" />,
-      },
-      { path: '*', element: <NotFoundPage /> },
     ],
   },
 ]);

--- a/apps/web/src/entities/user/index.ts
+++ b/apps/web/src/entities/user/index.ts
@@ -1,1 +1,1 @@
-export {};
+export type { User, UserRole } from './model/types';

--- a/apps/web/src/entities/user/model/types.ts
+++ b/apps/web/src/entities/user/model/types.ts
@@ -1,2 +1,8 @@
-// User, Role
-export {};
+export type UserRole = 'ADMIN' | 'EDITOR' | 'VIEWER';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+}

--- a/apps/web/src/features/auth/api/mutations.ts
+++ b/apps/web/src/features/auth/api/mutations.ts
@@ -1,2 +1,17 @@
-// login/me/refresh 등
-export {};
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { http } from '@/shared/api';
+
+import { authKeys } from './queries';
+
+export function useLogoutMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => http.post<void>('/v1/auth/logout'),
+    meta: { operationId: 'auth_logout' },
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: authKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/auth/api/queries.ts
+++ b/apps/web/src/features/auth/api/queries.ts
@@ -1,2 +1,20 @@
-// useMeQuery() 같은 read
-export {};
+import { useQuery } from '@tanstack/react-query';
+
+import type { User } from '@/entities/user';
+import { http } from '@/shared/api';
+
+export const authKeys = {
+  all: ['auth'] as const,
+  me: () => [...authKeys.all, 'me'] as const,
+};
+
+export function useMe() {
+  return useQuery({
+    queryKey: authKeys.me(),
+    queryFn: () => http.get<User>('/v1/me'),
+    staleTime: 30 * 60 * 1000,
+    retry: false,
+    throwOnError: false,
+    meta: { operationId: 'auth_me' },
+  });
+}

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -1,1 +1,14 @@
+export { useMe, authKeys } from './api/queries';
+export { useLogoutMutation } from './api/mutations';
+
+export { canUpload, canEditMeta, canDelete } from './lib/access';
+
+export { useAuthStore } from './model/store';
+export {
+  useAuthUser,
+  useAuthStatus,
+  useAuthRole,
+  useIsAuthenticated,
+} from './model/selectors';
+
 export { LoginForm } from './ui/login-form';

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -1,7 +1,7 @@
 export { useMe, authKeys } from './api/queries';
 export { useLogoutMutation } from './api/mutations';
 
-export { canUpload, canEditMeta, canDelete } from './lib/access';
+export { canUpload, canWriteMeta } from './lib/access';
 
 export { useAuthStore } from './model/store';
 export {

--- a/apps/web/src/features/auth/lib/access.test.ts
+++ b/apps/web/src/features/auth/lib/access.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+
+import { canDelete, canEditMeta, canUpload } from './access';
+
+describe('access policy', () => {
+  describe('canUpload', () => {
+    test('ADMIN, EDITOR만 업로드할 수 있다', () => {
+      expect(canUpload('ADMIN')).toBe(true);
+      expect(canUpload('EDITOR')).toBe(true);
+      expect(canUpload('VIEWER')).toBe(false);
+      expect(canUpload(undefined)).toBe(false);
+      expect(canUpload(null)).toBe(false);
+    });
+  });
+
+  describe('canEditMeta / canDelete', () => {
+    test('ADMIN은 모든 사진 편집/삭제 가능', () => {
+      expect(canEditMeta('ADMIN', 'uploader-1', 'me')).toBe(true);
+      expect(canDelete('ADMIN', 'uploader-1', 'me')).toBe(true);
+    });
+
+    test('EDITOR는 본인 업로드만 편집/삭제 가능', () => {
+      expect(canEditMeta('EDITOR', 'me', 'me')).toBe(true);
+      expect(canEditMeta('EDITOR', 'other', 'me')).toBe(false);
+      expect(canDelete('EDITOR', 'me', 'me')).toBe(true);
+      expect(canDelete('EDITOR', 'other', 'me')).toBe(false);
+    });
+
+    test('VIEWER는 편집/삭제 불가', () => {
+      expect(canEditMeta('VIEWER', 'me', 'me')).toBe(false);
+      expect(canDelete('VIEWER', 'me', 'me')).toBe(false);
+    });
+
+    test('uploaderId 또는 userId가 없으면 EDITOR도 거부 (소유권 불명)', () => {
+      expect(canEditMeta('EDITOR', undefined, 'me')).toBe(false);
+      expect(canEditMeta('EDITOR', 'me', undefined)).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/features/auth/lib/access.test.ts
+++ b/apps/web/src/features/auth/lib/access.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { canDelete, canEditMeta, canUpload } from './access';
+import { canUpload, canWriteMeta } from './access';
 
 describe('access policy', () => {
   describe('canUpload', () => {
@@ -13,27 +13,23 @@ describe('access policy', () => {
     });
   });
 
-  describe('canEditMeta / canDelete', () => {
-    test('ADMIN은 모든 사진 편집/삭제 가능', () => {
-      expect(canEditMeta('ADMIN', 'uploader-1', 'me')).toBe(true);
-      expect(canDelete('ADMIN', 'uploader-1', 'me')).toBe(true);
+  describe('canWriteMeta (수정·삭제 통합)', () => {
+    test('ADMIN은 모든 사진 쓰기 가능', () => {
+      expect(canWriteMeta('ADMIN', 'uploader-1', 'me')).toBe(true);
     });
 
-    test('EDITOR는 본인 업로드만 편집/삭제 가능', () => {
-      expect(canEditMeta('EDITOR', 'me', 'me')).toBe(true);
-      expect(canEditMeta('EDITOR', 'other', 'me')).toBe(false);
-      expect(canDelete('EDITOR', 'me', 'me')).toBe(true);
-      expect(canDelete('EDITOR', 'other', 'me')).toBe(false);
+    test('EDITOR는 본인 업로드만 쓰기 가능', () => {
+      expect(canWriteMeta('EDITOR', 'me', 'me')).toBe(true);
+      expect(canWriteMeta('EDITOR', 'other', 'me')).toBe(false);
     });
 
-    test('VIEWER는 편집/삭제 불가', () => {
-      expect(canEditMeta('VIEWER', 'me', 'me')).toBe(false);
-      expect(canDelete('VIEWER', 'me', 'me')).toBe(false);
+    test('VIEWER는 쓰기 불가', () => {
+      expect(canWriteMeta('VIEWER', 'me', 'me')).toBe(false);
     });
 
     test('uploaderId 또는 userId가 없으면 EDITOR도 거부 (소유권 불명)', () => {
-      expect(canEditMeta('EDITOR', undefined, 'me')).toBe(false);
-      expect(canEditMeta('EDITOR', 'me', undefined)).toBe(false);
+      expect(canWriteMeta('EDITOR', undefined, 'me')).toBe(false);
+      expect(canWriteMeta('EDITOR', 'me', undefined)).toBe(false);
     });
   });
 });

--- a/apps/web/src/features/auth/lib/access.ts
+++ b/apps/web/src/features/auth/lib/access.ts
@@ -1,2 +1,28 @@
-// canUpload/canDelete 같은 권한 파생
-export {};
+import type { UserRole } from '@/entities/user';
+
+type NullableRole = UserRole | null | undefined;
+
+export function canUpload(role: NullableRole): boolean {
+  return role === 'ADMIN' || role === 'EDITOR';
+}
+
+export function canEditMeta(
+  role: NullableRole,
+  uploaderId: string | undefined,
+  userId: string | undefined,
+): boolean {
+  if (role === 'ADMIN') return true;
+
+  const isEditor = role === 'EDITOR';
+  const isOwner = !!uploaderId && uploaderId === userId;
+
+  return isEditor && isOwner;
+}
+
+export function canDelete(
+  role: NullableRole,
+  uploaderId: string | undefined,
+  userId: string | undefined,
+): boolean {
+  return canEditMeta(role, uploaderId, userId);
+}

--- a/apps/web/src/features/auth/lib/access.ts
+++ b/apps/web/src/features/auth/lib/access.ts
@@ -6,7 +6,8 @@ export function canUpload(role: NullableRole): boolean {
   return role === 'ADMIN' || role === 'EDITOR';
 }
 
-export function canEditMeta(
+// 쓰기 권한은 수정과 삭제를 함께 포함한다(제품 정책: 쓰기 = 수정 + 삭제).
+export function canWriteMeta(
   role: NullableRole,
   uploaderId: string | undefined,
   userId: string | undefined,
@@ -17,12 +18,4 @@ export function canEditMeta(
   const isOwner = !!uploaderId && uploaderId === userId;
 
   return isEditor && isOwner;
-}
-
-export function canDelete(
-  role: NullableRole,
-  uploaderId: string | undefined,
-  userId: string | undefined,
-): boolean {
-  return canEditMeta(role, uploaderId, userId);
 }

--- a/apps/web/src/features/auth/model/selectors.ts
+++ b/apps/web/src/features/auth/model/selectors.ts
@@ -1,1 +1,7 @@
-export {};
+import { useAuthStore } from './store';
+
+export const useAuthUser = () => useAuthStore((s) => s.user);
+export const useAuthStatus = () => useAuthStore((s) => s.status);
+export const useAuthRole = () => useAuthStore((s) => s.user?.role);
+export const useIsAuthenticated = () =>
+  useAuthStore((s) => s.status === 'authenticated');

--- a/apps/web/src/features/auth/model/store.ts
+++ b/apps/web/src/features/auth/model/store.ts
@@ -1,2 +1,24 @@
-// Zustand: session/role + actions { status, user, role, login(), logout(), hydrate() }
-export {};
+import { create } from 'zustand';
+
+import type { User } from '@/entities/user';
+import { authTokenStore } from '@/shared/api/auth-token';
+
+export type AuthStatus = 'idle' | 'authenticated' | 'unauthenticated';
+
+interface AuthState {
+  user: User | null;
+  status: AuthStatus;
+  setUser: (user: User | null) => void;
+  reset: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  status: 'idle',
+  setUser: (user) =>
+    set({ user, status: user ? 'authenticated' : 'unauthenticated' }),
+  reset: () => {
+    authTokenStore.clear();
+    set({ user: null, status: 'unauthenticated' });
+  },
+}));

--- a/apps/web/src/features/auth/ui/login-form.tsx
+++ b/apps/web/src/features/auth/ui/login-form.tsx
@@ -1,1 +1,23 @@
-export function LoginForm() {}
+import { env } from '@/shared/config/env';
+import { Button } from '@/shared/ui/button';
+
+/**
+ * 카카오 OAuth 시작 버튼.
+ */
+export function LoginForm() {
+  const handleKakaoLogin = () => {
+    window.location.href = `${env.VITE_API_BASE_URL}/v1/auth/kakao`;
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Button
+        size="lg"
+        className="w-full bg-[#FEE500] text-[#191600] hover:bg-[#FEE500]/90"
+        onClick={handleKakaoLogin}
+      >
+        카카오로 시작하기
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/pages/auth/ui/page.tsx
+++ b/apps/web/src/pages/auth/ui/page.tsx
@@ -1,11 +1,17 @@
-// 가입/로그인 화면 — 실제 구현은 후속 PR에서 진행
+import { LoginForm } from '@/features/auth';
+
 export function AuthPage() {
   return (
-    <section className="mx-auto max-w-md p-6">
-      <h2 className="text-2xl font-semibold">로그인</h2>
-      <p className="mt-2 text-sm text-muted-foreground">
-        카카오 계정으로 로그인하세요.
-      </p>
-    </section>
+    <main className="flex min-h-screen items-center justify-center p-6">
+      <section className="w-full max-w-sm">
+        <header className="mb-8 text-center">
+          <h1 className="text-3xl font-bold">JOKA</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            우리 아이의 앨범, 함께 채우기.
+          </p>
+        </header>
+        <LoginForm />
+      </section>
+    </main>
   );
 }

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -36,14 +36,18 @@ function isRawBody(body: unknown): body is BodyInit {
 }
 
 function normalize(init: HttpInit): RequestInit {
-  const { body, ...rest } = init;
+  const { body, credentials, ...rest } = init;
+  const withCredentials: RequestInit = {
+    ...rest,
+    credentials: credentials ?? 'include',
+  };
 
   if (body === undefined || body === null) {
-    return { ...rest };
+    return withCredentials;
   }
 
   if (isRawBody(body)) {
-    return { ...rest, body };
+    return { ...withCredentials, body };
   }
 
   const mergedHeaders = new Headers(rest.headers);
@@ -51,7 +55,11 @@ function normalize(init: HttpInit): RequestInit {
     mergedHeaders.set('Content-Type', 'application/json');
   }
 
-  return { ...rest, headers: mergedHeaders, body: JSON.stringify(body) };
+  return {
+    ...withCredentials,
+    headers: mergedHeaders,
+    body: JSON.stringify(body),
+  };
 }
 
 async function parseResponse(response: Response): Promise<unknown> {

--- a/apps/web/src/shared/api/cookie.ts
+++ b/apps/web/src/shared/api/cookie.ts
@@ -1,0 +1,14 @@
+/**
+ * 브라우저 쿠키에서 특정 이름의 값을 추출한다.
+ */
+export function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+
+  const target = `${name}=`;
+  for (const segment of document.cookie.split('; ')) {
+    if (segment.startsWith(target)) {
+      return decodeURIComponent(segment.slice(target.length));
+    }
+  }
+  return null;
+}

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -1,3 +1,13 @@
+import { authTokenStore } from './auth-token';
 import { createHttpClient } from './client';
 
-export const http = createHttpClient();
+export const http = createHttpClient({
+  onUnauthorized: () => {
+    authTokenStore.clear();
+
+    if (typeof window === 'undefined') return;
+    if (window.location.pathname !== '/login') {
+      window.location.assign('/login');
+    }
+  },
+});

--- a/apps/web/src/shared/lib/business-ux-logging/index.ts
+++ b/apps/web/src/shared/lib/business-ux-logging/index.ts
@@ -12,7 +12,6 @@
 import { MEDIA_LIST_SLOW_THRESHOLD_MS } from './constants';
 
 import { log } from '@/shared/lib/logger';
-import type { UserRole } from '@/shared/types/monitoring';
 
 /** GET /media 응답이 2초 초과했을 때 호출 */
 export function recordMediaListSlow(
@@ -29,7 +28,7 @@ export function recordMediaListSlow(
 
 /** 403 발생 시 호출 (VIEWER가 수정 시도 등) */
 export function recordForbidden(context: {
-  userRole: UserRole;
+  userRole: string;
   operationId?: string;
 }): void {
   log.business('UX|forbidden|viewer_edit_attempt', {

--- a/apps/web/src/shared/lib/logger/types.ts
+++ b/apps/web/src/shared/lib/logger/types.ts
@@ -1,12 +1,12 @@
-import type { LogLayer, MediaState, UserRole } from '@/shared/types/monitoring';
+import type { LogLayer, MediaState } from '@/shared/types/monitoring';
 
-export type { LogLayer, MediaState, UserRole };
+export type { LogLayer, MediaState };
 
 /** 모든 로그에 공통으로 포함되는 컨텍스트 */
 export interface LogContext {
   operationId?: string;
   mediaState?: MediaState;
-  userRole?: UserRole;
+  userRole?: string;
   standardMessage?: string;
   [key: string]: unknown;
 }
@@ -16,5 +16,5 @@ export interface CommonFields {
   layer: LogLayer;
   operationId?: string;
   mediaState?: MediaState;
-  userRole?: UserRole;
+  userRole?: string;
 }

--- a/apps/web/src/shared/types/monitoring.ts
+++ b/apps/web/src/shared/types/monitoring.ts
@@ -3,6 +3,3 @@ export type LogLayer = 'expected' | 'business' | 'operational' | 'bug';
 
 /** 미디어 상태 */
 export type MediaState = 'DRAFT' | 'PREPARING' | 'COMPLETE';
-
-/** 사용자 역할 */
-export type UserRole = 'ADMIN' | 'EDITOR' | 'VIEWER';

--- a/apps/web/src/widgets/top-bar/ui/top-bar.tsx
+++ b/apps/web/src/widgets/top-bar/ui/top-bar.tsx
@@ -1,2 +1,79 @@
-// 타이틀/정렬/모드 토글/액션 버튼
-export function TopBar() {}
+import { Link, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import type { UserRole } from '@/entities/user';
+import {
+  canUpload,
+  useAuthStore,
+  useAuthUser,
+  useIsAuthenticated,
+  useLogoutMutation,
+} from '@/features/auth';
+import { Button } from '@/shared/ui/button';
+
+function UploadButton({ role }: { role: UserRole | undefined }) {
+  if (!canUpload(role)) return null;
+
+  return (
+    <Button variant="ghost" size="sm" asChild>
+      <Link to="/upload">업로드</Link>
+    </Button>
+  );
+}
+
+export function TopBar() {
+  const isAuthenticated = useIsAuthenticated();
+  const user = useAuthUser();
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur">
+      <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
+        <Link to="/photos" className="text-lg font-semibold tracking-tight">
+          JOKA
+        </Link>
+
+        {isAuthenticated ? (
+          <nav className="flex items-center gap-2">
+            <UploadButton role={user?.role} />
+            <span className="hidden text-sm text-muted-foreground sm:inline">
+              {user?.name}
+            </span>
+            <LogoutButton />
+          </nav>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+function LogoutButton() {
+  const navigate = useNavigate();
+  const reset = useAuthStore((s) => s.reset);
+  const logoutMutation = useLogoutMutation();
+
+  const handleLogout = () => {
+    logoutMutation.mutate(undefined, {
+      onSuccess: () => {
+        reset();
+        toast.success('로그아웃되었습니다.');
+        navigate('/login', { replace: true });
+      },
+      onError: () => {
+        reset();
+        toast.success('네트워크 문제가 있었지만 안전하게 로그아웃되었습니다.');
+        navigate('/login', { replace: true });
+      },
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={logoutMutation.isPending}
+      onClick={handleLogout}
+    >
+      {logoutMutation.isPending ? '로그아웃 중…' : '로그아웃'}
+    </Button>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zustand:
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
       '@storybook/addon-a11y':
         specifier: ^10.3.6
@@ -5472,6 +5475,24 @@ packages:
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -10720,3 +10741,9 @@ snapshots:
       youch-core: 0.3.3
 
   zod@4.3.5: {}
+
+  zustand@5.0.14(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)


### PR DESCRIPTION
## 📌 관련 이슈
* #60
---
## 🧹 작업 내용
JOKA 프론트엔드의 인증 전반 구현

1. **User 도메인 타입** — `User`/`UserRole` 정의. 권한 분기의 기준 타입
2. **HTTP 클라이언트 인증 연동** — `credentials: 'include'` 기본값(쿠키 자동 전송)
3. **세션 상태 단일 출처** — Zustand `useAuthStore`(user + status) + selector 훅 / 토큰은 `authTokenStore`(메모리) / user는 store로 분리
4. **권한 정책** — `canUpload`/`canEditMeta`/`canDelete`를 `lib/access.ts`에 모음. 
5. **AuthGuard** — 쿠키 부트 → `/me` 조회 → role 기반 라우트 분기 (비로그인 차단, VIEWER의 `/upload` 차단)
6. **TopBar 위젯** — 사용자 표시, 권한 기반 업로드 메뉴, 로그아웃

---
## 🛠️ 테스트
* [x] 단위 테스트 통과 (`access` 권한 정책 — role별/소유권/방어 케이스)
* [x] 빌드 통과
* [x] 백엔드 영향 없음 (프론트 only)
---
## ⚠️ 개발 환경에서의 로그인 (CORS 이슈)
현재 **로컬 개발 환경에서는 CORS 문제로 카카오 로그인 버튼이 동작하지 않음.**   
프론트(dev 서버)와 백엔드/카카오의 출처가 달라, OAuth 리다이렉트와 쿠키 설정이 막힘.

리뷰/동작 확인 시에는 콘솔에서 토큰을 직접 주입해 보호 페이지로 진입할 수 있음:
```js
// 브라우저 콘솔에서 (백엔드에서 발급받은 유효한 accessToken 사용)
document.cookie = 'accessToken=<발급받은_토큰>; path=/';
location.assign('/photos');
```
부트 시 `AuthGuard`가 이 쿠키를 읽어 `authTokenStore`에 옮기고 `/me`를 호출하므로, 이후 흐름은 실제 로그인과 동일하게 동작함.

**정상 동작(로그인 버튼)을 위해 필요한 것**
* 백엔드 CORS 설정 — dev 출처(`http://localhost:5173` 등)를 허용 origin에 추가, `Access-Control-Allow-Credentials: true`
* 쿠키 전송을 위한 `SameSite`/`Secure` 정책 정리 (cross-site 쿠키 허용)
* 카카오 OAuth redirect URI에 dev 콜백 주소 등록
* (또는) dev 서버 프록시로 백엔드 요청을 동일 출처로 우회시켜 CORS 자체를 회피  

---
## 🔍 고민 / 결정 사항
### ① 로그인 → 보호 페이지 진입 흐름
```mermaid
flowchart TD
  Login["/login — 카카오 버튼"] --> Kakao["백엔드 /v1/auth/kakao → 카카오"]
  Kakao --> Callback["백엔드 콜백 — 쿠키 발급<br/>accessToken(httpOnly:false)<br/>refreshToken(httpOnly:true)"]
  Callback --> Redirect["redirect → 앱 재진입(full reload)"]
  Redirect --> Boot["AuthGuard 부트"]
  Boot --> Token["쿠키 accessToken → authTokenStore"]
  Boot --> Me["useMe() → /v1/me"]
  Me --> Store["setUser → status 'authenticated'"]
  Store --> Branch{"분기"}
  Branch -->|비로그인 + 보호경로| ToLogin["/login"]
  Branch -->|VIEWER + /upload| ToPhotos["/photos"]
  Branch -->|통과| Outlet["페이지 렌더"]
```
### ② 상태 구조 (토큰 ↔ user 분리)
```mermaid
flowchart TD
  Cookie["accessToken 쿠키"] --> TokenStore["authTokenStore<br/>(shared/api · 토큰 문자열)"]
  TokenStore --> Interceptor["HTTP 인터셉터<br/>(Authorization 헤더 자동 첨부)"]
  MeRes["/me 응답"] --> AuthStore["useAuthStore<br/>(features/auth · user + status)"]
  AuthStore --> TopBar["TopBar / AuthGuard<br/>(selector 구독)"]
  AuthStore -->|reset| TokenStore
```
* 토큰과 user는 **다른 데이터·다른 위치**.   
  * 인터셉터는 React 밖에서 토큰을 동기적으로 읽어야 해 `authTokenStore`(shared)
  * user는 화면 구독용이라 `useAuthStore`(features)
* `reset()`이 둘을 함께 비우는 facade (로그아웃/refresh 실패 시)

---
## 💬 참고 사항
### 🔎 리뷰 추천 순서
1. **`entities/user/model/types.ts`** — User 타입 (가장 단순한 출발점)
2. **`features/auth/lib/access.ts` + `access.test.ts`** — 권한 정책 (독립적)
3. **`features/auth/model/store.ts` + `selectors.ts`** — 세션 상태 단일 출처
4. **`features/auth/api/queries.ts`** — `useMe`
5. **`app/providers/auth-guard.tsx`** — 위 4개를 모두 엮는 핵심
6. (보조) `top-bar.tsx`, `login-form.tsx`, `mutations.ts` — 위 이해 후 빠르게 읽힘
### 알아둘 점
* **CORS/쿠키 정책**은 위 "개발 환경" 섹션 참고 — 백엔드·인프라 설정 필요