### PR TITLE
[Feat] 사진 목록 — 무한 스크롤·정렬·다중 선택·다운로드 (#64)

### DIFF
--- a/apps/web/src/entities/photo/api/queries.test.ts
+++ b/apps/web/src/entities/photo/api/queries.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest';
+
+import type { MediaDto, MediaListResponse } from '../model/types';
+import { nextCursorOf, selectPhotos } from './queries';
+
+function page(
+  items: MediaDto[],
+  pagination: Partial<MediaListResponse['pagination']> = {},
+): MediaListResponse {
+  return {
+    items,
+    pagination: {
+      size: 20,
+      sortBy: 'CREATED_AT',
+      order: 'DESC',
+      hasNext: false,
+      ...pagination,
+    },
+  };
+}
+
+function dto(id: string): MediaDto {
+  return {
+    id,
+    description: id,
+    state: 'COMPLETE',
+    isFavorite: false,
+    content: {
+      location: { url: `s3://${id}`, accessUrl: `https://signed/${id}` },
+      size: 1,
+      eTag: 'e',
+      mimeType: 'image/jpeg',
+      thumbnail: null,
+    },
+    created: {
+      at: '2026-01-01T00:00:00.000Z',
+      by: { id: 'u', name: 'n', email: 'e' },
+    },
+  };
+}
+
+describe('nextCursorOf', () => {
+  test('hasNext가 true면 nextCursor를 반환한다', () => {
+    expect(nextCursorOf(page([], { hasNext: true, nextCursor: 'c2' }))).toBe(
+      'c2',
+    );
+  });
+
+  test('hasNext가 false면 nextCursor가 있어도 undefined (멈춤)', () => {
+    expect(
+      nextCursorOf(page([], { hasNext: false, nextCursor: 'c2' })),
+    ).toBeUndefined();
+  });
+
+  test('hasNext가 true여도 nextCursor가 없으면 undefined (모순 응답 방어)', () => {
+    expect(nextCursorOf(page([], { hasNext: true }))).toBeUndefined();
+  });
+});
+
+describe('selectPhotos', () => {
+  test('여러 페이지를 평탄화해 Photo[]로 매핑한다', () => {
+    const data = { pages: [page([dto('a'), dto('b')]), page([dto('c')])] };
+    const photos = selectPhotos(data);
+
+    expect(photos.map((p) => p.id)).toEqual(['a', 'b', 'c']);
+    expect(photos[0].imageUrl).toBe('https://signed/a');
+  });
+
+  test('빈 페이지가 섞여 있어도 항목만 이어붙인다', () => {
+    const data = { pages: [page([dto('a')]), page([]), page([dto('b')])] };
+
+    expect(selectPhotos(data).map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  test('content 없는 항목은 제외한다', () => {
+    const draft: MediaDto = { ...dto('d'), state: 'PREPARING', content: null };
+    const data = { pages: [page([dto('a'), draft])] };
+    const photos = selectPhotos(data);
+
+    expect(photos.map((p) => p.id)).toEqual(['a']);
+    expect(photos).toHaveLength(1);
+  });
+
+  test('data가 undefined면 빈 배열', () => {
+    expect(selectPhotos(undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -1,2 +1,64 @@
-// usePhotosInfinite(), usePhotoDetail()
-export {};
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { buildQuery, http } from '@/shared/api';
+import { recordMediaListSlow } from '@/shared/lib/business-ux-logging';
+
+import { toPhoto } from '../lib/mapper';
+import type { MediaListResponse, Photo } from '../model/types';
+import { photoKeys, type PhotoListFilters } from './keys';
+
+const PAGE_SIZE = 20;
+
+export function nextCursorOf(page: MediaListResponse): string | undefined {
+  return page.pagination.hasNext
+    ? (page.pagination.nextCursor ?? undefined)
+    : undefined;
+}
+
+export function selectPhotos(
+  data: { pages: MediaListResponse[] } | undefined,
+): Photo[] {
+  return (
+    data?.pages
+      .flatMap((page) => page.items)
+      .filter((dto) => dto.content != null)
+      .map(toPhoto) ?? []
+  );
+}
+
+async function fetchPhotoPage(
+  order: 'asc' | 'desc',
+  cursor: string | undefined,
+): Promise<MediaListResponse> {
+  const path = `/v1/media${buildQuery({
+    size: PAGE_SIZE,
+    order,
+    states: 'COMPLETE',
+    cursor,
+  })}`;
+
+  const startedAt = performance.now();
+  const response = await http.get<MediaListResponse>(path);
+  recordMediaListSlow(performance.now() - startedAt, 'listMedia');
+
+  return response;
+}
+
+export function usePhotosInfinite(
+  filters?: PhotoListFilters,
+  options?: { enabled?: boolean },
+) {
+  const order = filters?.order ?? 'desc';
+  const initialCursor: string | undefined = undefined;
+
+  return useInfiniteQuery({
+    queryKey: photoKeys.list(filters),
+    initialPageParam: initialCursor,
+    queryFn: ({ pageParam }) => fetchPhotoPage(order, pageParam),
+    getNextPageParam: nextCursorOf,
+    enabled: options?.enabled ?? true, // 앨범이 준비된 뒤에만 조회
+    staleTime: 60_000,
+    throwOnError: true,
+    meta: { operationId: 'listMedia' },
+  });
+}

--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -18,12 +18,10 @@ export function nextCursorOf(page: MediaListResponse): string | undefined {
 export function selectPhotos(
   data: { pages: MediaListResponse[] } | undefined,
 ): Photo[] {
-  return (
-    data?.pages
-      .flatMap((page) => page.items)
-      .filter((dto) => dto.content != null)
-      .map(toPhoto) ?? []
-  );
+  return (data?.pages ?? [])
+    .flatMap((page) => page.items)
+    .filter((dto) => dto.content != null)
+    .map(toPhoto);
 }
 
 async function fetchPhotoPage(

--- a/apps/web/src/entities/photo/index.ts
+++ b/apps/web/src/entities/photo/index.ts
@@ -1,3 +1,9 @@
+export { usePhotosInfinite, selectPhotos, nextCursorOf } from './api/queries';
+export { photoKeys, type PhotoListFilters } from './api/keys';
+
+export { toPhoto } from './lib/mapper';
+export type { Photo, PhotoState, MediaListResponse } from './model/types';
+
 export { PhotoCard } from './ui/photo-card';
 export { PhotoThumbnail } from './ui/photo-thumbnail';
 export { PhotoMeta } from './ui/photo-meta';

--- a/apps/web/src/entities/photo/lib/mapper.test.ts
+++ b/apps/web/src/entities/photo/lib/mapper.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest';
+
+import type { MediaContent, MediaDto } from '../model/types';
+import { toPhoto } from './mapper';
+
+function baseDto(overrides: Partial<MediaDto> = {}): MediaDto {
+  return {
+    id: 'media-1',
+    description: '바다',
+    state: 'COMPLETE',
+    isFavorite: false,
+    created: {
+      at: '2026-01-01T00:00:00.000Z',
+      by: { id: 'u1', name: '홍길동', email: 'a@b.com' },
+    },
+    ...overrides,
+  };
+}
+
+const content: MediaContent = {
+  location: { url: 's3://x', accessUrl: 'https://signed/x.jpg' },
+  size: 1234,
+  eTag: 'etag',
+  mimeType: 'image/jpeg',
+  thumbnail: null,
+};
+
+describe('toPhoto', () => {
+  test('content가 있으면 원본 accessUrl을 imageUrl/downloadUrl에 함께 채운다', () => {
+    const photo = toPhoto(baseDto({ content }));
+
+    expect(photo.imageUrl).toBe('https://signed/x.jpg');
+    expect(photo.downloadUrl).toBe('https://signed/x.jpg');
+    expect(photo.mimeType).toBe('image/jpeg');
+    expect(photo.size).toBe(1234);
+  });
+
+  test('content가 없으면 키 자체를 만들지 않는다', () => {
+    const photo = toPhoto(baseDto({ state: 'PREPARING', content: null }));
+
+    expect('imageUrl' in photo).toBe(false);
+    expect('downloadUrl' in photo).toBe(false);
+    expect('mimeType' in photo).toBe(false);
+    expect('size' in photo).toBe(false);
+  });
+
+  test('DRAFT 상태(content 없음)도 안전하게 매핑한다', () => {
+    const photo = toPhoto(baseDto({ state: 'DRAFT', content: null }));
+
+    expect(photo.state).toBe('DRAFT');
+    expect('imageUrl' in photo).toBe(false);
+  });
+
+  test('thumbnail이 있어도 원본 accessUrl을 쓴다 (썸네일 미사용 정책)', () => {
+    const withThumb = {
+      ...content,
+      thumbnail: {
+        location: { url: 's3://t', accessUrl: 'https://signed/thumb.jpg' },
+        size: 100,
+        eTag: 'te',
+        mimeType: 'image/jpeg',
+        blurhash: 'abc',
+      },
+    };
+    const photo = toPhoto(baseDto({ content: withThumb }));
+
+    expect(photo.imageUrl).toBe('https://signed/x.jpg');
+    expect(photo.downloadUrl).toBe('https://signed/x.jpg');
+  });
+
+  test('공통 필드(createdAt/createdBy/isFavorite/state)를 매핑한다', () => {
+    const photo = toPhoto(baseDto({ isFavorite: true }));
+
+    expect(photo.id).toBe('media-1');
+    expect(photo.state).toBe('COMPLETE');
+    expect(photo.isFavorite).toBe(true);
+    expect(photo.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(photo.createdBy).toEqual({
+      id: 'u1',
+      name: '홍길동',
+      email: 'a@b.com',
+    });
+  });
+});

--- a/apps/web/src/entities/photo/lib/mapper.ts
+++ b/apps/web/src/entities/photo/lib/mapper.ts
@@ -1,2 +1,25 @@
-// DTO -> Model (선택)
-export {};
+import type { MediaDto, Photo } from '../model/types';
+
+/**
+ * GET /v1/media item(MediaDto) → Photo.
+ * - content가 없으면(DRAFT/PREPARING) imageUrl/downloadUrl/mimeType/size를 생략한다.
+ * - 썸네일은 현재 백엔드 미지원이므로 원본 location.accessUrl을 표시·다운로드에 함께 사용한다.
+ */
+export function toPhoto(dto: MediaDto): Photo {
+  const { at: createdAt, by: createdBy } = dto.created;
+  const accessUrl = dto.content?.location.accessUrl;
+
+  return {
+    id: dto.id,
+    description: dto.description,
+    state: dto.state,
+    isFavorite: dto.isFavorite,
+    createdAt,
+    createdBy,
+    ...(accessUrl && { imageUrl: accessUrl, downloadUrl: accessUrl }),
+    ...(dto.content && {
+      mimeType: dto.content.mimeType,
+      size: dto.content.size,
+    }),
+  };
+}

--- a/apps/web/src/entities/photo/model/types.ts
+++ b/apps/web/src/entities/photo/model/types.ts
@@ -1,2 +1,75 @@
-// Photo, PhotoId, PhotoMeta
-export {};
+export type PhotoState = 'DRAFT' | 'PREPARING' | 'COMPLETE';
+
+export interface UserSummary {
+  id: string;
+  name: string;
+  email: string;
+}
+
+/**
+ * 목록/그리드에서 사용하는 프론트 도메인 모델.
+ *
+ * 현재 썸네일/blurhash를 생성하지 않으므로
+ *   - content.thumbnail === null
+ *   - 표시·다운로드 모두 원본 content.location.accessUrl(presigned)을 사용
+ */
+export interface Photo {
+  id: string;
+  description: string;
+  state: PhotoState;
+  imageUrl?: string;
+  downloadUrl?: string;
+  mimeType?: string;
+  size?: number;
+  isFavorite: boolean;
+  createdAt: string;
+  createdBy: UserSummary;
+}
+
+export interface MediaLocation {
+  url: string;
+  accessUrl: string;
+}
+
+export interface MediaThumbnail {
+  location: MediaLocation;
+  size: number;
+  eTag: string;
+  mimeType: string;
+  blurhash: string;
+}
+
+export interface MediaContent {
+  location: MediaLocation;
+  size: number;
+  eTag: string;
+  mimeType: string;
+  thumbnail?: MediaThumbnail | null;
+}
+
+export interface MediaCreated {
+  at: string;
+  by: UserSummary;
+}
+
+export interface MediaDto {
+  id: string;
+  description: string;
+  state: PhotoState;
+  content?: MediaContent | null;
+  isFavorite: boolean;
+  created: MediaCreated;
+}
+
+export interface MediaPagination {
+  size: number;
+  sortBy: 'CREATED_AT';
+  order: 'ASC' | 'DESC';
+  nextCursor?: string;
+  hasNext: boolean;
+}
+
+export interface MediaListResponse {
+  items: MediaDto[];
+  pagination: MediaPagination;
+}

--- a/apps/web/src/entities/photo/ui/photo-card.tsx
+++ b/apps/web/src/entities/photo/ui/photo-card.tsx
@@ -1,2 +1,46 @@
-// 썸네일 + 상태 배지 + 체크 표시(선택모드)
-export function PhotoCard() {}
+import type { ReactNode } from 'react';
+
+import { cn } from '@/shared/lib/utils/cn';
+
+import type { Photo } from '../model/types';
+import { PhotoThumbnail } from './photo-thumbnail';
+
+interface PhotoCardProps {
+  photo: Photo;
+  selectionSlot?: ReactNode | undefined;
+  actionSlot?: ReactNode | undefined;
+  selected?: boolean | undefined;
+  onOpen?: ((id: string) => void) | undefined;
+}
+
+export function PhotoCard({
+  photo,
+  selectionSlot,
+  actionSlot,
+  selected,
+  onOpen,
+}: PhotoCardProps) {
+  return (
+    <div className="group relative">
+      {selectionSlot && (
+        <div className="absolute left-2 top-2 z-10">{selectionSlot}</div>
+      )}
+      {actionSlot && (
+        <div className="absolute right-2 top-2 z-10 opacity-0 transition-opacity group-hover:opacity-100">
+          {actionSlot}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => onOpen?.(photo.id)}
+        aria-label={photo.description}
+        className={cn(
+          'block w-full overflow-hidden rounded-md text-left ring-offset-background transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          selected && 'ring-2 ring-primary ring-offset-2',
+        )}
+      >
+        <PhotoThumbnail src={photo.imageUrl} alt={photo.description} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
+++ b/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
@@ -1,1 +1,36 @@
-export function PhotoThumbnail() {}
+import { useState } from 'react';
+
+import { cn } from '@/shared/lib/utils/cn';
+
+interface PhotoThumbnailProps {
+  src?: string | undefined;
+  alt: string;
+  className?: string | undefined;
+}
+
+export function PhotoThumbnail({ src, alt, className }: PhotoThumbnailProps) {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        'relative aspect-square overflow-hidden rounded-md bg-muted',
+        className,
+      )}
+    >
+      {src && (
+        <img
+          src={src}
+          alt={alt}
+          loading="lazy"
+          decoding="async"
+          onLoad={() => setLoaded(true)}
+          className={cn(
+            'h-full w-full object-cover transition-opacity duration-300',
+            loaded ? 'opacity-100' : 'opacity-0',
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/photo-download/index.ts
+++ b/apps/web/src/features/photo-download/index.ts
@@ -1,1 +1,9 @@
+export { downloadFilename } from './lib/filename';
+export {
+  downloadOne,
+  downloadMany,
+  type DownloadTarget,
+  type DownloadManyResult,
+} from './lib/downloader';
+
 export { DownloadButton } from './ui/download-button';

--- a/apps/web/src/features/photo-download/lib/downloader.ts
+++ b/apps/web/src/features/photo-download/lib/downloader.ts
@@ -1,2 +1,74 @@
-// 단건/다건 다운로드 유틸(Zip 필요하면 여기)
-export {};
+import { ApiError } from '@/shared/api/error';
+
+export interface DownloadTarget {
+  url: string;
+  filename: string;
+}
+
+export interface DownloadManyResult {
+  ok: number;
+  failed: number;
+}
+
+const BATCH_DELAY_MS = 300; // 연속 다운로드를 브라우저가 차단하지 않도록 항목 간 간격
+
+function triggerAnchor(href: string, filename: string): void {
+  const anchor = document.createElement('a');
+  anchor.href = href;
+  anchor.download = filename;
+  anchor.rel = 'noopener'; // 풀백 시 새 탭이 열려도 원본 페이지 접근 차단 (보안)
+
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+export async function downloadOne(target: DownloadTarget): Promise<void> {
+  try {
+    const response = await fetch(target.url);
+    if (!response.ok) {
+      throw new ApiError({ status: response.status });
+    }
+
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+
+    triggerAnchor(objectUrl, target.filename);
+
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+  } catch (err) {
+    if (err instanceof TypeError) {
+      triggerAnchor(target.url, target.filename);
+      return;
+    }
+
+    throw err;
+  }
+}
+
+export async function downloadMany(
+  targets: DownloadTarget[],
+  options?: {
+    onError?: (target: DownloadTarget, error: unknown) => void;
+    delayMs?: number;
+  },
+): Promise<DownloadManyResult> {
+  const delay = options?.delayMs ?? BATCH_DELAY_MS;
+
+  let ok = 0;
+  let failed = 0;
+
+  for (const target of targets) {
+    try {
+      await downloadOne(target);
+      ok += 1;
+    } catch (err) {
+      failed += 1;
+      options?.onError?.(target, err);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+
+  return { ok, failed };
+}

--- a/apps/web/src/features/photo-download/lib/filename.test.ts
+++ b/apps/web/src/features/photo-download/lib/filename.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'vitest';
+
+import { downloadFilename } from './filename';
+
+describe('downloadFilename', () => {
+  test('description + mimeType 확장자로 파일명을 만든다', () => {
+    expect(
+      downloadFilename({
+        id: 'm1',
+        description: '제주 바다',
+        mimeType: 'image/png',
+      }),
+    ).toBe('제주 바다.png');
+  });
+
+  test('파일시스템 금지 문자는 _로 치환한다', () => {
+    expect(
+      downloadFilename({
+        id: 'm1',
+        description: 'a/b:c*d?',
+        mimeType: 'image/jpeg',
+      }),
+    ).toBe('a_b_c_d_.jpg');
+  });
+
+  test('연속 공백은 한 칸으로 정리하고 앞뒤 공백은 제거한다', () => {
+    expect(
+      downloadFilename({
+        id: 'm1',
+        description: '  제주   바다  ',
+        mimeType: 'image/png',
+      }),
+    ).toBe('제주 바다.png');
+  });
+
+  test('description이 공백뿐이면 id로 폴백한다', () => {
+    expect(
+      downloadFilename({
+        id: 'm1',
+        description: '   ',
+        mimeType: 'image/webp',
+      }),
+    ).toBe('m1.webp');
+  });
+
+  test('description이 빈 문자열이어도 id로 폴백한다', () => {
+    expect(
+      downloadFilename({ id: 'm1', description: '', mimeType: 'image/webp' }),
+    ).toBe('m1.webp');
+  });
+
+  test('mimeType이 없으면 jpg로 폴백한다', () => {
+    expect(downloadFilename({ id: 'm1', description: 'x' })).toBe('x.jpg');
+  });
+
+  test('지원하지 않는 mimeType이면 jpg로 폴백한다', () => {
+    expect(
+      downloadFilename({
+        id: 'm1',
+        description: 'x',
+        mimeType: 'application/pdf',
+      }),
+    ).toBe('x.jpg');
+  });
+
+  test('image/jpg도 jpg로 매핑한다', () => {
+    expect(
+      downloadFilename({ id: 'm1', description: 'x', mimeType: 'image/jpg' }),
+    ).toBe('x.jpg');
+  });
+
+  test('베이스명이 100자를 넘으면 자른다', () => {
+    const long = 'a'.repeat(150);
+
+    const result = downloadFilename({
+      id: 'm1',
+      description: long,
+      mimeType: 'image/jpeg',
+    });
+
+    expect(result).toBe(`${'a'.repeat(100)}.jpg`);
+  });
+});

--- a/apps/web/src/features/photo-download/lib/filename.ts
+++ b/apps/web/src/features/photo-download/lib/filename.ts
@@ -1,2 +1,33 @@
-// 파일명 정책
-export {};
+import type { Photo } from '@/entities/photo';
+
+const MIME_EXTENSION: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/avif': 'avif',
+  'image/heic': 'heic',
+};
+
+const MAX_BASE_LENGTH = 100;
+
+function extensionFromMime(mimeType?: string): string {
+  return (mimeType && MIME_EXTENSION[mimeType]) || 'jpg';
+}
+
+function sanitize(name: string): string {
+  return name
+    .replace(/[\\/:*?"<>|]/g, '_')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_BASE_LENGTH);
+}
+
+export function downloadFilename(
+  photo: Pick<Photo, 'id' | 'description' | 'mimeType'>,
+): string {
+  const base = sanitize(photo.description) || photo.id;
+
+  return `${base}.${extensionFromMime(photo.mimeType)}`;
+}

--- a/apps/web/src/features/photo-download/ui/download-button.tsx
+++ b/apps/web/src/features/photo-download/ui/download-button.tsx
@@ -1,1 +1,63 @@
-export function DownloadButton() {}
+import { Download } from 'lucide-react';
+import { useState } from 'react';
+
+import type { Photo } from '@/entities/photo';
+import { useAuthRole } from '@/features/auth';
+import { ApiError } from '@/shared/api/error';
+import { recordForbidden } from '@/shared/lib/business-ux-logging';
+import { Button, type ButtonProps } from '@/shared/ui/button';
+import { toast } from '@/shared/ui/toast';
+
+import { downloadOne } from '../lib/downloader';
+import { downloadFilename } from '../lib/filename';
+
+interface DownloadButtonProps {
+  photo: Photo;
+  variant?: ButtonProps['variant'];
+  size?: ButtonProps['size'];
+}
+
+/** 단건 다운로드 버튼. content가 없는 사진은 비활성화된다. */
+export function DownloadButton({
+  photo,
+  variant = 'secondary',
+  size = 'icon',
+}: DownloadButtonProps) {
+  const role = useAuthRole();
+  const [busy, setBusy] = useState(false);
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!photo.downloadUrl) return;
+
+    setBusy(true);
+    try {
+      await downloadOne({
+        url: photo.downloadUrl,
+        filename: downloadFilename(photo),
+      });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        recordForbidden({ userRole: role ?? 'unknown', operationId: 'downloadMedia' });
+        toast.error('다운로드 권한이 없거나 링크가 만료됐어요.');
+      } else {
+        toast.error('다운로드에 실패했어요.');
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      disabled={busy || !photo.downloadUrl}
+      onClick={handleClick}
+      aria-label="다운로드"
+    >
+      <Download className="size-4" />
+    </Button>
+  );
+}

--- a/apps/web/src/features/photo-select/index.ts
+++ b/apps/web/src/features/photo-select/index.ts
@@ -1,2 +1,11 @@
+export {
+  useSelectEnabled,
+  useSelectedCount,
+  useSelectedIds,
+  useIsSelected,
+} from './model/selectors';
+export { usePhotoSelectStore } from './model/store';
+
 export { SelectToggle } from './ui/select-toggle';
 export { SelectedCounter } from './ui/selected-counter';
+export { SelectCheckbox } from './ui/select-checkbox';

--- a/apps/web/src/features/photo-select/model/selectors.ts
+++ b/apps/web/src/features/photo-select/model/selectors.ts
@@ -1,1 +1,9 @@
-export {};
+import { usePhotoSelectStore } from './store';
+
+export const useSelectEnabled = () => usePhotoSelectStore((s) => s.enabled);
+export const useSelectedCount = () =>
+  usePhotoSelectStore((s) => s.selectedIds.size);
+export const useSelectedIds = () => usePhotoSelectStore((s) => s.selectedIds);
+
+export const useIsSelected = (id: string) =>
+  usePhotoSelectStore((s) => s.selectedIds.has(id));

--- a/apps/web/src/features/photo-select/model/store.test.ts
+++ b/apps/web/src/features/photo-select/model/store.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { usePhotoSelectStore } from './store';
+
+function reset() {
+  usePhotoSelectStore.setState({ enabled: false, selectedIds: new Set() });
+}
+
+describe('usePhotoSelectStore', () => {
+  beforeEach(reset);
+
+  test('toggle은 추가/제거를 번갈아 수행한다', () => {
+    const { toggle } = usePhotoSelectStore.getState();
+
+    toggle('a');
+    expect([...usePhotoSelectStore.getState().selectedIds]).toEqual(['a']);
+
+    toggle('a');
+    expect(usePhotoSelectStore.getState().selectedIds.size).toBe(0);
+  });
+
+  test('toggle은 서로 다른 id를 누적한다', () => {
+    const { toggle } = usePhotoSelectStore.getState();
+
+    toggle('a');
+    toggle('b');
+
+    expect([...usePhotoSelectStore.getState().selectedIds].sort()).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  test('toggle은 매번 새로운 Set 참조를 만든다', () => {
+    const before = usePhotoSelectStore.getState().selectedIds;
+
+    usePhotoSelectStore.getState().toggle('a');
+
+    const after = usePhotoSelectStore.getState().selectedIds;
+    expect(after).not.toBe(before);
+  });
+
+  test('toggleMode는 켤 때 기존 선택을 유지한다', () => {
+    usePhotoSelectStore.getState().selectMany(['a', 'b']);
+
+    usePhotoSelectStore.getState().toggleMode();
+
+    expect(usePhotoSelectStore.getState().enabled).toBe(true);
+    expect(usePhotoSelectStore.getState().selectedIds.size).toBe(2);
+  });
+
+  test('toggleMode는 끌 때 선택을 비운다', () => {
+    const store = usePhotoSelectStore.getState();
+    store.toggleMode();
+    store.toggle('a');
+
+    expect(usePhotoSelectStore.getState().enabled).toBe(true);
+    expect(usePhotoSelectStore.getState().selectedIds.size).toBe(1);
+
+    usePhotoSelectStore.getState().toggleMode();
+
+    expect(usePhotoSelectStore.getState().enabled).toBe(false);
+    expect(usePhotoSelectStore.getState().selectedIds.size).toBe(0);
+  });
+
+  test('selectMany는 선택 집합을 통째로 교체한다', () => {
+    usePhotoSelectStore.getState().toggle('z');
+
+    usePhotoSelectStore.getState().selectMany(['a', 'b', 'c']);
+
+    expect([...usePhotoSelectStore.getState().selectedIds].sort()).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  test('clear는 선택을 비운다', () => {
+    usePhotoSelectStore.getState().selectMany(['a', 'b']);
+
+    usePhotoSelectStore.getState().clear();
+
+    expect(usePhotoSelectStore.getState().selectedIds.size).toBe(0);
+  });
+});

--- a/apps/web/src/features/photo-select/model/store.ts
+++ b/apps/web/src/features/photo-select/model/store.ts
@@ -1,2 +1,42 @@
-// Zustand: { enabled, selectedIds(Set), toggle, clear }
-export {};
+import { create } from 'zustand';
+
+interface PhotoSelectState {
+  enabled: boolean;
+  selectedIds: Set<string>;
+
+  toggleMode: () => void;
+  toggle: (id: string) => void;
+  selectMany: (ids: string[]) => void;
+  clear: () => void;
+}
+
+/**
+ * 다중 선택 상태
+ * - selectedIds는 매 변경마다 새 Set을 반환해 구독 컴포넌트가 참조 변경을 감지한다.
+ */
+export const usePhotoSelectStore = create<PhotoSelectState>((set) => ({
+  enabled: false,
+  selectedIds: new Set(),
+
+  toggleMode: () =>
+    set((state) => ({
+      enabled: !state.enabled,
+      selectedIds: state.enabled ? new Set() : state.selectedIds,
+    })),
+
+  toggle: (id) =>
+    set((state) => {
+      const next = new Set(state.selectedIds);
+
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return { selectedIds: next };
+    }),
+
+  selectMany: (ids) => set({ selectedIds: new Set(ids) }),
+
+  clear: () => set({ selectedIds: new Set() }),
+}));

--- a/apps/web/src/features/photo-select/ui/select-checkbox.tsx
+++ b/apps/web/src/features/photo-select/ui/select-checkbox.tsx
@@ -1,0 +1,36 @@
+import { Check } from 'lucide-react';
+
+import { cn } from '@/shared/lib/utils/cn';
+
+import { useIsSelected } from '../model/selectors';
+import { usePhotoSelectStore } from '../model/store';
+
+interface SelectCheckboxProps {
+  id: string;
+}
+
+export function SelectCheckbox({ id }: SelectCheckboxProps) {
+  const selected = useIsSelected(id);
+  const toggle = usePhotoSelectStore((s) => s.toggle);
+
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={selected}
+      aria-label="선택"
+      onClick={(e) => {
+        e.stopPropagation();
+        toggle(id);
+      }}
+      className={cn(
+        'flex size-6 items-center justify-center rounded-md border-2 bg-background/80 shadow-sm transition',
+        selected
+          ? 'border-primary bg-primary text-primary-foreground'
+          : 'border-muted-foreground/50',
+      )}
+    >
+      {selected && <Check className="size-4" />}
+    </button>
+  );
+}

--- a/apps/web/src/features/photo-select/ui/select-toggle.tsx
+++ b/apps/web/src/features/photo-select/ui/select-toggle.tsx
@@ -1,2 +1,30 @@
-// 선택모드 on/off 버튼
-export function SelectToggle() {}
+import { CheckSquare, X } from 'lucide-react';
+
+import { Button } from '@/shared/ui/button';
+
+import { useSelectEnabled } from '../model/selectors';
+import { usePhotoSelectStore } from '../model/store';
+
+export function SelectToggle() {
+  const enabled = useSelectEnabled();
+  const toggleMode = usePhotoSelectStore((s) => s.toggleMode);
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={enabled ? 'secondary' : 'outline'}
+      onClick={toggleMode}
+    >
+      {enabled ? (
+        <>
+          <X className="mr-1 size-4" /> 선택 해제
+        </>
+      ) : (
+        <>
+          <CheckSquare className="mr-1 size-4" /> 선택
+        </>
+      )}
+    </Button>
+  );
+}

--- a/apps/web/src/features/photo-select/ui/selected-counter.tsx
+++ b/apps/web/src/features/photo-select/ui/selected-counter.tsx
@@ -1,1 +1,6 @@
-export function SelectedCounter() {}
+import { useSelectedCount } from '../model/selectors';
+
+export function SelectedCounter() {
+  const count = useSelectedCount();
+  return <span className="text-sm font-medium">{count}개 선택됨</span>;
+}

--- a/apps/web/src/features/photo-sort/index.ts
+++ b/apps/web/src/features/photo-sort/index.ts
@@ -1,1 +1,2 @@
+export { usePhotoSortStore, type SortOrder } from './model/store';
 export { SortSheet } from './ui/sort-sheet';

--- a/apps/web/src/features/photo-sort/model/store.ts
+++ b/apps/web/src/features/photo-sort/model/store.ts
@@ -1,2 +1,13 @@
-// (선택) 정렬 옵션을 전역으로 유지할지 결정
-export {};
+import { create } from 'zustand';
+
+export type SortOrder = 'asc' | 'desc';
+
+interface PhotoSortState {
+  order: SortOrder;
+  setOrder: (order: SortOrder) => void;
+}
+
+export const usePhotoSortStore = create<PhotoSortState>((set) => ({
+  order: 'desc',
+  setOrder: (order) => set({ order }),
+}));

--- a/apps/web/src/features/photo-sort/ui/sort-sheet.tsx
+++ b/apps/web/src/features/photo-sort/ui/sort-sheet.tsx
@@ -1,2 +1,35 @@
-// 정렬 bottom sheet
-export function SortSheet() {}
+import { Button } from '@/shared/ui/button';
+
+import { usePhotoSortStore, type SortOrder } from '../model/store';
+
+const OPTIONS: { value: SortOrder; label: string }[] = [
+  { value: 'desc', label: '최신순' },
+  { value: 'asc', label: '오래된순' },
+];
+
+export function SortSheet() {
+  const order = usePhotoSortStore((s) => s.order);
+  const setOrder = usePhotoSortStore((s) => s.setOrder);
+
+  return (
+    <div
+      role="group"
+      aria-label="정렬"
+      className="inline-flex overflow-hidden rounded-md border"
+    >
+      {OPTIONS.map((opt) => (
+        <Button
+          key={opt.value}
+          type="button"
+          size="sm"
+          variant={order === opt.value ? 'default' : 'ghost'}
+          aria-pressed={order === opt.value}
+          className="rounded-none"
+          onClick={() => setOrder(opt.value)}
+        >
+          {opt.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -1,8 +1,192 @@
-// Grid + Toolbar + InfiniteList 조립 — 실제 구현은 후속 PR에서 진행
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { ErrorBoundary } from '@/app/providers/error-boundary';
+import { useAlbumStore } from '@/entities/album';
+import {
+  PhotoCard,
+  selectPhotos,
+  usePhotosInfinite,
+  type Photo,
+} from '@/entities/photo';
+import { useAuthRole } from '@/features/auth';
+import {
+  DownloadButton,
+  downloadFilename,
+  downloadMany,
+} from '@/features/photo-download';
+import {
+  SelectCheckbox,
+  SelectToggle,
+  useIsSelected,
+  usePhotoSelectStore,
+  useSelectEnabled,
+  useSelectedIds,
+} from '@/features/photo-select';
+import { SortSheet, usePhotoSortStore } from '@/features/photo-sort';
+
+import { ApiError } from '@/shared/api/error';
+import { recordForbidden } from '@/shared/lib/business-ux-logging';
+import { Alert, AlertDescription, AlertTitle } from '@/shared/ui/alert';
+import { Button } from '@/shared/ui/button';
+import { toast } from '@/shared/ui/toast';
+
+import { PhotoGrid } from '@/widgets/photo-grid';
+import { SelectionBar } from '@/widgets/selection-bar';
+
+interface BatchDownloadResult {
+  ok: number;
+  failed: number;
+}
+
+function useBatchDownload(
+  photos: Photo[],
+  selectedIds: Set<string>,
+  role: string | undefined,
+) {
+  const [downloading, setDownloading] = useState(false);
+
+  const run = async (): Promise<BatchDownloadResult | null> => {
+    const targets = photos
+      .filter((photo) => selectedIds.has(photo.id) && photo.downloadUrl)
+      .map((photo) => ({
+        url: photo.downloadUrl!,
+        filename: downloadFilename(photo),
+      }));
+
+    if (targets.length === 0) return null;
+
+    setDownloading(true);
+
+    const result = await downloadMany(targets, {
+      onError: (_, err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          recordForbidden({
+            userRole: role ?? 'unknown',
+            operationId: 'downloadMedia',
+          });
+        }
+      },
+    });
+
+    setDownloading(false);
+
+    return result;
+  };
+
+  return { downloading, run };
+}
+
 export function PhotoListPage() {
+  const navigate = useNavigate();
+  const role = useAuthRole();
+
+  const order = usePhotoSortStore((s) => s.order);
+  const enabled = useSelectEnabled();
+  const selectedIds = useSelectedIds();
+  const clearSelection = usePhotoSelectStore((s) => s.clear);
+
+  const albumId = useAlbumStore((s) => s.current?.id);
+  const query = usePhotosInfinite(
+    { sortBy: 'createdAt', order },
+    { enabled: !!albumId },
+  );
+  const photos = selectPhotos(query.data);
+
+  const { downloading, run: runBatchDownload } = useBatchDownload(
+    photos,
+    selectedIds,
+    role,
+  );
+
+  const prevOrder = useRef(order);
+  useEffect(() => {
+    if (prevOrder.current !== order) {
+      prevOrder.current = order;
+      clearSelection();
+    }
+  }, [order, clearSelection]);
+
+  const handleBatchDownload = async () => {
+    const result = await runBatchDownload();
+    if (!result) return;
+
+    const { ok, failed } = result;
+    const message = `${ok}개 다운로드 완료${failed ? `, ${failed}개 실패` : ''}`;
+
+    if (failed) toast.warning(message);
+    else toast.success(message);
+  };
+
   return (
-    <section className="mx-auto max-w-5xl p-6">
-      <h2 className="text-2xl font-semibold">사진 목록</h2>
+    <section
+      className={`mx-auto max-w-5xl space-y-4 p-6 ${enabled ? 'pb-24' : ''}`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-2xl font-semibold">사진 목록</h2>
+        <div className="flex items-center gap-2">
+          <SortSheet />
+          <SelectToggle />
+        </div>
+      </div>
+
+      <ErrorBoundary fallback={<GridErrorFallback />}>
+        <PhotoGrid
+          photos={photos}
+          isLoading={!albumId || query.isLoading}
+          isFetchingNextPage={query.isFetchingNextPage}
+          hasNextPage={!!query.hasNextPage}
+          onLoadMore={() => query.fetchNextPage()}
+          renderCard={(photo) => (
+            <GridCard
+              key={photo.id}
+              photo={photo}
+              onOpen={(id) => navigate(`/photos/${id}`)}
+            />
+          )}
+        />
+      </ErrorBoundary>
+
+      <SelectionBar
+        onDownload={handleBatchDownload}
+        isDownloading={downloading}
+      />
     </section>
+  );
+}
+
+function GridErrorFallback() {
+  return (
+    <Alert variant="destructive" className="mx-auto max-w-md text-center">
+      <AlertTitle>이 영역을 불러오지 못했어요</AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>사진 목록을 표시하는 중 문제가 발생했어요.</p>
+        <Button size="sm" onClick={() => window.location.reload()}>
+          다시 시도
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+function GridCard({
+  photo,
+  onOpen,
+}: {
+  photo: Photo;
+  onOpen: (id: string) => void;
+}) {
+  const enabled = useSelectEnabled();
+  const selected = useIsSelected(photo.id);
+  const toggle = usePhotoSelectStore((s) => s.toggle);
+
+  return (
+    <PhotoCard
+      photo={photo}
+      selected={enabled && selected}
+      selectionSlot={enabled ? <SelectCheckbox id={photo.id} /> : undefined}
+      actionSlot={!enabled ? <DownloadButton photo={photo} /> : undefined}
+      onOpen={(id) => (enabled ? toggle(id) : onOpen(id))}
+    />
   );
 }

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -1,6 +1,8 @@
 import { authTokenStore } from './auth-token';
 import { createHttpClient } from './client';
 
+export { buildQuery } from './query-string';
+
 export const http = createHttpClient({
   onUnauthorized: () => {
     authTokenStore.clear();

--- a/apps/web/src/shared/api/query-string.test.ts
+++ b/apps/web/src/shared/api/query-string.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildQuery } from './query-string';
+
+describe('buildQuery', () => {
+  test('값들을 쿼리스트링으로 직렬화하고 선행 ?를 붙인다', () => {
+    expect(buildQuery({ size: 20, order: 'desc' })).toBe('?size=20&order=desc');
+  });
+
+  test('undefined/빈 문자열 값은 생략한다', () => {
+    expect(buildQuery({ size: 20, cursor: undefined, states: '' })).toBe(
+      '?size=20',
+    );
+  });
+
+  test('cursor가 undefined면 첫 페이지에서 키 자체가 빠진다', () => {
+    const queryString = buildQuery({ order: 'asc', cursor: undefined });
+
+    expect(queryString).toBe('?order=asc');
+    expect(queryString.includes('cursor')).toBe(false);
+  });
+
+  test('모든 값이 비면 빈 문자열을 반환한다', () => {
+    expect(buildQuery({ cursor: undefined, states: '' })).toBe('');
+  });
+
+  test('숫자 0은 생략하지 않고 유지한다', () => {
+    expect(buildQuery({ size: 0 })).toBe('?size=0');
+  });
+
+  test('배열은 같은 key를 반복해 펼친다', () => {
+    expect(buildQuery({ states: ['PENDING', 'DONE'] })).toBe(
+      '?states=PENDING&states=DONE',
+    );
+  });
+
+  test('배열과 낱개 값을 함께 직렬화한다', () => {
+    expect(buildQuery({ states: ['PENDING', 'DONE'], size: 20 })).toBe(
+      '?states=PENDING&states=DONE&size=20',
+    );
+  });
+
+  test('빈 배열은 키 자체가 빠진다', () => {
+    expect(buildQuery({ states: [] })).toBe('');
+  });
+
+  test('배열 안의 빈 문자열 항목만 건너뛴다', () => {
+    expect(buildQuery({ states: ['PENDING', '', 'DONE'] })).toBe(
+      '?states=PENDING&states=DONE',
+    );
+  });
+
+  test('특수문자가 든 값은 인코딩한다', () => {
+    expect(buildQuery({ q: 'a b&c' })).toBe('?q=a+b%26c');
+  });
+});

--- a/apps/web/src/shared/api/query-string.ts
+++ b/apps/web/src/shared/api/query-string.ts
@@ -1,0 +1,31 @@
+type QueryPrimitive = string | number;
+type QueryValue = QueryPrimitive | QueryPrimitive[] | undefined;
+
+/**
+ * 객체를 쿼리스트링으로 직렬화한다.
+ *   - undefined/빈 문자열 값은 생략한다
+ *   - 배열은 같은 key를 반복해 펼친다 (states=A&states=B)
+ *   - 결과가 비면 빈 문자열, 아니면 선행 `?`를 붙여 반환한다
+ */
+export function buildQuery(params: Record<string, QueryValue>): string {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item === '') continue;
+        searchParams.append(key, String(item));
+      }
+
+      continue;
+    }
+
+    if (value === '') continue;
+    searchParams.set(key, String(value));
+  }
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}

--- a/apps/web/src/shared/api/query-string.ts
+++ b/apps/web/src/shared/api/query-string.ts
@@ -11,21 +11,17 @@ export function buildQuery(params: Record<string, QueryValue>): string {
   const searchParams = new URLSearchParams();
 
   for (const [key, value] of Object.entries(params)) {
-    if (value === undefined) continue;
+    if (value === undefined || value === '') continue;
 
     if (Array.isArray(value)) {
-      for (const item of value) {
-        if (item === '') continue;
-        searchParams.append(key, String(item));
-      }
-
-      continue;
+      value
+        .filter((item) => item !== '')
+        .forEach((item) => searchParams.append(key, String(item)));
+    } else {
+      searchParams.append(key, String(value));
     }
-
-    if (value === '') continue;
-    searchParams.set(key, String(value));
   }
 
-  const queryString = searchParams.toString();
-  return queryString ? `?${queryString}` : '';
+  const query = searchParams.toString();
+  return query ? `?${query}` : '';
 }

--- a/apps/web/src/shared/lib/hooks/use-intersection.ts
+++ b/apps/web/src/shared/lib/hooks/use-intersection.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react';
+
+interface UseIntersectionOptions {
+  enabled?: boolean;
+  rootMargin?: string;
+}
+
+export function useIntersection<T extends Element = HTMLDivElement>(
+  onIntersect: () => void,
+  { enabled = true, rootMargin = '200px' }: UseIntersectionOptions = {},
+) {
+  const targetRef = useRef<T | null>(null);
+  const callbackRef = useRef(onIntersect);
+  callbackRef.current = onIntersect;
+
+  useEffect(() => {
+    const element = targetRef.current;
+    if (!element || !enabled) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          callbackRef.current();
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [enabled, rootMargin]);
+
+  return targetRef;
+}

--- a/apps/web/src/widgets/photo-grid/ui/photo-grid.tsx
+++ b/apps/web/src/widgets/photo-grid/ui/photo-grid.tsx
@@ -1,2 +1,60 @@
-// Grid 레이아웃 + skeleton/empty
-export function PhotoGrid() {}
+import type { ReactNode } from 'react';
+
+import type { Photo } from '@/entities/photo';
+import { useIntersection } from '@/shared/lib/hooks/use-intersection';
+import { Alert, AlertDescription, AlertTitle } from '@/shared/ui/alert';
+import { Skeleton } from '@/shared/ui/skeleton';
+
+interface PhotoGridProps {
+  photos: Photo[];
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+  onLoadMore: () => void;
+  renderCard: (photo: Photo) => ReactNode;
+}
+
+const GRID_CLASS = 'grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4';
+
+function GridSkeleton({ count = 12 }: { count?: number }) {
+  return (
+    <div className={GRID_CLASS}>
+      {Array.from({ length: count }, (_, i) => (
+        <Skeleton key={i} className="aspect-square rounded-md" />
+      ))}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <Alert className="mx-auto max-w-md text-center">
+      <AlertTitle>아직 사진이 없어요</AlertTitle>
+      <AlertDescription>사진을 업로드하면 이곳에 표시됩니다.</AlertDescription>
+    </Alert>
+  );
+}
+
+export function PhotoGrid({
+  photos,
+  isLoading,
+  isFetchingNextPage,
+  hasNextPage,
+  onLoadMore,
+  renderCard,
+}: PhotoGridProps) {
+  const sentinelRef = useIntersection(onLoadMore, {
+    enabled: hasNextPage && !isFetchingNextPage,
+  });
+
+  if (isLoading) return <GridSkeleton />;
+  if (photos.length === 0) return <EmptyState />;
+
+  return (
+    <div className="space-y-3">
+      <div className={GRID_CLASS}>{photos.map(renderCard)}</div>
+      <div ref={sentinelRef} aria-hidden className="h-8" />
+      {isFetchingNextPage && <GridSkeleton count={4} />}
+    </div>
+  );
+}

--- a/apps/web/src/widgets/selection-bar/ui/selection-bar.tsx
+++ b/apps/web/src/widgets/selection-bar/ui/selection-bar.tsx
@@ -1,2 +1,48 @@
-// 선택모드 하단바(선택수/다운로드)
-export function SelectionBar() {}
+import { Download } from 'lucide-react';
+
+import {
+  SelectedCounter,
+  useSelectEnabled,
+  useSelectedCount,
+  usePhotoSelectStore,
+} from '@/features/photo-select';
+import { Button } from '@/shared/ui/button';
+
+interface SelectionBarProps {
+  onDownload: () => void;
+  isDownloading?: boolean;
+}
+
+export function SelectionBar({ onDownload, isDownloading }: SelectionBarProps) {
+  const enabled = useSelectEnabled();
+  const count = useSelectedCount();
+  const clear = usePhotoSelectStore((s) => s.clear);
+
+  if (!enabled) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur">
+      <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 p-3">
+        <SelectedCounter />
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={clear}
+            disabled={count === 0}
+          >
+            선택 해제
+          </Button>
+          <Button
+            type="button"
+            onClick={onDownload}
+            disabled={count === 0 || isDownloading}
+          >
+            <Download className="mr-1 size-4" />
+            {isDownloading ? '다운로드 중…' : `${count}개 다운로드`}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 관련 이슈
* #64

---
## 🧹 작업 내용
사진 목록 페이지 구현.
커서 기반 무한 스크롤로 목록을 불러오고, 정렬 · 다중 선택 · 다운로드(단건/일괄)를 지원.

**목록 / 조회**
1. **쿼리스트링 빌더 + `useIntersection` 훅**
   - 무한 스크롤용 sentinel 교차 감지
2. **Photo 모델·mapper + 커서 기반 `usePhotosInfinite`** 
   -  `states=COMPLETE`만 조회
   - 앨범 준비 후에만 fetch하도록 게이팅
3. **PhotoCard / Thumbnail + 무한 스크롤 Grid 위젯**
   - 하단 sentinel 진입 시 다음 페이지 로드

**정렬 / 선택**

4. **정렬 스토어 + 토글 UI**  
   - 생성일 `asc`/`desc`
5. **다중 선택 스토어 + 체크박스 + SelectionBar**  
   - 선택 모드 토글 / 선택 개수 표시

**다운로드**

6. **다운로드 파일명 정책 + 단건·일괄 다운로더**    
   - `description` 기반 파일명(폴백: id), mime→확장자 추론
7. **페이지 통합**  
   - 정렬 · 선택 · 다운로드를 한 화면에 결합

---
## 🛠️ 테스트
* [x] 단위 테스트 통과 (쿼리스트링 빌더 · mapper · 파일명 정책 · 커서 페이지네이션 · 선택 스토어)
* [x] 빌드 통과

---
## 🔍 동작 흐름
```mermaid
flowchart TD
  Enter["사진 목록 진입"] --> Album{"앨범 준비됨?"}
  Album -->|아니오| Skel["스켈레톤 · 조회 보류"]
  Album -->|예| Fetch["usePhotosInfinite (커서)"]
  Fetch --> Grid["Grid 렌더"]
  Grid --> Sentinel{"하단 sentinel 교차?"}
  Sentinel -->|예| Next["fetchNextPage"] --> Grid
  Grid --> Select["선택 모드 → 체크박스 / SelectionBar"]
  Select --> Download["선택 항목 일괄 다운로드"]
  Download --> S3["downloadUrl(S3)에서 수신 + 파일명 정책 적용"]
```

---
## 💬 참고 사항
* **S3 다운로드 CORS 확인 필요** 
   * 응답 헤더 값을 프론트가 제대로 받아오는지(노출 헤더 / 다운로드용 헤더) 검증이 필요하다.

> **Content-Disposition**가 presigned URL 발급 시 `attachment`로 내려지는 상황인지 테스트 후 확인  
> 현재 blob으로 우회 중