### PR TITLE
[Fix] X-Album-Id 가드 수정

### DIFF
--- a/apps/joka-api/src/application/middleware/actor-resolver.middleware.ts
+++ b/apps/joka-api/src/application/middleware/actor-resolver.middleware.ts
@@ -1,21 +1,41 @@
-import { ForbiddenException } from '@joka/core/src/exception';
+import {
+  ForbiddenException,
+  InvalidArgumentException,
+  UncaughtException,
+} from '@joka/core/src/exception';
 import { createMiddleware } from 'hono/factory';
 
 import Config from '../config';
 import type { CloudflareEnv } from '../model';
 
-const actorResolverMiddleware = createMiddleware<CloudflareEnv>(
-  async (c, next) => {
+type ActorResolverOptions = {
+  required: boolean;
+};
+
+const tryToThrowByOptions = (shouldThrow: boolean) => {
+  if (shouldThrow) {
+    throw new InvalidArgumentException('REQUIRED_HEADER_OMITTED', [
+      'X-Album-Id 헤더가 누락되었습니다.',
+    ]);
+  }
+};
+
+const actorResolverMiddleware = (options: ActorResolverOptions) =>
+  createMiddleware<CloudflareEnv>(async (c, next) => {
     const albumCid = c.req.header('X-Album-Id');
     if (!albumCid) {
+      tryToThrowByOptions(options.required);
+
       await next();
       return;
     }
 
     const jwtPayload = c.get('jwtPayload');
     if (!jwtPayload) {
-      await next();
-      return;
+      throw new UncaughtException('FAILED_TO_RESOLVE_TOKEN_PAYLOAD', [
+        '토큰 페이로드를 조회하는 데에 실패했습니다.',
+        '관리자에게 문의하세요.',
+      ]);
     }
 
     const user = await Config.authService.findUserOrNull(jwtPayload.sub);
@@ -36,7 +56,6 @@ const actorResolverMiddleware = createMiddleware<CloudflareEnv>(
     c.set('actor', actor);
 
     await next();
-  },
-);
+  });
 
 export default actorResolverMiddleware;

--- a/apps/joka-api/src/application/middleware/actor-resolver.middleware.ts
+++ b/apps/joka-api/src/application/middleware/actor-resolver.middleware.ts
@@ -8,26 +8,13 @@ import { createMiddleware } from 'hono/factory';
 import Config from '../config';
 import type { CloudflareEnv } from '../model';
 
-type ActorResolverOptions = {
-  required: boolean;
-};
-
-const tryToThrowByOptions = (shouldThrow: boolean) => {
-  if (shouldThrow) {
-    throw new InvalidArgumentException('REQUIRED_HEADER_OMITTED', [
-      'X-Album-Id 헤더가 누락되었습니다.',
-    ]);
-  }
-};
-
-const actorResolverMiddleware = (options: ActorResolverOptions) =>
-  createMiddleware<CloudflareEnv>(async (c, next) => {
+const actorResolverMiddleware = createMiddleware<CloudflareEnv>(
+  async (c, next) => {
     const albumCid = c.req.header('X-Album-Id');
     if (!albumCid) {
-      tryToThrowByOptions(options.required);
-
-      await next();
-      return;
+      throw new InvalidArgumentException('REQUIRED_HEADER_OMITTED', [
+        'X-Album-Id 헤더가 누락되었습니다.',
+      ]);
     }
 
     const jwtPayload = c.get('jwtPayload');
@@ -56,6 +43,7 @@ const actorResolverMiddleware = (options: ActorResolverOptions) =>
     c.set('actor', actor);
 
     await next();
-  });
+  },
+);
 
 export default actorResolverMiddleware;

--- a/apps/joka-api/src/index.ts
+++ b/apps/joka-api/src/index.ts
@@ -18,8 +18,7 @@ app.onError(errorHandler);
 app.use('*', hyperdrive);
 app.use('*', objectStorage);
 app.use('*', auth);
-app.use('/v1/media/*', actorResolver({ required: true }));
-app.use('/v1/me/*', actorResolver({ required: false }));
+app.use('/v1/media/*', actorResolver);
 
 app.route('/', authController);
 app.route('/', me);

--- a/apps/joka-api/src/index.ts
+++ b/apps/joka-api/src/index.ts
@@ -18,7 +18,8 @@ app.onError(errorHandler);
 app.use('*', hyperdrive);
 app.use('*', objectStorage);
 app.use('*', auth);
-app.use('*', actorResolver);
+app.use('/v1/media/*', actorResolver({ required: true }));
+app.use('/v1/me/*', actorResolver({ required: false }));
 
 app.route('/', authController);
 app.route('/', me);

--- a/apps/joka-api/src/infrastructure/web/v1/albums.controller.ts
+++ b/apps/joka-api/src/infrastructure/web/v1/albums.controller.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedException } from '@joka/core/src/exception';
+import { ForbiddenException } from '@joka/core/src/exception';
 import { Hono } from 'hono';
 
 import Config from '../../../application/config';
@@ -11,9 +11,7 @@ albums.get('/', async (c) => {
 
   const user = await Config.authService.findUserOrNull(jwtPayload.sub);
   if (!user) {
-    throw new UnauthorizedException('INVALID_TOKEN', [
-      '유효하지 않은 인증 토큰입니다.',
-    ]);
+    throw new ForbiddenException('FORBIDDEN', ['존재하지 않는 사용자입니다.']);
   }
 
   const sizeParam = c.req.query('size');
@@ -38,6 +36,7 @@ albums.get('/', async (c) => {
       items: result.items.map((actor) => ({
         id: actor.album.cid,
         name: actor.album.name,
+        role: actor.role,
       })),
       pagination: result.pagination,
     },

--- a/apps/joka-api/src/infrastructure/web/v1/me.controller.ts
+++ b/apps/joka-api/src/infrastructure/web/v1/me.controller.ts
@@ -6,13 +6,11 @@ const me = new Hono<CloudflareEnv>().basePath('/v1/me');
 
 me.get('/', (c) => {
   const payload = c.get('jwtPayload');
-  const actor = c.get('actor');
 
   return c.json({
     id: payload.sub,
     name: payload.name,
     email: payload.email,
-    role: actor?.role ?? null,
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-storybook": "^10.3.6",
     "husky": "^9.1.7",
     "jest": "^30.2.0",
     "lint-staged": "^16.2.7",

--- a/packages/lib-openapi/docs/api-v1.yml
+++ b/packages/lib-openapi/docs/api-v1.yml
@@ -601,13 +601,10 @@ components:
                 description: 이메일 주소
                 format: email
                 minLength: 1
-              role:
-                $ref: '#/components/schemas/Role'
             required:
               - id
               - name
               - email
-              - role
     Error:
       description: 요청 처리 실패 응답
       content:
@@ -859,6 +856,9 @@ components:
         name:
           type: string
           description: 이름
+        role:
+          $ref: '#/components/schemas/Role'
       required:
         - id
         - name
+        - role

--- a/packages/lib-openapi/src/generated/api-v1.d.ts
+++ b/packages/lib-openapi/src/generated/api-v1.d.ts
@@ -354,6 +354,7 @@ export interface components {
       id: string;
       /** @description 이름 */
       name: string;
+      role: components['schemas']['Role'];
     };
   };
   responses: {
@@ -484,7 +485,6 @@ export interface components {
            * @description 이메일 주소
            */
           email: string;
-          role: components['schemas']['Role'];
         };
       };
     };

--- a/packages/lib-openapi/src/generated/type/types.gen.ts
+++ b/packages/lib-openapi/src/generated/type/types.gen.ts
@@ -197,6 +197,7 @@ export type Album = {
    * 이름
    */
   name: string;
+  role: Role;
 };
 
 /**
@@ -917,7 +918,6 @@ export type GetMyInfoResponses = {
      * 이메일 주소
      */
     email: string;
-    role: Role;
   };
 };
 

--- a/packages/lib-openapi/src/generated/type/zod.gen.ts
+++ b/packages/lib-openapi/src/generated/type/zod.gen.ts
@@ -109,6 +109,7 @@ export const zError = z.object({
 export const zAlbum = z.object({
   id: z.string(),
   name: z.string(),
+  role: zRole,
 });
 
 /**
@@ -384,5 +385,4 @@ export const zGetMyInfoResponse = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
   email: z.email().min(1),
-  role: zRole,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.5
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.0)
+      eslint-plugin-storybook:
+        specifier: ^10.3.6
+        version: 10.3.6(eslint@9.39.2(jiti@2.6.1))(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       husky:
         specifier: ^9.1.7
         version: 9.1.7


### PR DESCRIPTION
## 📌 관련 이슈

* #65 

---

## 🧹 작업 내용

* X-Album-Id가 없는 경우, 호출 경로에 따라 분기를 적용
* role 정보는 me API가 아닌 albums API에서 반환하도록 개선

---

## 🛠️ 테스트 (선택)

* [ ] 단위 테스트 통과
* [ ] 수동 테스트 완료
* [x] 기존 기능 영향 없음 확인

---

## 🔍 고민 / 결정 사항

* 현재 흐름에서, `[GET] /albums`를 호출할 때에는 권한이 있었는데 후속 API를 호출할 때에는 권한이 없어진 경우 무조건 403이 뜨게 됩니다. 근데 큰 문제는 아닐 것 같아서, 일단 공유만 드립니다!

---

## 💬 참고 사항

* ~~의도된 호출 흐름은 `[GET] /albums` -> `[GET] /me` 였는데, 생각해보니 내 정보를 조회하는 `me` API가 권한을 내려주면 안 될 것처럼 보이네요. `me`는 앨범 종속적이지 않은 '나'의 정보만 내려주고, 권한 조회는 별도 API로 처리했어야 할 것 같습니다. 이 부분은 전체 앱 개발 끝난 후 고도화 과정에서 적용하려고 해요!~~ 요 부분 반영했습니다! 아마 FE 로직이 깨질 수 있는데, BE 설계 의도는 최초 로그인시 `[GET] /me` -> `[GET] /albums` 호출이고, 앨범 목록에 각 앨범 별 접근 권한이 함께 반환된다는 점이 핵심입니다!