### PR TITLE
[Feat] 사진 상세 — 조회·메타 편집·삭제·이전/다음 네비게이션 (#66)

### DIFF
--- a/apps/web/src/entities/photo/api/mutations.test.ts
+++ b/apps/web/src/entities/photo/api/mutations.test.ts
@@ -1,0 +1,161 @@
+import { MutationObserver, QueryClient } from '@tanstack/react-query';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  buildDeletePhotoOptions,
+  buildUpdatePhotoMetaOptions,
+} from './mutations';
+import { photoKeys } from './keys';
+import type { MediaDto, Photo } from '../model/types';
+
+const mocks = vi.hoisted(() => ({
+  patch: vi.fn(),
+  del: vi.fn(),
+}));
+
+vi.mock('@/shared/api', () => ({
+  http: { patch: mocks.patch, delete: mocks.del },
+}));
+
+function photo(overrides: Partial<Photo> = {}): Photo {
+  return {
+    id: 'p1',
+    description: '원본 설명',
+    state: 'COMPLETE',
+    isFavorite: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    createdBy: { id: 'u1', name: '홍길동', email: 'u1@test.io' },
+    ...overrides,
+  };
+}
+
+function mediaDto(description: string): MediaDto {
+  return {
+    id: 'p1',
+    description,
+    state: 'COMPLETE',
+    isFavorite: false,
+    content: {
+      location: { url: 's3://p1', accessUrl: 'https://signed/p1' },
+      size: 10,
+      eTag: 'e',
+      mimeType: 'image/jpeg',
+      thumbnail: null,
+    },
+    created: { at: '2026-01-01T00:00:00.000Z', by: photo().createdBy },
+  };
+}
+
+function runUpdate(qc: QueryClient, vars: { id: string; description: string }) {
+  return new MutationObserver(qc, buildUpdatePhotoMetaOptions(qc)).mutate(vars);
+}
+
+function runDelete(qc: QueryClient, id: string) {
+  return new MutationObserver(qc, buildDeletePhotoOptions(qc)).mutate(id);
+}
+
+describe('buildUpdatePhotoMetaOptions', () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    mocks.patch.mockReset();
+    qc = new QueryClient();
+    qc.setQueryData(photoKeys.detail('p1'), photo());
+  });
+
+  test('성공 시 상세 캐시 description이 갱신된다(낙관적 반영 유지)', async () => {
+    mocks.patch.mockResolvedValueOnce(mediaDto('바뀐 설명'));
+
+    await runUpdate(qc, { id: 'p1', description: '바뀐 설명' });
+
+    expect(qc.getQueryData<Photo>(photoKeys.detail('p1'))?.description).toBe(
+      '바뀐 설명',
+    );
+    expect(mocks.patch).toHaveBeenCalledWith('/v1/media/p1', {
+      description: '바뀐 설명',
+    });
+  });
+
+  // TODO: RTL 도입 시 활성화
+  // - RTL 도입 후 `vi.waitFor`(또는 @testing-library/react의 waitFor)로 폴링해 검증 예정
+  //
+  // test('서버 응답 전에 캐시가 먼저 바뀐다(낙관적 반영의 즉시성)', async () => {
+  //   // given: patch가 끝나지 않는 pending 상태
+  //   let resolvePatch!: (dto: MediaDto) => void;
+  //   mocks.patch.mockReturnValueOnce(
+  //     new Promise<MediaDto>((resolve) => {
+  //       resolvePatch = resolve;
+  //     }),
+  //   );
+  //
+  //   // when: mutate만 호출하고 응답은 아직 기다리지 않는다
+  //   const settled = runUpdate(qc, { id: 'p1', description: '바뀐 설명' });
+  //
+  //   // then: patch가 pending인 동안 캐시가 먼저 바뀐다(서버 응답 전 즉시성)
+  //   await vi.waitFor(() =>
+  //     expect(qc.getQueryData<Photo>(photoKeys.detail('p1'))?.description).toBe(
+  //       '바뀐 설명',
+  //     ),
+  //   );
+  //
+  //   resolvePatch(mediaDto('바뀐 설명'));
+  //   await settled;
+  // });
+
+  test('실패 시 이전 값으로 롤백한다', async () => {
+    mocks.patch.mockRejectedValueOnce(new Error('fail'));
+
+    await expect(
+      runUpdate(qc, { id: 'p1', description: '바뀐 설명' }),
+    ).rejects.toThrow('fail');
+
+    expect(qc.getQueryData<Photo>(photoKeys.detail('p1'))?.description).toBe(
+      '원본 설명',
+    );
+  });
+
+  test('성공 후 상세와 목록 쿼리를 무효화한다', async () => {
+    mocks.patch.mockResolvedValueOnce(mediaDto('바뀐 설명'));
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    await runUpdate(qc, { id: 'p1', description: '바뀐 설명' });
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: photoKeys.detail('p1'),
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: photoKeys.lists() });
+  });
+
+  test('실패해도 상세와 목록 쿼리를 무효화한다', async () => {
+    mocks.patch.mockRejectedValueOnce(new Error('fail'));
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    await expect(
+      runUpdate(qc, { id: 'p1', description: '바뀐 설명' }),
+    ).rejects.toThrow('fail');
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: photoKeys.detail('p1'),
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: photoKeys.lists() });
+  });
+});
+
+describe('buildDeletePhotoOptions', () => {
+  beforeEach(() => mocks.del.mockReset());
+
+  test('성공 시 상세 캐시를 제거하고 목록을 무효화한다', async () => {
+    mocks.del.mockResolvedValueOnce(undefined);
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.detail('p1'), photo());
+
+    const remove = vi.spyOn(qc, 'removeQueries');
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    await runDelete(qc, 'p1');
+
+    expect(mocks.del).toHaveBeenCalledWith('/v1/media/p1');
+    expect(remove).toHaveBeenCalledWith({ queryKey: photoKeys.detail('p1') });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: photoKeys.lists() });
+  });
+});

--- a/apps/web/src/entities/photo/api/mutations.ts
+++ b/apps/web/src/entities/photo/api/mutations.ts
@@ -1,0 +1,84 @@
+import {
+  useMutation,
+  useQueryClient,
+  type QueryClient,
+  type UseMutationOptions,
+} from '@tanstack/react-query';
+
+import { http } from '@/shared/api';
+
+import { toPhoto } from '../lib/mapper';
+import type { MediaDto, Photo } from '../model/types';
+import { photoKeys } from './keys';
+
+export interface UpdatePhotoMetaVars {
+  id: string;
+  description: string;
+}
+
+interface UpdateContext {
+  id: string;
+  previous: Photo | undefined;
+}
+
+export function buildUpdatePhotoMetaOptions(
+  queryClient: QueryClient,
+): UseMutationOptions<Photo, Error, UpdatePhotoMetaVars, UpdateContext> {
+  return {
+    mutationFn: ({ id, description }) =>
+      http.patch<MediaDto>(`/v1/media/${id}`, { description }).then(toPhoto),
+    meta: { operationId: 'updateMedia' },
+
+    onMutate: async ({ id, description }) => {
+      await queryClient.cancelQueries({ queryKey: photoKeys.detail(id) });
+
+      const previous = queryClient.getQueryData<Photo>(photoKeys.detail(id));
+      if (previous) {
+        queryClient.setQueryData<Photo>(photoKeys.detail(id), {
+          ...previous,
+          description,
+        });
+      }
+
+      return { id, previous };
+    },
+
+    onError: (_error, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          photoKeys.detail(context.id),
+          context.previous,
+        );
+      }
+    },
+
+    onSettled: (_data, _error, { id }) => {
+      queryClient.invalidateQueries({ queryKey: photoKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
+    },
+  };
+}
+
+export function useUpdatePhotoMetaMutation() {
+  const queryClient = useQueryClient();
+  return useMutation(buildUpdatePhotoMetaOptions(queryClient));
+}
+
+export function buildDeletePhotoOptions(
+  queryClient: QueryClient,
+): UseMutationOptions<void, Error, string> {
+  return {
+    mutationFn: (id) => http.delete(`/v1/media/${id}`),
+    meta: { operationId: 'deleteMedia' },
+
+    onSuccess: (_data, id) => {
+      queryClient.removeQueries({ queryKey: photoKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
+    },
+  };
+}
+
+export function useDeletePhotoMutation() {
+  const queryClient = useQueryClient();
+  return useMutation(buildDeletePhotoOptions(queryClient));
+}

--- a/apps/web/src/entities/photo/api/queries.test.ts
+++ b/apps/web/src/entities/photo/api/queries.test.ts
@@ -1,7 +1,9 @@
+import { QueryClient } from '@tanstack/react-query';
 import { describe, expect, test } from 'vitest';
 
 import type { MediaDto, MediaListResponse } from '../model/types';
-import { nextCursorOf, selectPhotos } from './queries';
+import { photoKeys } from './keys';
+import { findPhotoInListCache, nextCursorOf, selectPhotos } from './queries';
 
 function page(
   items: MediaDto[],
@@ -83,5 +85,53 @@ describe('selectPhotos', () => {
 
   test('data가 undefined면 빈 배열', () => {
     expect(selectPhotos(undefined)).toEqual([]);
+  });
+});
+
+describe('findPhotoInListCache', () => {
+  test('로드된 목록 캐시에서 id에 해당하는 Photo를 찾는다', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a'), dto('b')])],
+    });
+
+    expect(findPhotoInListCache(qc, 'b')?.id).toBe('b');
+  });
+
+  test('정렬이 다른 여러 list 캐시를 순회해 찾는다', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a')])],
+    });
+    qc.setQueryData(photoKeys.list({ order: 'asc' }), {
+      pages: [page([dto('b')])],
+    });
+
+    expect(findPhotoInListCache(qc, 'b')?.id).toBe('b');
+  });
+
+  test('data가 비어있는 캐시 항목이 섞여 있어도 안전하게 넘어간다', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), undefined);
+    qc.setQueryData(photoKeys.list({ order: 'asc' }), {
+      pages: [page([dto('b')])],
+    });
+
+    expect(findPhotoInListCache(qc, 'b')?.id).toBe('b');
+  });
+
+  test('캐시에 id가 없으면 undefined(직접 진입 → normal fetch)', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a')])],
+    });
+
+    expect(findPhotoInListCache(qc, 'zzz')).toBeUndefined();
+  });
+
+  test('list 캐시가 하나도 없으면 undefined(루프를 돌지 않음)', () => {
+    const qc = new QueryClient();
+
+    expect(findPhotoInListCache(qc, 'a')).toBeUndefined();
   });
 });

--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -1,10 +1,15 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from '@tanstack/react-query';
 
 import { buildQuery, http } from '@/shared/api';
 import { recordMediaListSlow } from '@/shared/lib/business-ux-logging';
 
 import { toPhoto } from '../lib/mapper';
-import type { MediaListResponse, Photo } from '../model/types';
+import type { MediaDto, MediaListResponse, Photo } from '../model/types';
 import { photoKeys, type PhotoListFilters } from './keys';
 
 const PAGE_SIZE = 20;
@@ -40,6 +45,48 @@ async function fetchPhotoPage(
   recordMediaListSlow(performance.now() - startedAt, 'listMedia');
 
   return response;
+}
+
+/**
+ * 이미 로드된 목록 캐시(모든 list 쿼리)에서 id에 해당하는 Photo를 찾는다.
+ * - 목록 → 상세 진입 시 단건 요청을 기다리지 않고 즉시 표시한다.
+ * - 직접 진입(새로고침)처럼 캐시가 없으면 undefined를 반환해 정상 fetch로 넘어간다.
+ */
+export function findPhotoInListCache(
+  queryClient: QueryClient,
+  id: string,
+): Photo | undefined {
+  const entries = queryClient.getQueriesData<{ pages: MediaListResponse[] }>({
+    queryKey: photoKeys.lists(),
+  });
+
+  for (const [, data] of entries) {
+    const found = selectPhotos(data).find((photo) => photo.id === id);
+    if (found) {
+      return found;
+    }
+  }
+
+  return undefined;
+}
+
+async function fetchPhotoDetail(id: string): Promise<Photo> {
+  const dto = await http.get<MediaDto>(`/v1/media/${id}`);
+  return toPhoto(dto);
+}
+
+export function usePhotoDetail(id: string, options?: { enabled?: boolean }) {
+  const queryClient = useQueryClient();
+
+  return useQuery({
+    queryKey: photoKeys.detail(id),
+    queryFn: () => fetchPhotoDetail(id),
+    enabled: (options?.enabled ?? true) && !!id,
+    initialData: () => findPhotoInListCache(queryClient, id),
+    staleTime: 60_000,
+    throwOnError: true,
+    meta: { operationId: 'getMedia' },
+  });
 }
 
 export function usePhotosInfinite(

--- a/apps/web/src/entities/photo/index.ts
+++ b/apps/web/src/entities/photo/index.ts
@@ -1,8 +1,25 @@
-export { usePhotosInfinite, selectPhotos, nextCursorOf } from './api/queries';
 export { photoKeys, type PhotoListFilters } from './api/keys';
+export {
+  usePhotosInfinite,
+  usePhotoDetail,
+  findPhotoInListCache,
+  selectPhotos,
+  nextCursorOf,
+} from './api/queries';
+export {
+  useUpdatePhotoMetaMutation,
+  useDeletePhotoMutation,
+  type UpdatePhotoMetaVars,
+} from './api/mutations';
 
 export { toPhoto } from './lib/mapper';
-export type { Photo, PhotoState, MediaListResponse } from './model/types';
+export { formatBytes, formatDateTime } from './lib/format';
+export type {
+  Photo,
+  PhotoState,
+  MediaDto,
+  MediaListResponse,
+} from './model/types';
 
 export { PhotoCard } from './ui/photo-card';
 export { PhotoThumbnail } from './ui/photo-thumbnail';

--- a/apps/web/src/entities/photo/lib/format.test.ts
+++ b/apps/web/src/entities/photo/lib/format.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatBytes, formatDateTime } from './format';
+
+describe('formatBytes', () => {
+  test('단위를 올려가며 표기한다', () => {
+    expect(formatBytes(512)).toBe('512B');
+    expect(formatBytes(2048)).toBe('2KB');
+    expect(formatBytes(1_500_000)).toBe('1.4MB');
+  });
+
+  test('B↔KB 경계를 정확히 가른다', () => {
+    expect(formatBytes(1023)).toBe('1023B');
+    expect(formatBytes(1024)).toBe('1KB');
+    expect(formatBytes(1048576)).toBe('1MB');
+  });
+
+  test('바이트는 정수, KB 이상은 소수 첫째 자리로 반올림한다', () => {
+    expect(formatBytes(1)).toBe('1B');
+    expect(formatBytes(1536)).toBe('1.5KB');
+    expect(formatBytes(1100)).toBe('1.1KB');
+  });
+
+  test('GB를 상한으로 둔다(그 이상도 GB로 표기)', () => {
+    expect(formatBytes(5 * 1024 ** 3)).toBe('5GB');
+    expect(formatBytes(2 * 1024 ** 4)).toBe('2048GB');
+  });
+
+  test('없거나 유효하지 않거나 0 이하면 -', () => {
+    expect(formatBytes(undefined)).toBe('-');
+    expect(formatBytes(0)).toBe('-');
+    expect(formatBytes(-100)).toBe('-');
+    expect(formatBytes(NaN)).toBe('-');
+    expect(formatBytes(Infinity)).toBe('-');
+  });
+});
+
+describe('formatDateTime', () => {
+  test('유효한 ISO를 ko-KR 표기로 포맷한다', () => {
+    const formatted = formatDateTime('2026-01-01T00:00:00.000Z');
+
+    expect(formatted).not.toBe('2026-01-01T00:00:00.000Z');
+    expect(formatted).toContain('2026');
+  });
+
+  test('파싱 실패 시 원본을 반환한다', () => {
+    expect(formatDateTime('not-a-date')).toBe('not-a-date');
+    expect(formatDateTime('')).toBe('');
+  });
+});

--- a/apps/web/src/entities/photo/lib/format.ts
+++ b/apps/web/src/entities/photo/lib/format.ts
@@ -1,0 +1,48 @@
+const KB = 1024;
+const UNITS = ['B', 'KB', 'MB', 'GB'] as const;
+
+const roundToTenth = (n: number) => Math.round(n * 10) / 10;
+
+/**
+ * 바이트 크기를 사람이 읽기 쉬운 단위 문자열로 변환한다.
+ *
+ * - 1024를 기준으로 B → KB → MB → GB까지 환산하며, GB를 상한으로 둔다.
+ *
+ * @example
+ * formatBytes(1023);    // '1023B'
+ * formatBytes(1024);    // '1KB'
+ * formatBytes(1536);    // '1.5KB'
+ * formatBytes(0);       // '-'
+ * formatBytes(undefined); // '-'
+ */
+export function formatBytes(size: number | undefined): string {
+  if (size == null || !Number.isFinite(size) || size <= 0) return '-';
+
+  const exponent = Math.floor(Math.log(size) / Math.log(KB));
+  const unitIndex = Math.min(exponent, UNITS.length - 1);
+  const value = size / KB ** unitIndex;
+
+  return `${unitIndex === 0 ? value : roundToTenth(value)}${UNITS[unitIndex]}`;
+}
+
+/**
+ * ISO 8601 문자열을 한국어(ko-KR) 날짜·시각 표기로 변환한다.
+ *
+ * - 날짜는 medium(예: `2026. 1. 1.`), 시각은 short(예: `오후 3:00`) 스타일을 쓴다.
+ * - 파싱할 수 없는 입력이면 원본 문자열을 그대로 반환한다.
+ *
+ * @example
+ * formatDateTime('2026-01-01T15:00:00.000Z'); // '2026. 1. 1. 오후 3:00' (KST 기준)
+ * formatDateTime('not-a-date');               // 'not-a-date'
+ */
+export function formatDateTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return iso;
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}

--- a/apps/web/src/entities/photo/lib/format.ts
+++ b/apps/web/src/entities/photo/lib/format.ts
@@ -26,22 +26,31 @@ export function formatBytes(size: number | undefined): string {
 }
 
 /**
- * ISO 8601 문자열을 한국어(ko-KR) 날짜·시각 표기로 변환한다.
+ * ISO 8601 문자열을 날짜·시각 표기로 변환한다.
  *
- * - 날짜는 medium(예: `2026. 1. 1.`), 시각은 short(예: `오후 3:00`) 스타일을 쓴다.
+ * - 표기 언어·형식은 `locale`을 따른다. 생략하면 실행 환경(브라우저)의 기본 로케일을 쓴다.
+ * - 타임존은 지정하지 않으므로 실행 환경(브라우저)의 타임존을 따른다.
+ *   (서버가 UTC로 내려준 시각이 보는 사람의 현지 시각으로 표시된다)
+ * - 날짜는 medium, 시각은 short 스타일을 쓴다.
  * - 파싱할 수 없는 입력이면 원본 문자열을 그대로 반환한다.
  *
  * @example
- * formatDateTime('2026-01-01T15:00:00.000Z'); // '2026. 1. 1. 오후 3:00' (KST 기준)
- * formatDateTime('not-a-date');               // 'not-a-date'
+ * // 브라우저가 ko-KR / Asia/Seoul 인 경우 (06:00Z == 15:00 KST)
+ * formatDateTime('2026-01-01T06:00:00.000Z');          // '2026. 1. 1. 오후 3:00'
+ * // 로케일을 명시하면 그 언어로 (타임존은 여전히 브라우저 기준)
+ * formatDateTime('2026-01-01T06:00:00.000Z', 'en-US'); // 'Jan 1, 2026, 3:00 PM'
+ * formatDateTime('not-a-date');                        // 'not-a-date'
  */
-export function formatDateTime(iso: string): string {
+export function formatDateTime(
+  iso: string,
+  locale?: string, // 생략 시 브라우저 기본 로케일
+): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) {
     return iso;
   }
 
-  return new Intl.DateTimeFormat('ko-KR', {
+  return new Intl.DateTimeFormat(locale, {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(date);

--- a/apps/web/src/entities/photo/ui/photo-meta.tsx
+++ b/apps/web/src/entities/photo/ui/photo-meta.tsx
@@ -1,1 +1,40 @@
-export function PhotoMeta() {}
+import { formatBytes, formatDateTime } from '../lib/format';
+import type { Photo, PhotoState } from '../model/types';
+
+const STATE_LABEL: Record<PhotoState, string> = {
+  DRAFT: '임시',
+  PREPARING: '처리 중',
+  COMPLETE: '완료',
+};
+
+interface MetaRowProps {
+  label: string;
+  value: string;
+}
+
+interface PhotoMetaProps {
+  photo: Photo;
+}
+
+export function PhotoMeta({ photo }: PhotoMetaProps) {
+  return (
+    <dl className="divide-y divide-border rounded-md border p-4">
+      <MetaRow label="작성자" value={photo.createdBy.name} />
+      <MetaRow label="작성일" value={formatDateTime(photo.createdAt)} />
+      <MetaRow label="상태" value={STATE_LABEL[photo.state]} />
+      {photo.mimeType && <MetaRow label="형식" value={photo.mimeType} />}
+      {photo.size != null && (
+        <MetaRow label="크기" value={formatBytes(photo.size)} />
+      )}
+    </dl>
+  );
+}
+
+function MetaRow({ label, value }: MetaRowProps) {
+  return (
+    <div className="flex justify-between gap-4 py-1.5 text-sm">
+      <dt className="shrink-0 text-muted-foreground">{label}</dt>
+      <dd className="truncate text-right">{value}</dd>
+    </div>
+  );
+}

--- a/apps/web/src/features/photo-edit-meta/api/mutations.ts
+++ b/apps/web/src/features/photo-edit-meta/api/mutations.ts
@@ -1,2 +1,5 @@
-// useUpdatePhotoMetaMutation()
-export {};
+// 캐시 일관성 때문에 entities/photo에 구현(re-export)
+export {
+  useUpdatePhotoMetaMutation,
+  type UpdatePhotoMetaVars,
+} from '@/entities/photo';

--- a/apps/web/src/features/photo-edit-meta/index.ts
+++ b/apps/web/src/features/photo-edit-meta/index.ts
@@ -1,1 +1,6 @@
+export {
+  useUpdatePhotoMetaMutation,
+  type UpdatePhotoMetaVars,
+} from './api/mutations';
+
 export { EditMetaForm } from './ui/edit-meta-form';

--- a/apps/web/src/features/photo-edit-meta/ui/edit-meta-form.tsx
+++ b/apps/web/src/features/photo-edit-meta/ui/edit-meta-form.tsx
@@ -1,2 +1,107 @@
-// 제목/설명 수정
-export function EditMetaForm() {}
+import { Pencil } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { useUpdatePhotoMetaMutation, type Photo } from '@/entities/photo';
+
+import { Button } from '@/shared/ui/button';
+import { Input } from '@/shared/ui/input';
+import { toast } from '@/shared/ui/toast';
+
+interface EditMetaFormProps {
+  photo: Photo;
+  canEdit: boolean;
+}
+
+export function EditMetaForm({ photo, canEdit }: EditMetaFormProps) {
+  const [editing, setEditing] = useState(false);
+  const [description, setDescription] = useState(photo.description);
+
+  const mutation = useUpdatePhotoMetaMutation();
+
+  useEffect(() => {
+    if (!editing) {
+      setDescription(photo.description);
+    }
+  }, [photo.description, editing]);
+
+  const trimmed = description.trim();
+  const isValid = trimmed.length >= 1;
+  const isDirty = trimmed !== photo.description;
+  const canSave = isValid && isDirty && !mutation.isPending;
+
+  const handleSave = () => {
+    if (!canSave) return;
+    mutation.mutate(
+      { id: photo.id, description: trimmed },
+      {
+        onSuccess: () => {
+          toast.success('설명을 수정했어요.');
+          setEditing(false);
+        },
+        onError: () => toast.error('설명 수정에 실패했어요.'),
+      },
+    );
+  };
+
+  const handleCancel = () => {
+    setDescription(photo.description);
+    setEditing(false);
+  };
+
+  if (!editing) {
+    return (
+      <div className="flex items-start justify-between gap-3">
+        <p className="whitespace-pre-wrap wrap-break-word text-base">
+          {photo.description}
+        </p>
+        {canEdit && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={() => setEditing(true)}
+          >
+            <Pencil className="size-4" />
+            편집
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="space-y-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSave();
+      }}
+    >
+      <Input
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        aria-label="사진 설명"
+        autoFocus
+        disabled={mutation.isPending}
+      />
+      {!isValid && (
+        <p className="text-xs text-destructive">설명을 입력해 주세요.</p>
+      )}
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleCancel}
+          disabled={mutation.isPending}
+        >
+          취소
+        </Button>
+        <Button type="submit" size="sm" disabled={!canSave}>
+          {mutation.isPending ? '저장 중…' : '저장'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -1,12 +1,220 @@
-import { useParams } from 'react-router-dom';
+import { ArrowLeft, ChevronLeft, ChevronRight, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
-// 사진 상세 화면(제목/설명 수정 + 단건 다운로드) — 실제 구현은 후속 PR에서 진행
+import { ErrorBoundary } from '@/app/providers/error-boundary';
+import { useAlbumStore } from '@/entities/album';
+import {
+  PhotoMeta,
+  selectPhotos,
+  useDeletePhotoMutation,
+  usePhotoDetail,
+  usePhotosInfinite,
+  type Photo,
+} from '@/entities/photo';
+
+import { canWriteMeta, useAuthRole, useAuthUser } from '@/features/auth';
+import { DownloadButton } from '@/features/photo-download';
+import { EditMetaForm } from '@/features/photo-edit-meta';
+import { usePhotoSortStore } from '@/features/photo-sort';
+
+import { ApiError } from '@/shared/api/error';
+import { recordForbidden } from '@/shared/lib/business-ux-logging';
+import { Alert, AlertDescription, AlertTitle } from '@/shared/ui/alert';
+import { Button } from '@/shared/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shared/ui/dialog';
+import { Skeleton } from '@/shared/ui/skeleton';
+import { toast } from '@/shared/ui/toast';
+
+/**
+ * 현재 정렬 순서에 맞는 목록 캐시에서 이전/다음 사진 id를 계산한다.
+ *
+ * - 목록을 새로 요청하지 않고({ enabled: false }) 이미 로드된 캐시만 읽는다.
+ * - 목록을 거쳐 들어온 경우 인접 사진으로 이동할 수 있다.
+ * - 직접 진입(캐시 없음)이거나 목록에 없는 id면 prev/next 모두 undefined → 버튼 비활성.
+ *
+ * @param currentId - 현재 보고 있는 사진 id.
+ * @returns 이전/다음 사진 id. 없으면 각각 undefined.
+ */
+function usePrevNext(currentId: string) {
+  const order = usePhotoSortStore((s) => s.order);
+  const { data } = usePhotosInfinite(
+    { sortBy: 'createdAt', order },
+    { enabled: false },
+  );
+
+  const photos = selectPhotos(data);
+  const index = photos.findIndex((photo) => photo.id === currentId);
+  if (index === -1) {
+    return { prevId: undefined, nextId: undefined };
+  }
+
+  return {
+    prevId: photos[index - 1]?.id,
+    nextId: photos[index + 1]?.id,
+  };
+}
+
 export function PhotoDetailPage() {
-  const { id } = useParams<{ id: string }>();
+  const { id = '' } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const albumId = useAlbumStore((s) => s.current?.id);
+  const user = useAuthUser();
+
+  const query = usePhotoDetail(id, { enabled: !!albumId });
+  const photo = query.data;
+  const { prevId, nextId } = usePrevNext(id);
+
+  if (query.isLoading || !photo) {
+    return <DetailSkeleton />;
+  }
+
+  const canWrite = canWriteMeta(user?.role, photo.createdBy.id, user?.id);
+
   return (
-    <section className="mx-auto max-w-3xl p-6">
-      <h2 className="text-2xl font-semibold">사진 상세</h2>
-      <p className="mt-2 text-sm text-muted-foreground">id: {id}</p>
+    <section className="mx-auto max-w-4xl space-y-6 p-6">
+      <div className="flex items-center justify-between gap-2">
+        <Button variant="ghost" size="sm" onClick={() => navigate('/photos')}>
+          <ArrowLeft className="size-4" />
+          목록
+        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!prevId}
+            onClick={() => prevId && navigate(`/photos/${prevId}`)}
+          >
+            <ChevronLeft className="size-4" />
+            이전
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!nextId}
+            onClick={() => nextId && navigate(`/photos/${nextId}`)}
+          >
+            다음
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex justify-center overflow-hidden rounded-lg bg-muted">
+        {photo.imageUrl && (
+          <img
+            src={photo.imageUrl}
+            alt={photo.description}
+            className="max-h-[70vh] w-auto object-contain"
+          />
+        )}
+      </div>
+
+      <ErrorBoundary fallback={<MetaErrorFallback />}>
+        <div className="space-y-4">
+          <EditMetaForm photo={photo} canEdit={canWrite} />
+          <PhotoMeta photo={photo} />
+        </div>
+      </ErrorBoundary>
+
+      <div className="flex items-center justify-between">
+        <DownloadButton photo={photo} variant="secondary" />
+        {canWrite && <DeletePhotoButton photo={photo} />}
+      </div>
     </section>
+  );
+}
+
+function DeletePhotoButton({ photo }: { photo: Photo }) {
+  const navigate = useNavigate();
+  const role = useAuthRole();
+  const [open, setOpen] = useState(false);
+  const mutation = useDeletePhotoMutation();
+
+  const handleDelete = () => {
+    mutation.mutate(photo.id, {
+      onSuccess: () => {
+        toast.success('사진을 삭제했어요.');
+        navigate('/photos');
+      },
+
+      onError: (err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          recordForbidden({
+            userRole: role ?? 'unknown',
+            operationId: 'deleteMedia',
+          });
+          toast.error('삭제 권한이 없어요.');
+        } else {
+          toast.error('삭제에 실패했어요.');
+        }
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="destructive" size="sm">
+          <Trash2 className="size-4" />
+          삭제
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>사진을 삭제할까요?</DialogTitle>
+          <DialogDescription>삭제한 사진은 되돌릴 수 없어요.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={mutation.isPending}
+          >
+            취소
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? '삭제 중…' : '삭제'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <section className="mx-auto max-w-4xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-40" />
+      </div>
+      <Skeleton className="aspect-video w-full" />
+      <Skeleton className="h-24 w-full" />
+    </section>
+  );
+}
+
+function MetaErrorFallback() {
+  return (
+    <Alert variant="destructive">
+      <AlertTitle>이 영역을 불러오지 못했어요</AlertTitle>
+      <AlertDescription>
+        사진 정보를 표시하는 중 문제가 발생했어요.
+      </AlertDescription>
+    </Alert>
   );
 }


### PR DESCRIPTION
## 📌 관련 이슈
* #66

---
## 🧹 작업 내용
- 사진 상세 페이지 구현
- 단건 조회 · 설명(메타) 편집 · 삭제
- 목록 내 이전/다음 이동

**엔티티 API / 유틸**
1. **단건 조회 `usePhotoDetail`**
    - `/v1/media/:id` 조회. 목록 캐시에 이미 있으면 `initialData`로 즉시 표시 후 백그라운드 갱신
2. **수정 mutation `useUpdatePhotoMeta`**
    - `description` PATCH / 낙관적 업데이트(선반영 → 실패 시 롤백 → 정산 시 detail·목록 무효화)
3. **삭제 mutation `useDeletePhoto`**
    - 성공 시 detail 캐시 제거 + 목록 무효화

**메타 편집 feature**

- **`photo-edit-meta`
    - 설명 편집 폼 (수정 mutation 연결)

**상세 페이지 통합**

**뷰어 + 편집 + 삭제 + 네비게이션**
  - 권한에 따라 편집/삭제 노출
  - 삭제는 확인 다이얼로그
  - 이전/다음은 목록 캐시만 읽어 인접 사진으로 이동 `직접 진입 시 비활성`

---
## 🛠️ 테스트
* [x] 단위 테스트 통과 
* [x] 빌드 통과

---
## 🔍 동작 흐름
```mermaid
flowchart TD
  Enter["상세 진입 (/photos/:id)"] --> Cache{"목록 캐시에 있음?"}
  Cache -->|예| Instant["initialData로 즉시 표시"]
  Cache -->|아니오| Fetch["GET /v1/media/:id"]
  Instant --> View["뷰어 + 메타 표시"]
  Fetch --> View
  View --> Perm{"canWriteMeta?"}
  Perm -->|예| Edit["설명 편집 (낙관적 반영)"]
  Perm -->|예| Del["삭제 (확인 다이얼로그)"]
  Edit -->|실패| Rollback["이전 값 롤백"]
  Del -->|성공| List["목록으로 이동 + 캐시 무효화"]
  View --> Nav["이전/다음 — 목록 캐시 기준 인접 이동"]
```