### PR TITLE
[Chore] Chromatic 트리거를 UI 변경에만 한정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,18 +5,18 @@ on:
     branches:
       - main
     paths:
-      - 'apps/web/src/**'
+      - 'apps/web/src/**/ui/**'
+      - 'apps/web/src/**/*.stories.*'
+      - 'apps/web/src/app/styles/**'
       - 'apps/web/.storybook/**'
-      - 'apps/web/package.json'
-      - 'pnpm-lock.yaml'
       - '.github/workflows/chromatic.yml'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - 'apps/web/src/**'
+      - 'apps/web/src/**/ui/**'
+      - 'apps/web/src/**/*.stories.*'
+      - 'apps/web/src/app/styles/**'
       - 'apps/web/.storybook/**'
-      - 'apps/web/package.json'
-      - 'pnpm-lock.yaml'
       - '.github/workflows/chromatic.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## 📌 관련 이슈

* #76 

  ---

## 🧹 작업 내용

* Chromatic 워크플로우 트리거 paths를 UI 변경에만 한정
* 루트 `pnpm-lock.yaml` 제거 
    * 모노레포 단일 락파일이라 백엔드·인프라 의존성 변경에도 헛돌던 문제 해결
* `apps/web/package.json` 제거
    * date 등 비주얼 무관 라이브러리 설치 시 미실행
* `apps/web/src/**` → `ui` 세그먼트·스토리·전역 스타일(`app/styles`)로 좁혀 내부 로직(api/model/lib) 변경 시 제외
* 기능 변경 없음 (CI 트리거 설정 정리)