### PR TITLE
[Feat] 사진 업로드 — 큐 기반 순차 업로드/S3 직접 전송/취소·진행률 (#62)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.16.0",
+    "nanoid": "^5.1.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^6.30.3",

--- a/apps/web/src/app/providers/auth-guard.tsx
+++ b/apps/web/src/app/providers/auth-guard.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
+import { useAlbums, useAlbumStore } from '@/entities/album';
 import { useAuthStore, useMe, canUpload } from '@/features/auth';
 import { authTokenStore } from '@/shared/api/auth-token';
 import { readCookie } from '@/shared/api/cookie';
@@ -31,6 +32,10 @@ export function AuthGuard() {
   const status = useAuthStore((s) => s.status);
   const user = useAuthStore((s) => s.user);
 
+  const setAlbum = useAlbumStore((s) => s.setCurrent);
+  const clearAlbum = useAlbumStore((s) => s.clear);
+  const currentAlbum = useAlbumStore((s) => s.current);
+
   useEffect(() => {
     bootstrapAccessToken();
   }, []);
@@ -42,8 +47,22 @@ export function AuthGuard() {
       setUser(meQuery.data);
     } else if (meQuery.isError) {
       setUser(null);
+      clearAlbum();
     }
-  }, [meQuery.isSuccess, meQuery.isError, meQuery.data, setUser]);
+  }, [meQuery.isSuccess, meQuery.isError, meQuery.data, setUser, clearAlbum]);
+
+  const albumsQuery = useAlbums({ enabled: meQuery.isSuccess });
+
+  useEffect(() => {
+    if (!albumsQuery.isSuccess) return;
+
+    const first = albumsQuery.data[0] ?? null;
+    const shouldUpdate = first !== null && first.id !== currentAlbum?.id;
+
+    if (shouldUpdate) {
+      setAlbum(first);
+    }
+  }, [albumsQuery.isSuccess, albumsQuery.data, currentAlbum?.id, setAlbum]);
 
   const isPublic = PUBLIC_PATHS.has(location.pathname);
 

--- a/apps/web/src/entities/album/api/keys.ts
+++ b/apps/web/src/entities/album/api/keys.ts
@@ -1,0 +1,4 @@
+export const albumKeys = {
+  all: ['albums'] as const,
+  list: () => [...albumKeys.all, 'list'] as const,
+};

--- a/apps/web/src/entities/album/api/queries.ts
+++ b/apps/web/src/entities/album/api/queries.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { http } from '@/shared/api';
+
+import type { Album } from '../model/types';
+import { albumKeys } from './keys';
+
+interface AlbumListResponse {
+  items: Album[];
+}
+
+export function useAlbums(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: albumKeys.list(),
+    queryFn: async () => {
+      const response = await http.get<AlbumListResponse>('/v1/albums');
+      return response.items;
+    },
+    staleTime: 30 * 60 * 1000,
+    enabled: options?.enabled ?? true,
+    retry: false,
+    throwOnError: false,
+    meta: { operationId: 'album_list' },
+  });
+}

--- a/apps/web/src/entities/album/index.ts
+++ b/apps/web/src/entities/album/index.ts
@@ -1,0 +1,5 @@
+export { albumKeys } from './api/keys';
+export { useAlbums } from './api/queries';
+
+export type { Album } from './model/types';
+export { useAlbumStore } from './model/store';

--- a/apps/web/src/entities/album/model/store.ts
+++ b/apps/web/src/entities/album/model/store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+import { albumIdStore } from '@/shared/api/album-id';
+
+import type { Album } from './types';
+
+interface AlbumState {
+  current: Album | null;
+  setCurrent: (album: Album | null) => void;
+  clear: () => void;
+}
+
+export const useAlbumStore = create<AlbumState>((set) => ({
+  current: null,
+  setCurrent: (album) => {
+    albumIdStore.set(album?.id ?? null);
+    set({ current: album });
+  },
+  clear: () => {
+    albumIdStore.clear();
+    set({ current: null });
+  },
+}));

--- a/apps/web/src/entities/album/model/types.ts
+++ b/apps/web/src/entities/album/model/types.ts
@@ -1,0 +1,4 @@
+export interface Album {
+  id: string;
+  name: string;
+}

--- a/apps/web/src/features/auth/api/keys.ts
+++ b/apps/web/src/features/auth/api/keys.ts
@@ -1,0 +1,4 @@
+export const authKeys = {
+  all: ['auth'] as const,
+  me: () => [...authKeys.all, 'me'] as const,
+};

--- a/apps/web/src/features/auth/api/mutations.ts
+++ b/apps/web/src/features/auth/api/mutations.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAlbumStore } from '@/entities/album';
 import { http } from '@/shared/api';
 
-import { authKeys } from './queries';
+import { authKeys } from './keys';
 
 export function useLogoutMutation() {
   const queryClient = useQueryClient();

--- a/apps/web/src/features/auth/api/mutations.ts
+++ b/apps/web/src/features/auth/api/mutations.ts
@@ -1,17 +1,20 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { useAlbumStore } from '@/entities/album';
 import { http } from '@/shared/api';
 
 import { authKeys } from './queries';
 
 export function useLogoutMutation() {
   const queryClient = useQueryClient();
+  const clearAlbum = useAlbumStore((s) => s.clear);
 
   return useMutation({
     mutationFn: () => http.post<void>('/v1/auth/logout'),
     meta: { operationId: 'auth_logout' },
     onSuccess: () => {
       queryClient.removeQueries({ queryKey: authKeys.all });
+      clearAlbum();
     },
   });
 }

--- a/apps/web/src/features/auth/api/queries.ts
+++ b/apps/web/src/features/auth/api/queries.ts
@@ -3,10 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { User } from '@/entities/user';
 import { http } from '@/shared/api';
 
-export const authKeys = {
-  all: ['auth'] as const,
-  me: () => [...authKeys.all, 'me'] as const,
-};
+import { authKeys } from './keys';
 
 export function useMe() {
   return useQuery({

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -1,4 +1,5 @@
-export { useMe, authKeys } from './api/queries';
+export { authKeys } from './api/keys';
+export { useMe } from './api/queries';
 export { useLogoutMutation } from './api/mutations';
 
 export { canUpload, canWriteMeta } from './lib/access';

--- a/apps/web/src/features/photo-upload/api/mutations.test.ts
+++ b/apps/web/src/features/photo-upload/api/mutations.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { uploadSinglePhoto } from './mutations';
+import type { UploadQueueItem } from '../model/types';
+
+const mocks = vi.hoisted(() => ({
+  httpPost: vi.fn(),
+  putToS3: vi.fn(),
+  onConfirmDone: vi.fn(),
+  onUploadUrlsRequest: vi.fn(),
+  destroy: vi.fn(),
+  createFlow: vi.fn(),
+}));
+
+vi.mock('@/shared/api', () => ({
+  http: {
+    post: mocks.httpPost,
+    get: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+vi.mock('../lib/s3-uploader', () => ({
+  putToS3: mocks.putToS3,
+}));
+
+vi.mock('@/shared/lib/media-upload-logging', () => ({
+  createMediaUploadFlow: mocks.createFlow,
+}));
+
+function makeItem(overrides: Partial<UploadQueueItem> = {}): UploadQueueItem {
+  return {
+    id: 'q-1',
+    file: new File([new Uint8Array(10)], 'a.jpg', { type: 'image/jpeg' }),
+    description: '설명',
+    status: 'pending',
+    progress: 0,
+    retryCount: 0,
+    ...overrides,
+  };
+}
+
+function mockHappyResponses() {
+  mocks.httpPost
+    .mockResolvedValueOnce({ id: 'media-1', state: 'DRAFT' })
+    .mockResolvedValueOnce({ url: 'https://s3/url' })
+    .mockResolvedValueOnce({})
+    .mockResolvedValueOnce({});
+  mocks.putToS3.mockResolvedValueOnce(undefined);
+}
+
+describe('uploadSinglePhoto', () => {
+  beforeEach(() => {
+    mocks.httpPost.mockReset();
+    mocks.putToS3.mockReset();
+    mocks.onConfirmDone.mockReset();
+    mocks.onUploadUrlsRequest.mockReset();
+    mocks.destroy.mockReset();
+    mocks.createFlow.mockReset();
+    mocks.createFlow.mockReturnValue({
+      onUploadUrlsRequest: mocks.onUploadUrlsRequest,
+      onConfirmDone: mocks.onConfirmDone,
+      destroy: mocks.destroy,
+    });
+  });
+
+  test('올리면 mediaId를 반환하고 단계가 순서대로 진행된다', async () => {
+    mockHappyResponses();
+
+    const onStep = vi.fn();
+    const onProgress = vi.fn();
+
+    const mediaId = await uploadSinglePhoto(makeItem(), { onStep, onProgress });
+
+    expect(mediaId).toBe('media-1'); // 결과
+    expect(onStep.mock.calls.map((c) => c[0])).toEqual([
+      'create',
+      'urls',
+      'put',
+      'contents',
+      'confirm',
+    ]);
+    expect(mocks.onConfirmDone).toHaveBeenCalledWith(true); // 성공 기록
+    expect(mocks.destroy).toHaveBeenCalled(); // 정리 보장
+  });
+
+  test('create로 받은 id가 이후 단계 URL에 일관되게 쓰인다', async () => {
+    mocks.httpPost
+      .mockResolvedValueOnce({ id: 'XYZ', state: 'DRAFT' })
+      .mockResolvedValueOnce({ url: 'u' })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+    mocks.putToS3.mockResolvedValueOnce(undefined);
+
+    await uploadSinglePhoto(makeItem(), {
+      onStep: vi.fn(),
+      onProgress: vi.fn(),
+    });
+
+    const urls = mocks.httpPost.mock.calls.map((c) => c[0] as string);
+    expect(urls[1]).toContain('XYZ'); // upload-urls
+    expect(urls[2]).toContain('XYZ'); // contents
+    expect(urls[3]).toContain('XYZ'); // confirm
+  });
+
+  test('putToS3의 진행률이 onProgress로 전달된다', async () => {
+    mocks.httpPost
+      .mockResolvedValueOnce({ id: 'm', state: 'DRAFT' })
+      .mockResolvedValueOnce({ url: 'u' })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+    mocks.putToS3.mockImplementationOnce(
+      (
+        _url: string,
+        _file: File,
+        opts: { onProgress?: (p: number) => void },
+      ) => {
+        opts.onProgress?.(50);
+        return Promise.resolve();
+      },
+    );
+
+    const onProgress = vi.fn();
+    await uploadSinglePhoto(makeItem(), { onStep: vi.fn(), onProgress });
+
+    expect(onProgress).toHaveBeenCalledWith(50);
+  });
+
+  test('description 이 공백이면 파일명으로 대체된다', async () => {
+    mocks.httpPost
+      .mockResolvedValueOnce({ id: 'm', state: 'DRAFT' })
+      .mockResolvedValueOnce({ url: 'u' })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+    mocks.putToS3.mockResolvedValueOnce(undefined);
+
+    await uploadSinglePhoto(makeItem({ description: '   ' }), {
+      onStep: vi.fn(),
+      onProgress: vi.fn(),
+    });
+
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      1,
+      '/v1/media',
+      { description: 'a.jpg' },
+      undefined,
+    );
+  });
+
+  test('S3 PUT 실패 시 confirm 호출 없이 throw + destroy', async () => {
+    mocks.httpPost
+      .mockResolvedValueOnce({ id: 'm', state: 'DRAFT' })
+      .mockResolvedValueOnce({ url: 'u' });
+    mocks.putToS3.mockRejectedValueOnce(new Error('S3 down'));
+
+    await expect(
+      uploadSinglePhoto(makeItem(), { onStep: vi.fn(), onProgress: vi.fn() }),
+    ).rejects.toThrow('S3 down');
+
+    expect(mocks.httpPost).toHaveBeenCalledTimes(2);
+    expect(mocks.onConfirmDone).not.toHaveBeenCalled();
+    expect(mocks.destroy).toHaveBeenCalled();
+  });
+
+  test('/contents 실패 시 confirm 미호출 + destroy', async () => {
+    mocks.httpPost
+      .mockResolvedValueOnce({ id: 'm', state: 'DRAFT' })
+      .mockResolvedValueOnce({ url: 'u' })
+      .mockRejectedValueOnce(new Error('contents 422'));
+    mocks.putToS3.mockResolvedValueOnce(undefined);
+
+    await expect(
+      uploadSinglePhoto(makeItem(), { onStep: vi.fn(), onProgress: vi.fn() }),
+    ).rejects.toThrow('contents 422');
+
+    expect(mocks.onConfirmDone).not.toHaveBeenCalled();
+    expect(mocks.destroy).toHaveBeenCalled();
+  });
+
+  test('/confirm 실패 시 flow.onConfirmDone(false) 호출 후 throw', async () => {
+    mocks.httpPost
+      .mockResolvedValueOnce({ id: 'm', state: 'DRAFT' })
+      .mockResolvedValueOnce({ url: 'u' })
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('confirm 500'));
+    mocks.putToS3.mockResolvedValueOnce(undefined);
+
+    await expect(
+      uploadSinglePhoto(makeItem(), { onStep: vi.fn(), onProgress: vi.fn() }),
+    ).rejects.toThrow('confirm 500');
+
+    expect(mocks.onConfirmDone).toHaveBeenCalledWith(false);
+    expect(mocks.destroy).toHaveBeenCalled();
+  });
+
+  test('각 단계를 정확한 URL·body로 순서대로 호출한다', async () => {
+    mockHappyResponses();
+
+    await uploadSinglePhoto(makeItem(), {
+      onStep: vi.fn(),
+      onProgress: vi.fn(),
+    });
+
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      1,
+      '/v1/media',
+      { description: '설명' },
+      undefined,
+    );
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      2,
+      '/v1/media/media-1/upload-urls',
+      {},
+      undefined,
+    );
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      3,
+      '/v1/media/media-1/contents',
+      { url: 'media/media-1/original' },
+      undefined,
+    );
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      4,
+      '/v1/media/media-1/confirm',
+      {},
+      undefined,
+    );
+    expect(mocks.putToS3).toHaveBeenCalledWith(
+      'https://s3/url',
+      expect.any(File),
+      expect.objectContaining({ onProgress: expect.any(Function) }),
+    );
+    expect(mocks.onUploadUrlsRequest).toHaveBeenCalledWith('DRAFT');
+  });
+
+  test('signal 전달 시 각 http.post 와 putToS3 에 그대로 전파', async () => {
+    mockHappyResponses();
+
+    const controller = new AbortController();
+    await uploadSinglePhoto(makeItem(), {
+      onStep: vi.fn(),
+      onProgress: vi.fn(),
+      signal: controller.signal,
+    });
+
+    for (const call of mocks.httpPost.mock.calls) {
+      expect(call[2]).toEqual({ signal: controller.signal });
+    }
+    expect(mocks.putToS3).toHaveBeenCalledWith(
+      'https://s3/url',
+      expect.any(File),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+});

--- a/apps/web/src/features/photo-upload/api/mutations.ts
+++ b/apps/web/src/features/photo-upload/api/mutations.ts
@@ -1,2 +1,113 @@
-// useUploadPhotosMutation(), presigned flow
-export {};
+import { putToS3, PutToS3Options } from '../lib/s3-uploader';
+import { UploadQueueItem, UploadStep } from '../model/types';
+
+import { http } from '@/shared/api';
+import type { HttpInit } from '@/shared/api/client';
+
+import { createMediaUploadFlow } from '@/shared/lib/media-upload-logging';
+
+interface CreateMediaResponse {
+  id: string;
+  state: string;
+}
+
+interface UploadUrlsResponse {
+  url: string;
+}
+
+export interface UploadCallbacks {
+  onStep: (step: UploadStep) => void;
+  onProgress: (percent: number) => void;
+  signal?: AbortSignal;
+}
+
+type UploadFlow = ReturnType<typeof createMediaUploadFlow>;
+
+export async function uploadSinglePhoto(
+  item: UploadQueueItem,
+  callbacks: UploadCallbacks,
+): Promise<string> {
+  const { onStep, onProgress, signal } = callbacks;
+  const reqOptions = signal ? { signal } : undefined;
+
+  onStep('create');
+  const mediaId = await createMedia(item, reqOptions);
+
+  const flow = createMediaUploadFlow(mediaId);
+
+  try {
+    onStep('urls');
+    flow.onUploadUrlsRequest('DRAFT');
+    const url = await getUploadUrl(mediaId, reqOptions);
+
+    onStep('put');
+    const putOptions: PutToS3Options = { onProgress };
+    if (signal) {
+      putOptions.signal = signal;
+    }
+    await putToS3(url, item.file, putOptions);
+
+    onStep('contents');
+    await registerContents(mediaId, reqOptions);
+
+    onStep('confirm');
+    await confirmMedia(mediaId, flow, reqOptions);
+
+    return mediaId;
+  } finally {
+    flow.destroy();
+  }
+}
+
+async function createMedia(
+  item: UploadQueueItem,
+  reqOptions?: HttpInit,
+): Promise<string> {
+  const created = await http.post<CreateMediaResponse>(
+    '/v1/media',
+    { description: item.description.trim() || item.file.name },
+    reqOptions,
+  );
+
+  return created.id;
+}
+
+async function getUploadUrl(
+  mediaId: string,
+  reqOptions?: HttpInit,
+): Promise<string> {
+  const { url } = await http.post<UploadUrlsResponse>(
+    `/v1/media/${mediaId}/upload-urls`,
+    {},
+    reqOptions,
+  );
+
+  return url;
+}
+
+async function registerContents(
+  mediaId: string,
+  reqOptions?: HttpInit,
+): Promise<void> {
+  await http.post(
+    `/v1/media/${mediaId}/contents`,
+    {
+      url: `media/${mediaId}/original`,
+    },
+    reqOptions,
+  );
+}
+
+async function confirmMedia(
+  mediaId: string,
+  flow: UploadFlow,
+  reqOptions?: HttpInit,
+): Promise<void> {
+  try {
+    await http.post(`/v1/media/${mediaId}/confirm`, {}, reqOptions);
+    flow.onConfirmDone(true);
+  } catch (err) {
+    flow.onConfirmDone(false);
+    throw err;
+  }
+}

--- a/apps/web/src/features/photo-upload/index.ts
+++ b/apps/web/src/features/photo-upload/index.ts
@@ -1,2 +1,8 @@
+export type { UploadQueueItem, UploadStatus, UploadStep } from './model/types';
+
+export { useUploadRunner } from './model/runner';
+export { useUploadQueueStore } from './model/store';
+
 export { UploadDropzone } from './ui/upload-dropzone';
+export { UploadItem } from './ui/upload-item';
 export { UploadProgress } from './ui/upload-progress';

--- a/apps/web/src/features/photo-upload/lib/filename.test.ts
+++ b/apps/web/src/features/photo-upload/lib/filename.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+
+import { stripExtension } from './filename';
+
+describe('stripExtension', () => {
+  test('일반 파일', () => {
+    expect(stripExtension('photo.jpg')).toBe('photo');
+  });
+
+  test('다중 dot 은 마지막만 제거', () => {
+    expect(stripExtension('my.photo.jpg')).toBe('my.photo');
+  });
+
+  test('확장자 없음은 그대로', () => {
+    expect(stripExtension('photo')).toBe('photo');
+  });
+
+  test('dotfile (.gitignore) 은 그대로', () => {
+    expect(stripExtension('.gitignore')).toBe('.gitignore');
+  });
+});

--- a/apps/web/src/features/photo-upload/lib/filename.ts
+++ b/apps/web/src/features/photo-upload/lib/filename.ts
@@ -1,0 +1,8 @@
+export function stripExtension(name: string): string {
+  const dotIdx = name.lastIndexOf('.');
+
+  if (dotIdx <= 0) {
+    return name;
+  }
+  return name.slice(0, dotIdx);
+}

--- a/apps/web/src/features/photo-upload/lib/s3-uploader.test.ts
+++ b/apps/web/src/features/photo-upload/lib/s3-uploader.test.ts
@@ -1,0 +1,236 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+  type Mock,
+} from 'vitest';
+
+import { putToS3, S3UploadError } from './s3-uploader';
+
+interface FakeXhr {
+  upload: { onprogress: ((e: ProgressEvent) => void) | null };
+  onload: (() => void) | null;
+  onerror: (() => void) | null;
+  onabort: (() => void) | null;
+  status: number;
+  open: Mock;
+  setRequestHeader: Mock;
+  send: Mock;
+  abort: Mock;
+}
+
+function createFakeXhr(): FakeXhr {
+  const xhr: FakeXhr = {
+    upload: { onprogress: null },
+    onload: null,
+    onerror: null,
+    onabort: null,
+    status: 0,
+    open: vi.fn(),
+    setRequestHeader: vi.fn(),
+    send: vi.fn(),
+    abort: vi.fn(),
+  };
+  xhr.abort.mockImplementation(() => {
+    xhr.onabort?.();
+  });
+  return xhr;
+}
+
+function makeFile(type = 'image/jpeg', name = 'a.jpg', size = 100): File {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+function completeWith(xhr: FakeXhr, status: number): void {
+  xhr.status = status;
+  xhr.onload?.();
+}
+
+function emitProgress(
+  xhr: FakeXhr,
+  loaded: number,
+  total: number,
+  lengthComputable = true,
+): void {
+  xhr.upload.onprogress?.({
+    lengthComputable,
+    loaded,
+    total,
+  } as ProgressEvent);
+}
+
+describe('putToS3', () => {
+  let instances: FakeXhr[] = [];
+
+  beforeEach(() => {
+    instances = [];
+    vi.stubGlobal(
+      'XMLHttpRequest',
+      vi.fn(() => {
+        const xhr = createFakeXhr();
+        instances.push(xhr);
+        return xhr;
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test('200 응답이면 resolve하고 진행률을 전달한다', async () => {
+    // given: jpeg 파일 + 진행률 콜백
+    const file = makeFile('image/jpeg');
+    const onProgress = vi.fn();
+
+    // when: 업로드 시작 → 50% 진행 → 200 완료
+    const promise = putToS3('http://s3/url', file, { onProgress });
+    const xhr = instances[0];
+    emitProgress(xhr, 50, 100);
+    completeWith(xhr, 200);
+
+    // then: resolve + 요청 설정 + 진행률(50 → 100)
+    await expect(promise).resolves.toBeUndefined();
+    expect(xhr.open).toHaveBeenCalledWith('PUT', 'http://s3/url', true);
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'image/jpeg',
+    );
+    expect(xhr.send).toHaveBeenCalledWith(file);
+    expect(onProgress).toHaveBeenCalledWith(50);
+    expect(onProgress).toHaveBeenLastCalledWith(100);
+  });
+
+  test('빈 type이면 Content-Type을 application/octet-stream으로 보낸다', async () => {
+    // given: type이 빈 파일
+    const file = makeFile('', 'a.bin', 1);
+
+    // when: 업로드 시작 → 200 완료
+    const promise = putToS3('http://s3', file);
+    const xhr = instances[0];
+    completeWith(xhr, 200);
+
+    // then: octet-stream 폴백
+    await promise;
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'application/octet-stream',
+    );
+  });
+
+  test('성공 경계: 200 응답은 resolve한다', async () => {
+    const promise = putToS3('http://s3', makeFile());
+    completeWith(instances[0], 200);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test('성공 경계: 299 응답도 resolve한다', async () => {
+    const promise = putToS3('http://s3', makeFile());
+    completeWith(instances[0], 299);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test('실패 경계: 300 응답은 reject한다 (2xx 벗어남)', async () => {
+    const promise = putToS3('http://s3', makeFile());
+    completeWith(instances[0], 300);
+
+    await expect(promise).rejects.toBeInstanceOf(S3UploadError);
+    await expect(promise).rejects.toMatchObject({ status: 300 });
+  });
+
+  test('5xx 응답이면 status를 담은 S3UploadError로 reject한다', async () => {
+    const promise = putToS3('http://s3', makeFile());
+    completeWith(instances[0], 500);
+
+    await expect(promise).rejects.toBeInstanceOf(S3UploadError);
+    await expect(promise).rejects.toMatchObject({ status: 500 });
+  });
+
+  test('진행률은 loaded/total 비율을 반올림해 전달한다', async () => {
+    // given
+    const onProgress = vi.fn();
+
+    // when: 1/3 진행 (33.33...) → 2/3 진행 (66.66...)
+    const promise = putToS3('http://s3', makeFile(), { onProgress });
+    const xhr = instances[0];
+    emitProgress(xhr, 1, 3);
+    emitProgress(xhr, 2, 3);
+
+    // then
+    expect(onProgress).toHaveBeenCalledWith(33);
+    expect(onProgress).toHaveBeenCalledWith(67);
+
+    completeWith(xhr, 200);
+    await promise;
+  });
+
+  test('lengthComputable이 false면 진행률을 전달하지 않는다', async () => {
+    // given
+    const onProgress = vi.fn();
+
+    // when: 크기를 알 수 없는 진행 이벤트
+    const promise = putToS3('http://s3', makeFile(), { onProgress });
+    const xhr = instances[0];
+    emitProgress(xhr, 50, 100, false);
+
+    // then: onProgress 미호출 (완료 전까지)
+    expect(onProgress).not.toHaveBeenCalled();
+
+    completeWith(xhr, 200);
+    await promise;
+  });
+
+  test('onProgress를 넘기지 않아도 진행률 이벤트에서 터지지 않는다', async () => {
+    // given: 콜백 없이 업로드
+    const promise = putToS3('http://s3', makeFile());
+    const xhr = instances[0];
+
+    // when: 진행 이벤트 발생 (콜백 없음)
+    emitProgress(xhr, 50, 100);
+
+    // then: 에러 없이 정상 완료
+    completeWith(xhr, 200);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test('네트워크 에러면 status 0의 S3UploadError로 reject한다', async () => {
+    const promise = putToS3('http://s3', makeFile());
+
+    instances[0].onerror?.();
+
+    await expect(promise).rejects.toMatchObject({ status: 0 });
+  });
+
+  test('signal이 abort되면 xhr.abort를 호출하고 AbortError로 reject한다', async () => {
+    // given: 취소 컨트롤러와 함께 업로드 시작
+    const controller = new AbortController();
+    const promise = putToS3('http://s3', makeFile(), {
+      signal: controller.signal,
+    });
+
+    // when: 취소
+    controller.abort();
+
+    // then: xhr 중단 + AbortError
+    expect(instances[0].abort).toHaveBeenCalled();
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  test('이미 abort된 signal이면 xhr을 만들지 않고 즉시 reject한다', async () => {
+    // given: 미리 취소된 컨트롤러
+    const controller = new AbortController();
+    controller.abort();
+
+    // when & then: 즉시 AbortError + xhr 생성 안 됨
+    await expect(
+      putToS3('http://s3', makeFile(), { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(instances).toHaveLength(0);
+  });
+});

--- a/apps/web/src/features/photo-upload/lib/s3-uploader.ts
+++ b/apps/web/src/features/photo-upload/lib/s3-uploader.ts
@@ -1,0 +1,84 @@
+export interface PutToS3Options {
+  onProgress?: (percent: number) => void;
+  signal?: AbortSignal;
+}
+
+export class S3UploadError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'S3UploadError';
+    this.status = status;
+  }
+}
+
+type StatusCheck = { ok: true } | { ok: false; error: S3UploadError };
+
+function toPercent(event: ProgressEvent): number | null {
+  if (!event.lengthComputable) return null;
+
+  return Math.round((event.loaded / event.total) * 100);
+}
+
+function checkStatus(xhr: XMLHttpRequest): StatusCheck {
+  if (xhr.status >= 200 && xhr.status < 300) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    error: new S3UploadError(`S3 PUT 실패 (${xhr.status})`, xhr.status),
+  };
+}
+
+export function putToS3(
+  url: string,
+  file: File,
+  options: PutToS3Options = {},
+): Promise<void> {
+  const { onProgress, signal } = options;
+
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('PUT', url, true);
+    xhr.setRequestHeader(
+      'Content-Type',
+      file.type || 'application/octet-stream',
+    );
+
+    xhr.upload.onprogress = (event) => {
+      const percent = toPercent(event);
+      if (percent !== null) {
+        onProgress?.(percent);
+      }
+    };
+
+    xhr.onload = () => {
+      const result = checkStatus(xhr);
+
+      if (result.ok) {
+        onProgress?.(100);
+        resolve();
+      } else {
+        reject(result.error);
+      }
+    };
+
+    xhr.onerror = () => {
+      reject(new S3UploadError('S3 PUT 네트워크 오류', 0));
+    };
+
+    xhr.onabort = () => {
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+
+    signal?.addEventListener('abort', () => xhr.abort());
+    xhr.send(file);
+  });
+}

--- a/apps/web/src/features/photo-upload/lib/validate.test.ts
+++ b/apps/web/src/features/photo-upload/lib/validate.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'vitest';
+
+import { MAX_FILE_SIZE, WARN_FILE_SIZE, validateFile } from './validate';
+
+function makeFile(name: string, type: string, size: number): File {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+describe('validateFile', () => {
+  describe('허용 형식', () => {
+    test('이미지 MIME 통과 (jpeg/png/webp/heic/heif)', () => {
+      expect(validateFile(makeFile('a.jpg', 'image/jpeg', 1024)).ok).toBe(true);
+      expect(validateFile(makeFile('a.png', 'image/png', 1024)).ok).toBe(true);
+      expect(validateFile(makeFile('a.webp', 'image/webp', 1024)).ok).toBe(
+        true,
+      );
+      expect(validateFile(makeFile('a.heic', 'image/heic', 1024)).ok).toBe(
+        true,
+      );
+      expect(validateFile(makeFile('a.heif', 'image/heif', 1024)).ok).toBe(
+        true,
+      );
+    });
+
+    test('영상 MIME 통과 (mp4/quicktime)', () => {
+      expect(validateFile(makeFile('a.mp4', 'video/mp4', 1024)).ok).toBe(true);
+      expect(validateFile(makeFile('a.mov', 'video/quicktime', 1024)).ok).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('확장자 폴백 (file.type이 비어 들어오는 케이스)', () => {
+    test('빈 MIME이어도 허용 확장자면 통과 (iOS HEIC)', () => {
+      expect(validateFile(makeFile('IMG_0001.heic', '', 1024)).ok).toBe(true);
+    });
+
+    test('빈 MIME이어도 허용 영상 확장자면 통과 (.mov)', () => {
+      expect(validateFile(makeFile('clip.mov', '', 1024)).ok).toBe(true);
+    });
+
+    test('확장자 대소문자 무시', () => {
+      expect(validateFile(makeFile('A.JPG', '', 1024)).ok).toBe(true);
+    });
+  });
+
+  describe('거부 형식', () => {
+    test('빈 MIME + 허용되지 않는 확장자 거부', () => {
+      const result = validateFile(makeFile('a.bin', '', 1024));
+      expect(result.ok).toBe(false);
+
+      if (!result.ok) {
+        expect(result.reason).toBe('mime');
+      }
+    });
+
+    test('허용되지 않는 MIME 거부 (gif)', () => {
+      const result = validateFile(makeFile('a.gif', 'image/gif', 1024));
+      expect(result.ok).toBe(false);
+
+      if (!result.ok) {
+        expect(result.reason).toBe('mime');
+      }
+    });
+
+    test('확장자도 없는 파일 거부', () => {
+      const result = validateFile(makeFile('noext', '', 1024));
+      expect(result.ok).toBe(false);
+
+      if (!result.ok) {
+        expect(result.reason).toBe('mime');
+        expect(result.message).toContain('알 수 없음');
+      }
+    });
+  });
+
+  describe('크기 정책', () => {
+    test('최대 크기 경계(50MB)는 통과', () => {
+      expect(
+        validateFile(makeFile('big.jpg', 'image/jpeg', MAX_FILE_SIZE)).ok,
+      ).toBe(true);
+    });
+
+    test('최대 크기 초과 거부', () => {
+      const result = validateFile(
+        makeFile('big.jpg', 'image/jpeg', MAX_FILE_SIZE + 1),
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('size');
+      }
+    });
+
+    test('경고 경계(20MB) 이상이면 통과하되 warning 포함', () => {
+      const result = validateFile(
+        makeFile('mid.jpg', 'image/jpeg', WARN_FILE_SIZE),
+      );
+      expect(result.ok).toBe(true);
+
+      if (result.ok) {
+        expect(result.warning).toBeDefined();
+      }
+    });
+
+    test('경고 경계 미만이면 warning 없음', () => {
+      const result = validateFile(
+        makeFile('small.jpg', 'image/jpeg', WARN_FILE_SIZE - 1),
+      );
+      expect(result.ok).toBe(true);
+
+      if (result.ok) {
+        expect(result.warning).toBeUndefined();
+      }
+    });
+  });
+});

--- a/apps/web/src/features/photo-upload/lib/validate.ts
+++ b/apps/web/src/features/photo-upload/lib/validate.ts
@@ -1,2 +1,75 @@
-// 파일 타입/개수/용량 등
-export {};
+const IMAGE_MIME = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+];
+
+const VIDEO_MIME = ['video/mp4', 'video/quicktime'];
+
+const ALLOWED_MIME = new Set([...IMAGE_MIME, ...VIDEO_MIME]);
+
+// file.type이 비어 들어오는 케이스(iOS HEIC) 보완용 확장자 화이트리스트
+const ALLOWED_EXTENSIONS = new Set([
+  'jpg',
+  'jpeg',
+  'png',
+  'webp',
+  'heic',
+  'heif',
+  'mp4',
+  'mov',
+]);
+
+export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB 초과 → 거부
+export const WARN_FILE_SIZE = 20 * 1024 * 1024; // 20MB 이상 → 경고
+
+export type ValidationResult =
+  | { ok: true; warning?: string }
+  | { ok: false; reason: 'mime' | 'size'; message: string };
+
+function getExtension(name: string): string {
+  const dotIdx = name.lastIndexOf('.');
+
+  if (dotIdx < 0) return '';
+  return name.slice(dotIdx + 1).toLowerCase();
+}
+
+function toMb(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(1);
+}
+
+function isAllowedType(file: File): boolean {
+  if (file.type && ALLOWED_MIME.has(file.type)) return true;
+
+  const extension = getExtension(file.name);
+  return ALLOWED_EXTENSIONS.has(extension);
+}
+
+export function validateFile(file: File): ValidationResult {
+  if (!isAllowedType(file)) {
+    return {
+      ok: false,
+      reason: 'mime',
+      message: `지원하지 않는 형식이에요 (${file.type || getExtension(file.name) || '알 수 없음'})`,
+    };
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return {
+      ok: false,
+      reason: 'size',
+      message: `파일이 너무 커요 (${toMb(file.size)}MB, 최대 ${MAX_FILE_SIZE / 1024 / 1024}MB)`,
+    };
+  }
+
+  if (file.size >= WARN_FILE_SIZE) {
+    return {
+      ok: true,
+      warning: `파일이 커서 업로드가 오래 걸릴 수 있어요 (${toMb(file.size)}MB)`,
+    };
+  }
+
+  return { ok: true };
+}

--- a/apps/web/src/features/photo-upload/model/runner.ts
+++ b/apps/web/src/features/photo-upload/model/runner.ts
@@ -1,0 +1,125 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef } from 'react';
+
+import { MAX_RETRY_COUNT } from '@/app/providers/constants';
+import { photoKeys } from '@/entities/photo/api/keys';
+import { recordNetworkRetryExceeded } from '@/shared/lib/business-ux-logging';
+
+import { uploadSinglePhoto } from '../api/mutations';
+import { useUploadQueueStore } from './store';
+import type { UploadQueueItem } from './types';
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'AbortError';
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+
+  return '업로드에 실패했어요.';
+}
+
+function handleSuccess(id: string, mediaId: string): void {
+  const store = useUploadQueueStore.getState();
+
+  store.setStatus(id, { status: 'success', mediaId });
+  store.setProgress(id, 100);
+}
+
+function handleFailure(id: string, err: unknown): void {
+  if (isAbortError(err)) return;
+
+  const store = useUploadQueueStore.getState();
+  store.incrementRetry(id);
+
+  const updated = store.items.find((item) => item.id === id);
+  if (updated && updated.retryCount >= MAX_RETRY_COUNT) {
+    recordNetworkRetryExceeded({
+      retryCount: updated.retryCount,
+      operationId: 'upload_flow',
+    });
+  }
+
+  store.setStatus(id, {
+    status: 'error',
+    errorMessage: describeError(err),
+  });
+}
+
+export function useUploadRunner() {
+  const queryClient = useQueryClient();
+  const abortersRef = useRef(new Map<string, AbortController>());
+
+  useEffect(() => {
+    let unmounted = false;
+
+    async function runUpload(item: UploadQueueItem): Promise<boolean> {
+      const controller = new AbortController();
+      abortersRef.current.set(item.id, controller);
+
+      try {
+        const mediaId = await uploadSinglePhoto(item, {
+          signal: controller.signal,
+          onStep: (step) =>
+            useUploadQueueStore.getState().setStatus(item.id, { step }),
+          onProgress: (pct) =>
+            useUploadQueueStore.getState().setProgress(item.id, pct),
+        });
+
+        handleSuccess(item.id, mediaId);
+        return true;
+      } catch (err) {
+        handleFailure(item.id, err);
+        return false;
+      } finally {
+        abortersRef.current.delete(item.id);
+      }
+    }
+
+    async function processNext(): Promise<void> {
+      if (unmounted) return;
+
+      const state = useUploadQueueStore.getState();
+      if (state.isRunning) return;
+
+      const next = state.items.find((it) => it.status === 'pending');
+      if (!next) return;
+
+      state.setRunning(true);
+      state.setStatus(next.id, { status: 'uploading', step: 'create' });
+
+      const success = await runUpload(next);
+      useUploadQueueStore.getState().setRunning(false);
+
+      if (success) {
+        queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
+      }
+
+      if (!unmounted) {
+        queueMicrotask(() => void processNext());
+      }
+    }
+
+    const unsubscribe = useUploadQueueStore.subscribe(() => {
+      void processNext();
+    });
+    void processNext();
+
+    return () => {
+      unmounted = true;
+      unsubscribe();
+      abortersRef.current.forEach((c) => c.abort());
+      abortersRef.current.clear();
+    };
+  }, [queryClient]);
+
+  const cancel = useCallback((id: string) => {
+    const controller = abortersRef.current.get(id);
+    controller?.abort();
+    useUploadQueueStore.getState().remove(id);
+  }, []);
+
+  return { cancel };
+}

--- a/apps/web/src/features/photo-upload/model/store.test.ts
+++ b/apps/web/src/features/photo-upload/model/store.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { useUploadQueueStore } from './store';
+
+function makeFile(name: string): File {
+  return new File([new Uint8Array(10)], name, { type: 'image/jpeg' });
+}
+
+describe('useUploadQueueStore', () => {
+  beforeEach(() => {
+    useUploadQueueStore.getState().reset();
+  });
+
+  test('enqueue 는 파일명을 description 기본값으로 채운다', () => {
+    useUploadQueueStore.getState().enqueue([makeFile('a.jpg'), makeFile('b.png')]);
+    const items = useUploadQueueStore.getState().items;
+
+    expect(items).toHaveLength(2);
+    expect(items[0].description).toBe('a');
+    expect(items[1].description).toBe('b');
+    expect(items.every((it) => it.status === 'pending')).toBe(true);
+    expect(items.every((it) => it.progress === 0)).toBe(true);
+    expect(items.every((it) => it.retryCount === 0)).toBe(true);
+  });
+
+  test('setProgress 는 0~100 으로 클램프', () => {
+    useUploadQueueStore.getState().enqueue([makeFile('a.jpg')]);
+    const id = useUploadQueueStore.getState().items[0].id;
+
+    useUploadQueueStore.getState().setProgress(id, 150);
+    expect(useUploadQueueStore.getState().items[0].progress).toBe(100);
+
+    useUploadQueueStore.getState().setProgress(id, -10);
+    expect(useUploadQueueStore.getState().items[0].progress).toBe(0);
+
+    useUploadQueueStore.getState().setProgress(id, 42);
+    expect(useUploadQueueStore.getState().items[0].progress).toBe(42);
+  });
+
+  test('setStatus 는 부분 업데이트', () => {
+    useUploadQueueStore.getState().enqueue([makeFile('a.jpg')]);
+    const id = useUploadQueueStore.getState().items[0].id;
+
+    useUploadQueueStore
+      .getState()
+      .setStatus(id, { status: 'uploading', step: 'put' });
+    const item = useUploadQueueStore.getState().items[0];
+    expect(item.status).toBe('uploading');
+    expect(item.step).toBe('put');
+    expect(item.description).toBe('a');
+  });
+
+  test('remove 후 길이 감소', () => {
+    useUploadQueueStore.getState().enqueue([makeFile('a.jpg'), makeFile('b.jpg')]);
+    const firstId = useUploadQueueStore.getState().items[0].id;
+
+    useUploadQueueStore.getState().remove(firstId);
+    const remaining = useUploadQueueStore.getState().items;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].file.name).toBe('b.jpg');
+  });
+
+  test('updateDescription 반영', () => {
+    useUploadQueueStore.getState().enqueue([makeFile('a.jpg')]);
+    const id = useUploadQueueStore.getState().items[0].id;
+
+    useUploadQueueStore.getState().updateDescription(id, '새 설명');
+    expect(useUploadQueueStore.getState().items[0].description).toBe('새 설명');
+  });
+
+  test('incrementRetry 누적', () => {
+    useUploadQueueStore.getState().enqueue([makeFile('a.jpg')]);
+    const id = useUploadQueueStore.getState().items[0].id;
+
+    useUploadQueueStore.getState().incrementRetry(id);
+    useUploadQueueStore.getState().incrementRetry(id);
+    expect(useUploadQueueStore.getState().items[0].retryCount).toBe(2);
+  });
+
+  test('reset 은 큐와 isRunning 모두 초기화', () => {
+    useUploadQueueStore.getState().enqueue([makeFile('a.jpg')]);
+    useUploadQueueStore.getState().setRunning(true);
+
+    useUploadQueueStore.getState().reset();
+    expect(useUploadQueueStore.getState().items).toEqual([]);
+    expect(useUploadQueueStore.getState().isRunning).toBe(false);
+  });
+});

--- a/apps/web/src/features/photo-upload/model/store.ts
+++ b/apps/web/src/features/photo-upload/model/store.ts
@@ -1,0 +1,89 @@
+import { nanoid } from 'nanoid';
+import { create } from 'zustand';
+
+import { stripExtension } from '../lib/filename';
+import type { UploadQueueItem } from './types';
+
+interface StatusPatch {
+  status?: UploadQueueItem['status'];
+  step?: UploadQueueItem['step'] | undefined;
+  errorMessage?: string | undefined;
+  mediaId?: string | undefined;
+}
+
+interface UploadQueueState {
+  items: UploadQueueItem[];
+  isRunning: boolean;
+
+  enqueue: (files: File[]) => void;
+  remove: (id: string) => void;
+  reset: () => void;
+
+  updateDescription: (id: string, description: string) => void;
+  setStatus: (id: string, patch: StatusPatch) => void;
+  setProgress: (id: string, progress: number) => void;
+  incrementRetry: (id: string) => void;
+
+  setRunning: (running: boolean) => void;
+}
+
+function makeItem(file: File): UploadQueueItem {
+  return {
+    id: nanoid(),
+    file,
+    description: stripExtension(file.name),
+    status: 'pending',
+    progress: 0,
+    retryCount: 0,
+  };
+}
+
+function patchItem(
+  items: UploadQueueItem[],
+  id: string,
+  update: (item: UploadQueueItem) => UploadQueueItem,
+): UploadQueueItem[] {
+  return items.map((it) => (it.id === id ? update(it) : it));
+}
+
+export const useUploadQueueStore = create<UploadQueueState>((set) => ({
+  items: [],
+  isRunning: false,
+
+  // 큐 조작
+  enqueue: (files) =>
+    set((state) => ({ items: [...state.items, ...files.map(makeItem)] })),
+  remove: (id) =>
+    set((state) => ({ items: state.items.filter((it) => it.id !== id) })),
+  reset: () => set({ items: [], isRunning: false }),
+
+  // 항목 수정
+  updateDescription: (id, description) =>
+    set((state) => ({
+      items: patchItem(state.items, id, (it) => ({ ...it, description })),
+    })),
+  setStatus: (id, patch) =>
+    set((state) => ({
+      items: patchItem(state.items, id, (it) => ({ ...it, ...patch })),
+    })),
+  setProgress: (id, progress) =>
+    set((state) => {
+      const clamped = Math.min(100, Math.max(0, progress));
+      return {
+        items: patchItem(state.items, id, (it) => ({
+          ...it,
+          progress: clamped,
+        })),
+      };
+    }),
+  incrementRetry: (id) =>
+    set((state) => ({
+      items: patchItem(state.items, id, (it) => ({
+        ...it,
+        retryCount: it.retryCount + 1,
+      })),
+    })),
+
+  // 실행 락
+  setRunning: (isRunning) => set({ isRunning }),
+}));

--- a/apps/web/src/features/photo-upload/model/types.ts
+++ b/apps/web/src/features/photo-upload/model/types.ts
@@ -1,2 +1,14 @@
-// UploadState, UploadItem
-export {};
+export type UploadStatus = 'pending' | 'uploading' | 'success' | 'error';
+export type UploadStep = 'create' | 'urls' | 'put' | 'contents' | 'confirm';
+
+export interface UploadQueueItem {
+  id: string;
+  file: File;
+  description: string;
+  status: UploadStatus;
+  step?: UploadStep | undefined;
+  progress: number;
+  mediaId?: string | undefined;
+  errorMessage?: string | undefined;
+  retryCount: number;
+}

--- a/apps/web/src/features/photo-upload/ui/upload-dropzone.tsx
+++ b/apps/web/src/features/photo-upload/ui/upload-dropzone.tsx
@@ -1,2 +1,88 @@
-// DnD + 파일 선택
-export function UploadDropzone() {}
+import { useRef, useState, type ChangeEvent, type DragEvent } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/shared/ui/button';
+import { cn } from '@/shared/lib/utils/cn';
+
+import { validateFile } from '../lib/validate';
+import { useUploadQueueStore } from '../model/store';
+
+export function UploadDropzone() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const enqueue = useUploadQueueStore((s) => s.enqueue);
+
+  function handleFiles(fileList: FileList | null): void {
+    if (!fileList) return;
+
+    const accepted: File[] = [];
+    for (const file of Array.from(fileList)) {
+      const result = validateFile(file);
+
+      if (!result.ok) {
+        toast.error(`${file.name}: ${result.message}`);
+        continue;
+      }
+
+      if (result.warning) {
+        toast.warning(`${file.name}: ${result.warning}`);
+      }
+      accepted.push(file);
+    }
+
+    if (accepted.length > 0) {
+      enqueue(accepted);
+    }
+  }
+
+  function onDrop(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setIsDragging(false);
+
+    handleFiles(e.dataTransfer.files);
+  }
+
+  function onDragOver(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setIsDragging(true);
+  }
+
+  function onDragLeave(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setIsDragging(false);
+  }
+
+  function onChange(e: ChangeEvent<HTMLInputElement>) {
+    handleFiles(e.target.files);
+    e.target.value = '';
+  }
+
+  return (
+    <div
+      onDrop={onDrop}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed p-10 transition-colors',
+        isDragging
+          ? 'border-primary bg-primary/5'
+          : 'border-border bg-muted/30',
+      )}
+    >
+      <p className="text-sm text-muted-foreground">
+        사진·영상을 여기에 끌어다 놓거나 버튼을 눌러 선택하세요.
+      </p>
+      <Button type="button" onClick={() => inputRef.current?.click()}>
+        파일 선택
+      </Button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*,video/*"
+        multiple
+        hidden
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/photo-upload/ui/upload-item.tsx
+++ b/apps/web/src/features/photo-upload/ui/upload-item.tsx
@@ -1,0 +1,81 @@
+import { Button } from '@/shared/ui/button';
+import { Input } from '@/shared/ui/input';
+
+import { useUploadQueueStore } from '../model/store';
+import type { UploadQueueItem } from '../model/types';
+
+import { UploadProgress } from './upload-progress';
+
+interface UploadItemProps {
+  item: UploadQueueItem;
+  onCancel?: (id: string) => void;
+}
+
+const statusLabel: Record<UploadQueueItem['status'], string> = {
+  pending: '대기',
+  uploading: '업로드 중',
+  success: '완료',
+  error: '실패',
+};
+
+export function UploadItem({ item, onCancel }: UploadItemProps) {
+  const updateDescription = useUploadQueueStore((s) => s.updateDescription);
+  const remove = useUploadQueueStore((s) => s.remove);
+  const setStatus = useUploadQueueStore((s) => s.setStatus);
+
+  const isPending = item.status === 'pending';
+  const isUploading = item.status === 'uploading';
+  const isError = item.status === 'error';
+
+  function retry() {
+    setStatus(item.id, {
+      status: 'pending',
+      step: undefined,
+      errorMessage: undefined,
+    });
+  }
+
+  function handleRemove() {
+    if (isUploading && onCancel) {
+      onCancel(item.id);
+      return;
+    }
+    remove(item.id);
+  }
+
+  return (
+    <div className="flex items-start gap-3 rounded-md border bg-card p-3">
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-xs text-muted-foreground">
+            {item.file.name}
+          </span>
+          <span className="ml-auto text-xs text-muted-foreground">
+            {statusLabel[item.status]}
+          </span>
+        </div>
+        <Input
+          value={item.description}
+          onChange={(e) => updateDescription(item.id, e.target.value)}
+          placeholder="남기고 싶은 말을 적어보세요"
+          disabled={!isPending}
+          maxLength={120}
+        />
+        <UploadProgress value={item.progress} />
+        {isError && item.errorMessage ? (
+          <p className="text-xs text-destructive">{item.errorMessage}</p>
+        ) : null}
+      </div>
+      <div className="flex flex-col gap-1">
+        {isError ? (
+          <Button type="button" variant="outline" size="sm" onClick={retry}>
+            재시도
+          </Button>
+        ) : null}
+        <Button type="button" variant="ghost" size="sm" onClick={handleRemove}>
+          {isUploading ? '취소' : '삭제'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/photo-upload/ui/upload-progress.tsx
+++ b/apps/web/src/features/photo-upload/ui/upload-progress.tsx
@@ -1,1 +1,28 @@
-export function UploadProgress() {}
+import { cn } from '@/shared/lib/utils/cn';
+
+interface UploadProgressProps {
+  value: number;
+  className?: string;
+}
+
+export function UploadProgress({ value, className }: UploadProgressProps) {
+  const clamped = Math.min(100, Math.max(0, value));
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className={cn(
+        'h-2 w-full overflow-hidden rounded-full bg-muted',
+        className,
+      )}
+    >
+      <div
+        className="h-full bg-primary transition-all"
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/upload/ui/page.tsx
+++ b/apps/web/src/pages/upload/ui/page.tsx
@@ -1,8 +1,61 @@
-// 관리자 업로드 화면 — 실제 구현은 후속 PR에서 진행
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import {
+  UploadDropzone,
+  UploadItem,
+  useUploadQueueStore,
+  useUploadRunner,
+} from '@/features/photo-upload';
+
 export function UploadPage() {
+  const items = useUploadQueueStore((s) => s.items);
+  const reset = useUploadQueueStore((s) => s.reset);
+
+  const { cancel } = useUploadRunner();
+
+  const navigate = useNavigate();
+  const hadItemsRef = useRef(false);
+
+  useEffect(() => {
+    if (items.length === 0) return;
+    hadItemsRef.current = true;
+
+    const inFlight = items.some(
+      (item) => item.status === 'pending' || item.status === 'uploading',
+    );
+    if (inFlight) return;
+
+    const successCount = items.filter(
+      (item) => item.status === 'success',
+    ).length;
+    if (!hadItemsRef.current || successCount === 0) return;
+
+    toast.success(`${successCount}개 업로드 완료`);
+    hadItemsRef.current = false;
+    reset();
+    navigate('/photos');
+  }, [items, navigate, reset]);
+
   return (
-    <section className="mx-auto max-w-3xl p-6">
-      <h2 className="text-2xl font-semibold">업로드</h2>
+    <section className="mx-auto max-w-3xl space-y-6 p-6">
+      <header className="space-y-1">
+        <h2 className="text-2xl font-semibold">업로드</h2>
+        <p className="text-sm text-muted-foreground">
+          이미지를 추가하면 자동으로 업로드가 시작됩니다.
+        </p>
+      </header>
+
+      <UploadDropzone />
+
+      {items.length > 0 ? (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <UploadItem key={item.id} item={item} onCancel={cancel} />
+          ))}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/shared/api/album-id.ts
+++ b/apps/web/src/shared/api/album-id.ts
@@ -1,0 +1,34 @@
+type Listener = (albumId: string | null) => void;
+
+let currentAlbumId: string | null = null;
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener(currentAlbumId);
+  }
+}
+
+export const albumIdStore = {
+  get(): string | null {
+    return currentAlbumId;
+  },
+
+  set(albumId: string | null): void {
+    if (currentAlbumId === albumId) return;
+
+    currentAlbumId = albumId;
+    notify();
+  },
+
+  clear(): void {
+    this.set(null);
+  },
+
+  subscribe(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};

--- a/apps/web/src/shared/api/client.test.ts
+++ b/apps/web/src/shared/api/client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { authTokenStore } from './auth-token';
+import { albumIdStore } from './album-id';
 import { createHttpClient } from './client';
 
 const BASE = 'http://api.test';
@@ -31,6 +32,7 @@ function headerOf(init: RequestInit | undefined, name: string): string | null {
 describe('createHttpClient', () => {
   beforeEach(() => {
     authTokenStore.clear();
+    albumIdStore.clear();
   });
 
   afterEach(() => {
@@ -58,6 +60,42 @@ describe('createHttpClient', () => {
 
       const [, init] = fetchSpy.mock.calls[0];
       expect(headerOf(init, 'Authorization')).toBeNull();
+    });
+  });
+
+  describe('X-Album-Id 헤더', () => {
+    test('albumIdStore에 값이 있으면 X-Album-Id를 주입한다', async () => {
+      albumIdStore.set('album-1');
+      const fetchSpy = stubFetch(async () => jsonResponse({ ok: true }));
+
+      const http = createHttpClient({ baseURL: BASE });
+      await http.get('/v1/media');
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(headerOf(init, 'X-Album-Id')).toBe('album-1');
+    });
+
+    test('albumIdStore가 비어 있으면 헤더를 주입하지 않는다', async () => {
+      const fetchSpy = stubFetch(async () => jsonResponse({ ok: true }));
+
+      const http = createHttpClient({ baseURL: BASE });
+      await http.get('/v1/albums');
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(headerOf(init, 'X-Album-Id')).toBeNull();
+    });
+
+    test('Authorization와 X-Album-Id 모두 동시에 주입된다', async () => {
+      authTokenStore.set('access-1');
+      albumIdStore.set('album-1');
+      const fetchSpy = stubFetch(async () => jsonResponse({ ok: true }));
+
+      const http = createHttpClient({ baseURL: BASE });
+      await http.get('/v1/media');
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(headerOf(init, 'Authorization')).toBe('Bearer access-1');
+      expect(headerOf(init, 'X-Album-Id')).toBe('album-1');
     });
   });
 

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -2,7 +2,11 @@ import { env } from '@/shared/config/env';
 import { ApiError, reportApiError, toApiError } from './error';
 import { createRefresher } from './refresh';
 import { authTokenStore } from './auth-token';
-import { type ApiRequest, attachAuthHeader } from './interceptors';
+import {
+  type ApiRequest,
+  attachAuthHeader,
+  attachAlbumHeader,
+} from './interceptors';
 
 const DEFAULT_BASE_URL = env.VITE_API_BASE_URL;
 const DEFAULT_REFRESH_PATH = env.VITE_AUTH_REFRESH_PATH;
@@ -116,10 +120,12 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
     options.onUnauthorized ?? (() => authTokenStore.clear());
 
   function buildRequest(path: string, init: HttpInit): ApiRequest {
-    return attachAuthHeader({
-      url: `${baseURL}${path}`,
-      options: normalize(init),
-    });
+    return attachAlbumHeader(
+      attachAuthHeader({
+        url: `${baseURL}${path}`,
+        options: normalize(init),
+      }),
+    );
   }
 
   async function handleUnauthorized<T>(

--- a/apps/web/src/shared/api/interceptors.ts
+++ b/apps/web/src/shared/api/interceptors.ts
@@ -1,4 +1,5 @@
 import { authTokenStore } from './auth-token';
+import { albumIdStore } from './album-id';
 
 export interface ApiRequest {
   url: string;
@@ -13,5 +14,16 @@ export function attachAuthHeader(request: ApiRequest): ApiRequest {
 
   const headers = new Headers(request.options.headers);
   headers.set('Authorization', `Bearer ${token}`);
+  return { ...request, options: { ...request.options, headers } };
+}
+
+export function attachAlbumHeader(request: ApiRequest): ApiRequest {
+  const albumId = albumIdStore.get();
+  if (!albumId) {
+    return request;
+  }
+
+  const headers = new Headers(request.options.headers);
+  headers.set('X-Album-Id', albumId);
   return { ...request, options: { ...request.options, headers } };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.4)
+      nanoid:
+        specifier: ^5.1.11
+        version: 5.1.11
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -4288,6 +4291,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   napi-postinstall@0.3.4:
@@ -9497,6 +9505,8 @@ snapshots:
   nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.11: {}
 
   napi-postinstall@0.3.4: {}
 


### PR DESCRIPTION
## 📌 관련 이슈
* #62

---
## 🧹 작업 내용
사진/영상 업로드 기능 구현. 
파일을 추가하면 큐에 쌓이고, runner가 하나씩 순차로 꺼내 S3에 직접 업로드.  
진행률 표시와 취소를 지원.

**인프라**
1. **X-Album-Id 인터셉터** — HTTP 클라이언트에 추가. 요청 시 현재 앨범 헤더 자동 주입
2. **Album 엔티티 + 인증 부트스트랩** — 로그인 시 앨범 컨텍스트 설정
3. **authKeys 분리** — `keys.ts` 리프 모듈로 분리

**업로드 도메인**

4. **검증·파일명 유틸 + 큐 상태 머신** — `pending`/`uploading`/`success`/`error` 관리
5. **Dropzone / Progress / Item UI** — 드래그앤드롭 · 진행률 · 항목별 상태 표시

**업로드 실행**

6. **S3 PUT 업로더 + 미디어 업로드 mutation** — XHR 기반 PUT(진행률·취소 지원), `create → upload-urls → S3 PUT → contents → confirm` 5단계
7. **runner 훅 + 업로드 페이지 통합** — 큐 구독해 순차 실행 / `AbortController`로 취소 관리 / 성공 시 `photoKeys.lists()` 무효화

---
## 🛠️ 테스트
* [x] 단위 테스트 통과 (업로드 검증 · 큐 상태 전이)
* [x] 빌드 통과

---
## 🔍 고민 / 결정 사항
### ① 업로드 동작 흐름
```mermaid
flowchart TD
  Drop["Dropzone — 파일 추가"] --> Validate["검증 (크기·타입)"]
  Validate --> Queue["큐에 적재 (pending)"]
  Queue --> Subscribe["runner: 큐 구독"]
  Subscribe --> Pick{"pending 있고 isRunning=false?"}
  Pick -->|예| Upload["uploadSinglePhoto"]
  Pick -->|아니오| Wait["대기"]
  Upload --> Steps["create → upload-urls → S3 PUT → contents → confirm"]
  Steps --> Result{"결과"}
  Result -->|성공| Success["status success / 목록 캐시 무효화"]
  Result -->|실패| Error["status error / 재시도 카운트"]
  Result -->|취소| Abort["AbortError 조용히 처리"]
  Success --> Next["queueMicrotask → 다음 항목"]
  Error --> Next
  Next --> Pick
```
* Dropzone에 파일 추가 → 검증 후 큐에 적재
* runner가 `pending` 항목을 **한 번에 하나씩** 꺼내 업로드
* 각 단계 진행률·상태를 큐에 반영 → UI 갱신
* 전체 완료 시 토스트 표시 후 `/photos` 이동

### ② XHR 사용 (진행률)
* `fetch`가 업로드 진행률을 표준 지원하지 않아 **XHR로 PUT 구현**.
* 진행률 이벤트를 받아 항목별 상태로 반영.

### ③ 취소 처리 (AbortController)
* 페이지 이탈·사용자 취소 시 진행 중인 업로드를 `AbortController`로 중단.
* `AbortError`는 실패가 아니라 **조용히 처리**(상태 오염 방지).

---
## 💬 참고 사항
### 🔎 리뷰 추천 순서
1. **검증·파일명 유틸** — 가장 단순하고 독립적인 출발점
2. **큐 상태 머신(store)** — `pending/uploading/success/error` 전이 정의
3. **S3 PUT 업로더** — XHR 기반, 진행률·취소의 실제 구현부
4. **미디어 업로드 mutation** — 5단계(`create → upload-urls → S3 PUT → contents → confirm`)
5. **runner 훅** — 위를 엮어 큐 구독·순차 실행하는 핵심
6. (보조) `Dropzone/Progress/Item UI`, 업로드 페이지, `X-Album-Id` 인터셉터 — 위 이해 후 빠르게 읽힘