### PR TITLE
[Fix] 전 기능 실연동 QA — 프론트-백엔드 연동 버그 수정 및 UX 일부 개선

### DIFF
--- a/apps/web/src/app/providers/auth-guard.tsx
+++ b/apps/web/src/app/providers/auth-guard.tsx
@@ -30,7 +30,6 @@ export function AuthGuard() {
 
   const setUser = useAuthStore((s) => s.setUser);
   const status = useAuthStore((s) => s.status);
-  const user = useAuthStore((s) => s.user);
 
   const setAlbum = useAlbumStore((s) => s.setCurrent);
   const clearAlbum = useAlbumStore((s) => s.clear);
@@ -82,10 +81,19 @@ export function AuthGuard() {
     return <Navigate to="/photos" replace />;
   }
 
+  const isEditorRoute = isEditorOnly(location.pathname);
+  const isAlbumRolePending = !currentAlbum && !albumsQuery.isError;
+  const shouldDeferUploadGuard =
+    status === 'authenticated' && isEditorRoute && isAlbumRolePending;
+
+  if (shouldDeferUploadGuard) {
+    return <GuardFallback />;
+  }
+
   const lacksUploadPermission =
     status === 'authenticated' &&
-    isEditorOnly(location.pathname) &&
-    !canUpload(user?.role);
+    isEditorRoute &&
+    !canUpload(currentAlbum?.role);
   if (lacksUploadPermission) {
     return <Navigate to="/photos" replace />;
   }

--- a/apps/web/src/app/providers/auth-guard.tsx
+++ b/apps/web/src/app/providers/auth-guard.tsx
@@ -40,7 +40,8 @@ export function AuthGuard() {
     bootstrapAccessToken();
   }, []);
 
-  const meQuery = useMe();
+  // unauthenticated 상태에서 /me 재요청을 막아 로그아웃이 되살아나지 않게 한다
+  const meQuery = useMe({ enabled: status !== 'unauthenticated' });
 
   useEffect(() => {
     if (meQuery.isSuccess) {

--- a/apps/web/src/app/providers/query-client.tsx
+++ b/apps/web/src/app/providers/query-client.tsx
@@ -2,8 +2,22 @@ import { QueryCache, QueryClient } from '@tanstack/react-query';
 
 import { MAX_RETRY_COUNT } from './constants';
 
+import { ApiError } from '@/shared/api/error';
 import { recordNetworkRetryExceeded } from '@/shared/lib/business-ux-logging';
 import { log } from '@/shared/lib/logger';
+
+const RETRYABLE_CLIENT_ERRORS = new Set([408, 429]); // 타임아웃, 레이트리밋
+
+// 4xx는 재요청해도 결과가 같다 → 재시도 안 함(408·429만 일시적이라 예외)
+function isRetryable(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    const { status } = error;
+    if (status >= 400 && status < 500) {
+      return RETRYABLE_CLIENT_ERRORS.has(status);
+    }
+  }
+  return true; // 5xx·네트워크 등은 재시도
+}
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -22,7 +36,9 @@ export const queryClient = new QueryClient({
   }),
   defaultOptions: {
     queries: {
-      retry: (failureCount) => {
+      retry: (failureCount, error) => {
+        if (!isRetryable(error)) return false;
+
         if (failureCount === MAX_RETRY_COUNT) {
           recordNetworkRetryExceeded({
             retryCount: failureCount,

--- a/apps/web/src/app/providers/route-error-fallback.tsx
+++ b/apps/web/src/app/providers/route-error-fallback.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import {
   isRouteErrorResponse,
   useNavigate,
-  useRevalidator,
   useRouteError,
 } from 'react-router-dom';
 
@@ -24,7 +23,6 @@ function exitLabel(backTo: string): string {
 export function RouteErrorFallback({ backTo = '/' }: RouteErrorFallbackProps) {
   const error = useRouteError();
   const navigate = useNavigate();
-  const revalidator = useRevalidator();
   const redirecting = useAuthErrorRedirect(error);
 
   useEffect(() => {
@@ -43,8 +41,6 @@ export function RouteErrorFallback({ backTo = '/' }: RouteErrorFallbackProps) {
   // 401/403은 로그인으로 리다이렉트 중 → 풀백 깜빡임 방지로 렌더 생략.
   if (redirecting) return null;
 
-  const isRevalidating = revalidator.state === 'loading';
-
   return (
     <ErrorState
       fill="screen"
@@ -52,8 +48,7 @@ export function RouteErrorFallback({ backTo = '/' }: RouteErrorFallbackProps) {
       description={errorFallbackMessage(error)}
       retry={{
         label: '다시 시도',
-        pending: isRevalidating,
-        onClick: () => revalidator.revalidate(),
+        onClick: () => window.location.reload(),
       }}
       secondary={{
         label: exitLabel(backTo),

--- a/apps/web/src/entities/album/index.ts
+++ b/apps/web/src/entities/album/index.ts
@@ -3,3 +3,4 @@ export { useAlbums } from './api/queries';
 
 export type { Album } from './model/types';
 export { useAlbumStore } from './model/store';
+export { useCurrentAlbumRole } from './model/selectors';

--- a/apps/web/src/entities/album/model/selectors.ts
+++ b/apps/web/src/entities/album/model/selectors.ts
@@ -1,0 +1,3 @@
+import { useAlbumStore } from './store';
+
+export const useCurrentAlbumRole = () => useAlbumStore((s) => s.current?.role);

--- a/apps/web/src/entities/album/model/types.ts
+++ b/apps/web/src/entities/album/model/types.ts
@@ -1,4 +1,7 @@
+import type { UserRole } from '@/entities/user';
+
 export interface Album {
   id: string;
   name: string;
+  role: UserRole;
 }

--- a/apps/web/src/entities/user/model/types.ts
+++ b/apps/web/src/entities/user/model/types.ts
@@ -4,5 +4,4 @@ export interface User {
   id: string;
   name: string;
   email: string;
-  role: UserRole;
 }

--- a/apps/web/src/features/auth/api/mutations.ts
+++ b/apps/web/src/features/auth/api/mutations.ts
@@ -1,19 +1,15 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { useAlbumStore } from '@/entities/album';
 import { http } from '@/shared/api';
 
-import { authKeys } from './keys';
-
 export function useLogoutMutation() {
-  const queryClient = useQueryClient();
   const clearAlbum = useAlbumStore((s) => s.clear);
 
   return useMutation({
     mutationFn: () => http.post<void>('/v1/auth/logout'),
     meta: { operationId: 'auth_logout' },
     onSuccess: () => {
-      queryClient.removeQueries({ queryKey: authKeys.all });
       clearAlbum();
     },
   });

--- a/apps/web/src/features/auth/api/queries.ts
+++ b/apps/web/src/features/auth/api/queries.ts
@@ -1,14 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { authKeys } from './keys';
+
 import type { User } from '@/entities/user';
 import { http } from '@/shared/api';
 
-import { authKeys } from './keys';
-
-export function useMe() {
+export function useMe(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: authKeys.me(),
     queryFn: () => http.get<User>('/v1/me'),
+    enabled: options?.enabled ?? true,
     staleTime: 30 * 60 * 1000,
     retry: false,
     throwOnError: false,

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -9,7 +9,6 @@ export { useAuthStore } from './model/store';
 export {
   useAuthUser,
   useAuthStatus,
-  useAuthRole,
   useIsAuthenticated,
 } from './model/selectors';
 

--- a/apps/web/src/features/auth/model/selectors.ts
+++ b/apps/web/src/features/auth/model/selectors.ts
@@ -2,6 +2,5 @@ import { useAuthStore } from './store';
 
 export const useAuthUser = () => useAuthStore((s) => s.user);
 export const useAuthStatus = () => useAuthStore((s) => s.status);
-export const useAuthRole = () => useAuthStore((s) => s.user?.role);
 export const useIsAuthenticated = () =>
   useAuthStore((s) => s.status === 'authenticated');

--- a/apps/web/src/features/photo-download/lib/downloader.ts
+++ b/apps/web/src/features/photo-download/lib/downloader.ts
@@ -37,12 +37,14 @@ export async function downloadOne(target: DownloadTarget): Promise<void> {
 
     setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
   } catch (err) {
-    if (err instanceof TypeError) {
-      triggerAnchor(target.url, target.filename);
-      return;
-    }
+    if (err instanceof ApiError) throw err;
 
-    throw err;
+    // cross-origin이라 a[download] 무시됨 → URL 이동 대신 에러 처리
+    throw new ApiError({
+      status: 0,
+      code: 'NETWORK',
+      message: '다운로드에 실패했어요. 네트워크를 확인해 주세요.',
+    });
   }
 }
 

--- a/apps/web/src/features/photo-download/lib/downloader.ts
+++ b/apps/web/src/features/photo-download/lib/downloader.ts
@@ -8,6 +8,7 @@ export interface DownloadTarget {
 export interface DownloadManyResult {
   ok: number;
   failed: number;
+  errors: unknown[]; // 실패한 항목들의 에러(사유별 메시지 분기에 사용)
 }
 
 const BATCH_DELAY_MS = 300; // 연속 다운로드를 브라우저가 차단하지 않도록 항목 간 간격
@@ -59,6 +60,7 @@ export async function downloadMany(
 
   let ok = 0;
   let failed = 0;
+  const errors: unknown[] = [];
 
   for (const target of targets) {
     try {
@@ -66,11 +68,12 @@ export async function downloadMany(
       ok += 1;
     } catch (err) {
       failed += 1;
+      errors.push(err);
       options?.onError?.(target, err);
     }
 
     await new Promise((resolve) => setTimeout(resolve, delay));
   }
 
-  return { ok, failed };
+  return { ok, failed, errors };
 }

--- a/apps/web/src/features/photo-download/ui/download-button.tsx
+++ b/apps/web/src/features/photo-download/ui/download-button.tsx
@@ -1,15 +1,15 @@
 import { Download } from 'lucide-react';
 import { useState } from 'react';
 
+import { downloadOne } from '../lib/downloader';
+import { downloadFilename } from '../lib/filename';
+
+import { useCurrentAlbumRole } from '@/entities/album';
 import type { Photo } from '@/entities/photo';
-import { useAuthRole } from '@/features/auth';
 import { ApiError } from '@/shared/api/error';
 import { recordForbidden } from '@/shared/lib/business-ux-logging';
 import { Button, type ButtonProps } from '@/shared/ui/button';
 import { toast } from '@/shared/ui/toast';
-
-import { downloadOne } from '../lib/downloader';
-import { downloadFilename } from '../lib/filename';
 
 interface DownloadButtonProps {
   photo: Photo;
@@ -23,7 +23,7 @@ export function DownloadButton({
   variant = 'secondary',
   size = 'icon',
 }: DownloadButtonProps) {
-  const role = useAuthRole();
+  const role = useCurrentAlbumRole();
   const [busy, setBusy] = useState(false);
 
   const handleClick = async (e: React.MouseEvent) => {
@@ -38,7 +38,10 @@ export function DownloadButton({
       });
     } catch (err) {
       if (err instanceof ApiError && err.status === 403) {
-        recordForbidden({ userRole: role ?? 'unknown', operationId: 'downloadMedia' });
+        recordForbidden({
+          userRole: role ?? 'unknown',
+          operationId: 'downloadMedia',
+        });
         toast.error('다운로드 권한이 없거나 링크가 만료됐어요.');
       } else {
         toast.error('다운로드에 실패했어요.');

--- a/apps/web/src/features/photo-upload/api/mutations.test.ts
+++ b/apps/web/src/features/photo-upload/api/mutations.test.ts
@@ -218,7 +218,7 @@ describe('uploadSinglePhoto', () => {
     expect(mocks.httpPost).toHaveBeenNthCalledWith(
       3,
       '/v1/media/media-1/contents',
-      { url: 'media/media-1/original' },
+      { url: 'https://s3/url' },
       undefined,
     );
     expect(mocks.httpPost).toHaveBeenNthCalledWith(
@@ -233,6 +233,35 @@ describe('uploadSinglePhoto', () => {
       expect.objectContaining({ onProgress: expect.any(Function) }),
     );
     expect(mocks.onUploadUrlsRequest).toHaveBeenCalledWith('DRAFT');
+  });
+
+  test('contents에는 presigned URL의 쿼리스트링을 제거한 객체 URL을 보낸다', async () => {
+    mocks.httpPost
+      .mockResolvedValueOnce({ id: 'media-1', state: 'DRAFT' })
+      .mockResolvedValueOnce({
+        url: 'https://s3/bucket/media/media-1/original?X-Amz-Signature=abc&X-Amz-Expires=180',
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+    mocks.putToS3.mockResolvedValueOnce(undefined);
+
+    await uploadSinglePhoto(makeItem(), {
+      onStep: vi.fn(),
+      onProgress: vi.fn(),
+    });
+
+    // PUT은 쿼리 포함 presigned URL로, contents는 쿼리 제거한 객체 URL로
+    expect(mocks.putToS3).toHaveBeenCalledWith(
+      'https://s3/bucket/media/media-1/original?X-Amz-Signature=abc&X-Amz-Expires=180',
+      expect.any(File),
+      expect.anything(),
+    );
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      3,
+      '/v1/media/media-1/contents',
+      { url: 'https://s3/bucket/media/media-1/original' },
+      undefined,
+    );
   });
 
   test('signal 전달 시 각 http.post 와 putToS3 에 그대로 전파', async () => {

--- a/apps/web/src/features/photo-upload/api/mutations.ts
+++ b/apps/web/src/features/photo-upload/api/mutations.ts
@@ -3,7 +3,6 @@ import { UploadQueueItem, UploadStep } from '../model/types';
 
 import { http } from '@/shared/api';
 import type { HttpInit } from '@/shared/api/client';
-
 import { createMediaUploadFlow } from '@/shared/lib/media-upload-logging';
 
 interface CreateMediaResponse {
@@ -48,7 +47,9 @@ export async function uploadSinglePhoto(
     await putToS3(url, item.file, putOptions);
 
     onStep('contents');
-    await registerContents(mediaId, reqOptions);
+
+    const contentUrl = url.split('?')[0];
+    await registerContents(mediaId, contentUrl, reqOptions);
 
     onStep('confirm');
     await confirmMedia(mediaId, flow, reqOptions);
@@ -87,15 +88,10 @@ async function getUploadUrl(
 
 async function registerContents(
   mediaId: string,
+  url: string,
   reqOptions?: HttpInit,
 ): Promise<void> {
-  await http.post(
-    `/v1/media/${mediaId}/contents`,
-    {
-      url: `media/${mediaId}/original`,
-    },
-    reqOptions,
-  );
+  await http.post(`/v1/media/${mediaId}/contents`, { url }, reqOptions);
 }
 
 async function confirmMedia(

--- a/apps/web/src/features/photo-upload/model/runner.ts
+++ b/apps/web/src/features/photo-upload/model/runner.ts
@@ -21,10 +21,14 @@ function describeError(err: unknown): string {
   return '업로드에 실패했어요.';
 }
 
-function handleSuccess(id: string, mediaId: string): void {
+function handleSuccess(
+  id: string,
+  mediaId: string,
+  syncedDescription: string,
+): void {
   const store = useUploadQueueStore.getState();
 
-  store.setStatus(id, { status: 'success', mediaId });
+  store.setStatus(id, { status: 'success', mediaId, syncedDescription });
   store.setProgress(id, 100);
 }
 
@@ -59,6 +63,8 @@ export function useUploadRunner() {
       const controller = new AbortController();
       abortersRef.current.set(item.id, controller);
 
+      const sentDescription = item.description.trim() || item.file.name;
+
       try {
         const mediaId = await uploadSinglePhoto(item, {
           signal: controller.signal,
@@ -68,7 +74,7 @@ export function useUploadRunner() {
             useUploadQueueStore.getState().setProgress(item.id, pct),
         });
 
-        handleSuccess(item.id, mediaId);
+        handleSuccess(item.id, mediaId, sentDescription);
         return true;
       } catch (err) {
         handleFailure(item.id, err);

--- a/apps/web/src/features/photo-upload/model/runner.ts
+++ b/apps/web/src/features/photo-upload/model/runner.ts
@@ -1,13 +1,13 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef } from 'react';
 
+import { useUploadQueueStore } from './store';
+import type { UploadQueueItem } from './types';
+import { uploadSinglePhoto } from '../api/mutations';
+
 import { MAX_RETRY_COUNT } from '@/app/providers/constants';
 import { photoKeys } from '@/entities/photo/api/keys';
 import { recordNetworkRetryExceeded } from '@/shared/lib/business-ux-logging';
-
-import { uploadSinglePhoto } from '../api/mutations';
-import { useUploadQueueStore } from './store';
-import type { UploadQueueItem } from './types';
 
 function isAbortError(err: unknown): boolean {
   return err instanceof DOMException && err.name === 'AbortError';
@@ -89,6 +89,7 @@ export function useUploadRunner() {
 
       state.setRunning(true);
       state.setStatus(next.id, { status: 'uploading', step: 'create' });
+      state.setProgress(next.id, 0);
 
       const success = await runUpload(next);
       useUploadQueueStore.getState().setRunning(false);

--- a/apps/web/src/features/photo-upload/model/runner.ts
+++ b/apps/web/src/features/photo-upload/model/runner.ts
@@ -122,5 +122,17 @@ export function useUploadRunner() {
     useUploadQueueStore.getState().remove(id);
   }, []);
 
-  return { cancel };
+  const cancelAll = useCallback(() => {
+    abortersRef.current.forEach((controller) => controller.abort());
+    abortersRef.current.clear();
+
+    const store = useUploadQueueStore.getState();
+    store.items.forEach((item) => {
+      if (item.status === 'pending' || item.status === 'uploading') {
+        store.setStatus(item.id, { status: 'canceled', step: undefined });
+      }
+    });
+  }, []);
+
+  return { cancel, cancelAll };
 }

--- a/apps/web/src/features/photo-upload/model/runner.ts
+++ b/apps/web/src/features/photo-upload/model/runner.ts
@@ -77,7 +77,9 @@ export function useUploadRunner() {
         handleSuccess(item.id, mediaId, sentDescription);
         return true;
       } catch (err) {
-        handleFailure(item.id, err);
+        if (!controller.signal.aborted) {
+          handleFailure(item.id, err);
+        }
         return false;
       } finally {
         abortersRef.current.delete(item.id);

--- a/apps/web/src/features/photo-upload/model/store.test.ts
+++ b/apps/web/src/features/photo-upload/model/store.test.ts
@@ -11,13 +11,15 @@ describe('useUploadQueueStore', () => {
     useUploadQueueStore.getState().reset();
   });
 
-  test('enqueue 는 파일명을 description 기본값으로 채운다', () => {
-    useUploadQueueStore.getState().enqueue([makeFile('a.jpg'), makeFile('b.png')]);
+  test('enqueue 는 description 을 빈 값으로 둔다(설명은 선택사항)', () => {
+    useUploadQueueStore
+      .getState()
+      .enqueue([makeFile('a.jpg'), makeFile('b.png')]);
     const items = useUploadQueueStore.getState().items;
 
     expect(items).toHaveLength(2);
-    expect(items[0].description).toBe('a');
-    expect(items[1].description).toBe('b');
+    expect(items[0].description).toBe('');
+    expect(items[1].description).toBe('');
     expect(items.every((it) => it.status === 'pending')).toBe(true);
     expect(items.every((it) => it.progress === 0)).toBe(true);
     expect(items.every((it) => it.retryCount === 0)).toBe(true);
@@ -47,11 +49,13 @@ describe('useUploadQueueStore', () => {
     const item = useUploadQueueStore.getState().items[0];
     expect(item.status).toBe('uploading');
     expect(item.step).toBe('put');
-    expect(item.description).toBe('a');
+    expect(item.description).toBe('');
   });
 
   test('remove 후 길이 감소', () => {
-    useUploadQueueStore.getState().enqueue([makeFile('a.jpg'), makeFile('b.jpg')]);
+    useUploadQueueStore
+      .getState()
+      .enqueue([makeFile('a.jpg'), makeFile('b.jpg')]);
     const firstId = useUploadQueueStore.getState().items[0].id;
 
     useUploadQueueStore.getState().remove(firstId);

--- a/apps/web/src/features/photo-upload/model/store.ts
+++ b/apps/web/src/features/photo-upload/model/store.ts
@@ -1,7 +1,6 @@
 import { nanoid } from 'nanoid';
 import { create } from 'zustand';
 
-import { stripExtension } from '../lib/filename';
 import type { UploadQueueItem } from './types';
 
 interface StatusPatch {
@@ -9,6 +8,7 @@ interface StatusPatch {
   step?: UploadQueueItem['step'] | undefined;
   errorMessage?: string | undefined;
   mediaId?: string | undefined;
+  syncedDescription?: string | undefined;
 }
 
 interface UploadQueueState {
@@ -31,7 +31,7 @@ function makeItem(file: File): UploadQueueItem {
   return {
     id: nanoid(),
     file,
-    description: stripExtension(file.name),
+    description: '',
     status: 'pending',
     progress: 0,
     retryCount: 0,

--- a/apps/web/src/features/photo-upload/model/types.ts
+++ b/apps/web/src/features/photo-upload/model/types.ts
@@ -16,4 +16,5 @@ export interface UploadQueueItem {
   mediaId?: string | undefined;
   errorMessage?: string | undefined;
   retryCount: number;
+  syncedDescription?: string | undefined;
 }

--- a/apps/web/src/features/photo-upload/model/types.ts
+++ b/apps/web/src/features/photo-upload/model/types.ts
@@ -1,4 +1,9 @@
-export type UploadStatus = 'pending' | 'uploading' | 'success' | 'error';
+export type UploadStatus =
+  | 'pending'
+  | 'uploading'
+  | 'success'
+  | 'error'
+  | 'canceled';
 export type UploadStep = 'create' | 'urls' | 'put' | 'contents' | 'confirm';
 
 export interface UploadQueueItem {

--- a/apps/web/src/features/photo-upload/ui/upload-item.tsx
+++ b/apps/web/src/features/photo-upload/ui/upload-item.tsx
@@ -1,4 +1,4 @@
-import { ImageIcon, RefreshCw, X } from 'lucide-react';
+import { Check, ImageIcon, RefreshCw, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { useUploadQueueStore } from '../model/store';
@@ -29,6 +29,7 @@ export function UploadItem({
   const isUploading = item.status === 'uploading';
   const isError = item.status === 'error';
   const isUploaded = item.status === 'success';
+  const isWaiting = item.status === 'pending' || item.status === 'canceled';
 
   function retry() {
     setStatus(item.id, {
@@ -65,7 +66,10 @@ export function UploadItem({
               src={previewUrl}
               alt=""
               onError={() => setImgError(true)}
-              className="size-full object-cover"
+              className={cn(
+                'size-full object-cover',
+                isWaiting && 'opacity-40',
+              )}
             />
           ) : (
             <span className="flex size-full items-center justify-center text-muted-foreground">
@@ -92,6 +96,23 @@ export function UploadItem({
               <RefreshCw className="size-5" />
             </span>
           </button>
+        )}
+
+        {/* 업로드 완료 표시 */}
+        {isUploaded && (
+          <span
+            aria-hidden
+            className="absolute bottom-1.5 right-1.5 z-10 flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground shadow"
+          >
+            <Check className="size-3" />
+          </span>
+        )}
+
+        {/* 대기/취소: 아직 업로드되지 않음 */}
+        {isWaiting && (
+          <span className="absolute bottom-1.5 left-1.5 z-10 rounded-full bg-black/55 px-1.5 py-0.5 text-[10px] font-medium text-white">
+            {item.status === 'canceled' ? '취소됨' : '대기'}
+          </span>
         )}
 
         {/* 우상단 제거/취소 X — 이미 업로드된 사진은 숨김 */}

--- a/apps/web/src/features/photo-upload/ui/upload-item.tsx
+++ b/apps/web/src/features/photo-upload/ui/upload-item.tsx
@@ -27,9 +27,9 @@ export function UploadItem({
   useEffect(() => () => URL.revokeObjectURL(previewUrl), [previewUrl]);
 
   const isUploading = item.status === 'uploading';
-  const isError = item.status === 'error';
   const isUploaded = item.status === 'success';
   const isWaiting = item.status === 'pending' || item.status === 'canceled';
+  const isRetryable = item.status === 'error' || item.status === 'canceled';
 
   function retry() {
     setStatus(item.id, {
@@ -84,12 +84,12 @@ export function UploadItem({
           )}
         </button>
 
-        {/* 실패: 이미지 위 원형 재시도 (타일 버튼과 형제 → 중첩 버튼 방지) */}
-        {isError && (
+        {/* 실패·취소: 탭하면 다시 업로드 (타일 버튼과 형제 → 중첩 버튼 방지) */}
+        {isRetryable && (
           <button
             type="button"
             onClick={retry}
-            aria-label="재시도"
+            aria-label={item.status === 'canceled' ? '다시 올리기' : '재시도'}
             className="absolute inset-0 z-10 flex items-center justify-center rounded-[14px] bg-black/60"
           >
             <span className="flex size-10 items-center justify-center rounded-full bg-white/90 text-neutral-600">
@@ -108,10 +108,10 @@ export function UploadItem({
           </span>
         )}
 
-        {/* 대기/취소: 아직 업로드되지 않음 */}
-        {isWaiting && (
+        {/* 대기: 아직 업로드 안 됨 (취소는 위 재시도 오버레이로 표시) */}
+        {item.status === 'pending' && (
           <span className="absolute bottom-1.5 left-1.5 z-10 rounded-full bg-black/55 px-1.5 py-0.5 text-[10px] font-medium text-white">
-            {item.status === 'canceled' ? '취소됨' : '대기'}
+            대기
           </span>
         )}
 

--- a/apps/web/src/features/photo-upload/ui/upload-item.tsx
+++ b/apps/web/src/features/photo-upload/ui/upload-item.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
 import { ImageIcon, RefreshCw, X } from 'lucide-react';
-
-import { cn } from '@/shared/lib/utils/cn';
+import { useEffect, useState } from 'react';
 
 import { useUploadQueueStore } from '../model/store';
 import type { UploadQueueItem } from '../model/types';
+
+import { cn } from '@/shared/lib/utils/cn';
 
 interface UploadItemProps {
   item: UploadQueueItem;
@@ -28,6 +28,7 @@ export function UploadItem({
 
   const isUploading = item.status === 'uploading';
   const isError = item.status === 'error';
+  const isUploaded = item.status === 'success';
 
   function retry() {
     setStatus(item.id, {
@@ -93,15 +94,17 @@ export function UploadItem({
           </button>
         )}
 
-        {/* 우상단 제거/취소 X */}
-        <button
-          type="button"
-          onClick={handleRemove}
-          aria-label={isUploading ? '취소' : '삭제'}
-          className="absolute right-2 top-2 z-20 flex size-5 items-center justify-center rounded-full bg-white/90 text-black shadow"
-        >
-          <X className="size-3" />
-        </button>
+        {/* 우상단 제거/취소 X — 이미 업로드된 사진은 숨김 */}
+        {!isUploaded && (
+          <button
+            type="button"
+            onClick={handleRemove}
+            aria-label={isUploading ? '취소' : '삭제'}
+            className="absolute right-2 top-2 z-20 flex size-5 items-center justify-center rounded-full bg-white/90 text-black shadow"
+          >
+            <X className="size-3" />
+          </button>
+        )}
       </div>
 
       <p className="truncate text-xs text-muted-foreground">{item.file.name}</p>

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { ErrorBoundary } from '@/app/providers/error-boundary';
-import { useAlbumStore } from '@/entities/album';
+import { useAlbumStore, useCurrentAlbumRole } from '@/entities/album';
 import {
   PhotoMeta,
   selectPhotos,
@@ -12,17 +12,14 @@ import {
   usePhotosInfinite,
   type Photo,
 } from '@/entities/photo';
-
 import {
   canWriteMeta,
   useAuthErrorRedirect,
-  useAuthRole,
   useAuthUser,
 } from '@/features/auth';
 import { DownloadButton } from '@/features/photo-download';
 import { EditMetaForm } from '@/features/photo-edit-meta';
 import { usePhotoSortStore } from '@/features/photo-sort';
-
 import { ApiError } from '@/shared/api/error';
 import { recordForbidden } from '@/shared/lib/business-ux-logging';
 import { errorFallbackMessage } from '@/shared/lib/error-fallback';
@@ -73,6 +70,7 @@ export function PhotoDetailPage() {
 
   const albumId = useAlbumStore((s) => s.current?.id);
   const user = useAuthUser();
+  const role = useCurrentAlbumRole();
 
   const query = usePhotoDetail(id, { enabled: !!albumId && !!id });
   const photo = query.data;
@@ -82,7 +80,7 @@ export function PhotoDetailPage() {
     return <DetailSkeleton />;
   }
 
-  const canWrite = canWriteMeta(user?.role, photo.createdBy.id, user?.id);
+  const canWrite = canWriteMeta(role, photo.createdBy.id, user?.id);
 
   return (
     <section className="mx-auto max-w-2xl space-y-6 p-6">
@@ -185,7 +183,7 @@ function NavArrow({
 
 function DeletePhotoButton({ photo }: { photo: Photo }) {
   const navigate = useNavigate();
-  const role = useAuthRole();
+  const role = useCurrentAlbumRole();
   const [open, setOpen] = useState(false);
   const mutation = useDeletePhotoMutation();
 

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -35,6 +35,7 @@ import { SelectionBar } from '@/widgets/selection-bar';
 interface BatchDownloadResult {
   ok: number;
   failed: number;
+  errors: unknown[];
 }
 
 function useBatchDownload(
@@ -75,6 +76,22 @@ function useBatchDownload(
   return { downloading, run };
 }
 
+function allFailMessage(errors: unknown[]): string {
+  const all403 = errors.every((e) => e instanceof ApiError && e.status === 403);
+  if (all403) {
+    return '다운로드 링크가 만료됐어요. 새로고침 후 다시 시도해 주세요.';
+  }
+
+  const allNetwork = errors.every(
+    (e) => e instanceof ApiError && e.status === 0,
+  );
+  if (allNetwork) {
+    return '네트워크 연결을 확인하고 다시 시도해 주세요.';
+  }
+
+  return '다운로드에 실패했어요. 잠시 후 다시 시도해 주세요.';
+}
+
 export function PhotoListPage() {
   const navigate = useNavigate();
   const role = useCurrentAlbumRole();
@@ -109,11 +126,15 @@ export function PhotoListPage() {
     const result = await runBatchDownload();
     if (!result) return;
 
-    const { ok, failed } = result;
-    const message = `${ok}개 다운로드 완료${failed ? `, ${failed}개 실패` : ''}`;
+    const { ok, failed, errors } = result;
 
-    if (failed) toast.warning(message);
-    else toast.success(message);
+    if (failed === 0) {
+      toast.success(`${ok}장 다운로드 완료`);
+    } else if (ok === 0) {
+      toast.error(allFailMessage(errors));
+    } else {
+      toast.warning(`${ok}장 완료 · ${failed}장 실패`);
+    }
   };
 
   return (

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -2,14 +2,14 @@ import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { ErrorBoundary } from '@/app/providers/error-boundary';
-import { useAlbumStore } from '@/entities/album';
+import { useAlbumStore, useCurrentAlbumRole } from '@/entities/album';
 import {
   PhotoCard,
   selectPhotos,
   usePhotosInfinite,
   type Photo,
 } from '@/entities/photo';
-import { canUpload, useAuthErrorRedirect, useAuthRole } from '@/features/auth';
+import { canUpload, useAuthErrorRedirect } from '@/features/auth';
 import {
   DownloadButton,
   downloadFilename,
@@ -23,14 +23,12 @@ import {
   useSelectedIds,
 } from '@/features/photo-select';
 import { SortSheet, usePhotoSortStore } from '@/features/photo-sort';
-
 import { ApiError } from '@/shared/api/error';
 import { recordForbidden } from '@/shared/lib/business-ux-logging';
 import { errorFallbackMessage } from '@/shared/lib/error-fallback';
 import { cn } from '@/shared/lib/utils/cn';
 import { ErrorState } from '@/shared/ui/error-state';
 import { toast } from '@/shared/ui/toast';
-
 import { PhotoGrid } from '@/widgets/photo-grid';
 import { SelectionBar } from '@/widgets/selection-bar';
 
@@ -79,7 +77,7 @@ function useBatchDownload(
 
 export function PhotoListPage() {
   const navigate = useNavigate();
-  const role = useAuthRole();
+  const role = useCurrentAlbumRole();
 
   const order = usePhotoSortStore((s) => s.order);
   const enabled = useSelectEnabled();

--- a/apps/web/src/pages/upload/ui/page.tsx
+++ b/apps/web/src/pages/upload/ui/page.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Check } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
+import { useUpdatePhotoMetaMutation } from '@/entities/photo';
 import {
   UploadDropzone,
   UploadItem,
@@ -16,11 +17,12 @@ export function UploadPage() {
   const items = useUploadQueueStore((s) => s.items);
   const reset = useUploadQueueStore((s) => s.reset);
   const updateDescription = useUploadQueueStore((s) => s.updateDescription);
+  const setStatus = useUploadQueueStore((s) => s.setStatus);
 
   const { cancel, cancelAll } = useUploadRunner();
+  const updateMeta = useUpdatePhotoMetaMutation();
 
   const navigate = useNavigate();
-  const hadItemsRef = useRef(false);
 
   // 딤·ESC 닫기 (업로드 중엔 무시, 중단은 "취소" 버튼으로)
   const close = useCallback(() => {
@@ -36,27 +38,31 @@ export function UploadPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const selectedItem = items.find((i) => i.id === selectedId) ?? items[0];
 
-  useEffect(() => {
-    if (items.length === 0) return;
-    hadItemsRef.current = true;
+  const inFlight = items.some(
+    (i) => i.status === 'pending' || i.status === 'uploading',
+  );
 
-    const inFlight = items.some(
-      (item) => item.status === 'pending' || item.status === 'uploading',
+  const canEditDesc = selectedItem?.status === 'success';
+
+  const selectedDesc = (selectedItem?.description ?? '').trim();
+  const selectedSynced = (selectedItem?.syncedDescription ?? '').trim();
+  const canSaveDesc =
+    !!selectedItem?.mediaId &&
+    selectedDesc.length > 0 &&
+    selectedDesc !== selectedSynced;
+  const descSaved =
+    !!selectedItem?.mediaId &&
+    selectedDesc.length > 0 &&
+    selectedDesc === selectedSynced;
+
+  const handleSaveDescription = () => {
+    if (!selectedItem?.mediaId || !canSaveDesc) return;
+    const id = selectedItem.id;
+    updateMeta.mutate(
+      { id: selectedItem.mediaId, description: selectedDesc },
+      { onSuccess: () => setStatus(id, { syncedDescription: selectedDesc }) },
     );
-    if (inFlight) return;
-
-    if (items.some((item) => item.status === 'canceled')) return;
-
-    const successCount = items.filter(
-      (item) => item.status === 'success',
-    ).length;
-    if (!hadItemsRef.current || successCount === 0) return;
-
-    toast.success(`${successCount}개 업로드 완료`);
-    hadItemsRef.current = false;
-    reset();
-    navigate('/photos');
-  }, [items, navigate, reset]);
+  };
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -115,33 +121,53 @@ export function UploadPage() {
                 ))}
               </div>
 
-              {/* 설명 */}
-              <div className="px-6">
+              {/* 설명 + 저장 (선택사항) */}
+              <div className="flex items-center gap-2 px-6">
                 <Input
                   value={selectedItem?.description ?? ''}
                   onChange={(e) =>
                     selectedItem &&
                     updateDescription(selectedItem.id, e.target.value)
                   }
+                  disabled={!canEditDesc}
                   placeholder={
-                    selectedItem
-                      ? `${selectedItem.file.name}에 남기실 말이 있으신가요?`
-                      : ''
+                    !selectedItem
+                      ? ''
+                      : canEditDesc
+                        ? `${selectedItem.file.name}에 남기실 말이 있으신가요?`
+                        : '업로드되면 설명을 남길 수 있어요'
                   }
                   maxLength={120}
-                  className="h-[45px] rounded-[14px] border-transparent bg-muted text-muted-foreground placeholder:text-muted-foreground/60"
+                  className="h-[45px] flex-1 rounded-[14px] border-transparent bg-muted text-muted-foreground placeholder:text-muted-foreground/60"
                 />
+                <Button
+                  type="button"
+                  onClick={handleSaveDescription}
+                  disabled={!canSaveDesc || updateMeta.isPending}
+                  className="h-[45px] shrink-0 gap-1 rounded-[14px] px-4"
+                >
+                  {descSaved ? (
+                    <>
+                      <Check className="size-4" />
+                      저장됨
+                    </>
+                  ) : updateMeta.isPending ? (
+                    '저장 중…'
+                  ) : (
+                    '저장'
+                  )}
+                </Button>
               </div>
 
-              {/* 액션 */}
+              {/* 액션: 업로드 중이면 취소(중단), 끝나면 완료(닫기) */}
               <div className="px-6 pb-6 pt-6">
                 <Button
                   type="button"
                   variant="secondary"
-                  onClick={cancelAll}
+                  onClick={inFlight ? cancelAll : close}
                   className="h-12 w-full rounded-[14px] text-base font-medium"
                 >
-                  취소
+                  {inFlight ? '취소' : '완료'}
                 </Button>
               </div>
             </>

--- a/apps/web/src/pages/upload/ui/page.tsx
+++ b/apps/web/src/pages/upload/ui/page.tsx
@@ -1,9 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-
-import { Button } from '@/shared/ui/button';
-import { Input } from '@/shared/ui/input';
 
 import {
   UploadDropzone,
@@ -11,18 +8,30 @@ import {
   useUploadQueueStore,
   useUploadRunner,
 } from '@/features/photo-upload';
-
 import { PhotoListPage } from '@/pages/photo-list'; // TODO: 목록 콘텐츠 widget 추출/라우터 오버레이
+import { Button } from '@/shared/ui/button';
+import { Input } from '@/shared/ui/input';
 
 export function UploadPage() {
   const items = useUploadQueueStore((s) => s.items);
   const reset = useUploadQueueStore((s) => s.reset);
   const updateDescription = useUploadQueueStore((s) => s.updateDescription);
 
-  const { cancel } = useUploadRunner();
+  const { cancel, cancelAll } = useUploadRunner();
 
   const navigate = useNavigate();
   const hadItemsRef = useRef(false);
+
+  // 딤·ESC 닫기 (업로드 중엔 무시, 중단은 "취소" 버튼으로)
+  const close = useCallback(() => {
+    const flying = useUploadQueueStore
+      .getState()
+      .items.some((i) => i.status === 'pending' || i.status === 'uploading');
+    if (flying) return;
+
+    reset();
+    navigate('/photos');
+  }, [reset, navigate]);
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const selectedItem = items.find((i) => i.id === selectedId) ?? items[0];
@@ -36,6 +45,8 @@ export function UploadPage() {
     );
     if (inFlight) return;
 
+    if (items.some((item) => item.status === 'canceled')) return;
+
     const successCount = items.filter(
       (item) => item.status === 'success',
     ).length;
@@ -47,6 +58,14 @@ export function UploadPage() {
     navigate('/photos');
   }, [items, navigate, reset]);
 
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [close]);
+
   const hasItems = items.length > 0;
 
   return (
@@ -55,8 +74,13 @@ export function UploadPage() {
       <div aria-hidden className="pointer-events-none">
         <PhotoListPage />
       </div>
-      {/* 딤 */}
-      <div aria-hidden className="fixed inset-0 z-20 bg-black/20" />
+      {/* 딤 (클릭 시 닫기) */}
+      <button
+        type="button"
+        aria-label="닫기"
+        className="fixed inset-0 z-20 bg-black/20"
+        onClick={close}
+      />
 
       {/* 바텀시트 */}
       <section className="fixed inset-x-0 bottom-0 z-30">
@@ -114,7 +138,7 @@ export function UploadPage() {
                 <Button
                   type="button"
                   variant="secondary"
-                  onClick={reset}
+                  onClick={cancelAll}
                   className="h-12 w-full rounded-[14px] text-base font-medium"
                 >
                   취소

--- a/apps/web/src/shared/ui/toast/toaster.tsx
+++ b/apps/web/src/shared/ui/toast/toaster.tsx
@@ -4,13 +4,17 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       className="toaster group"
+      position="top-center"
       toastOptions={{
+        duration: 2000,
         classNames: {
           toast:
             'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
           description: 'group-[.toast]:text-muted-foreground',
-          actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
-          cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+          actionButton:
+            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+          cancelButton:
+            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
         },
       }}
       {...props}

--- a/apps/web/src/widgets/top-bar/ui/top-bar.stories.tsx
+++ b/apps/web/src/widgets/top-bar/ui/top-bar.stories.tsx
@@ -3,10 +3,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { expect, within } from 'storybook/test';
 
+import { TopBar } from './top-bar';
+
+import { useAlbumStore } from '@/entities/album';
 import { useAuthStore } from '@/features/auth';
 import { usePhotoSelectStore } from '@/features/photo-select';
-
-import { TopBar } from './top-bar';
 
 const meta = {
   title: 'widgets/TopBar',
@@ -33,6 +34,7 @@ type Story = StoryObj<typeof meta>;
 export const LoggedOut: Story = {
   async beforeEach() {
     useAuthStore.getState().reset();
+    useAlbumStore.getState().clear();
   },
 };
 
@@ -47,9 +49,16 @@ export const EditorOnPhotoList: Story = {
       id: 'u1',
       name: '홍길동',
       email: 'user@joka.app',
+    });
+    useAlbumStore.getState().setCurrent({
+      id: 'a1',
+      name: '테스트 앨범',
       role: 'EDITOR',
     });
-    return () => useAuthStore.getState().reset();
+    return () => {
+      useAuthStore.getState().reset();
+      useAlbumStore.getState().clear();
+    };
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -76,9 +85,16 @@ export const EditorElsewhere: Story = {
       id: 'u1',
       name: '홍길동',
       email: 'user@joka.app',
+    });
+    useAlbumStore.getState().setCurrent({
+      id: 'a1',
+      name: '테스트 앨범',
       role: 'EDITOR',
     });
-    return () => useAuthStore.getState().reset();
+    return () => {
+      useAuthStore.getState().reset();
+      useAlbumStore.getState().clear();
+    };
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -100,9 +116,16 @@ export const ViewerOnPhotoList: Story = {
       id: 'u2',
       name: '뷰어',
       email: 'viewer@joka.app',
+    });
+    useAlbumStore.getState().setCurrent({
+      id: 'a1',
+      name: '테스트 앨범',
       role: 'VIEWER',
     });
-    return () => useAuthStore.getState().reset();
+    return () => {
+      useAuthStore.getState().reset();
+      useAlbumStore.getState().clear();
+    };
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/apps/web/src/widgets/top-bar/ui/top-bar.tsx
+++ b/apps/web/src/widgets/top-bar/ui/top-bar.tsx
@@ -1,24 +1,22 @@
-import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { LogOut, Plus } from 'lucide-react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
+import { useCurrentAlbumRole } from '@/entities/album';
 import type { UserRole } from '@/entities/user';
 import {
   canUpload,
   useAuthStore,
-  useAuthUser,
   useIsAuthenticated,
   useLogoutMutation,
 } from '@/features/auth';
-
 import { SelectToggle } from '@/features/photo-select';
 import { ThemeToggle } from '@/features/theme';
-
 import { Button } from '@/shared/ui/button';
 
 export function TopBar() {
   const isAuthenticated = useIsAuthenticated();
-  const user = useAuthUser();
+  const role = useCurrentAlbumRole();
   const isListRoute = useLocation().pathname.endsWith('/photos');
 
   return (
@@ -33,7 +31,7 @@ export function TopBar() {
           <ThemeToggle />
           {isAuthenticated ? (
             <>
-              <UploadFab role={user?.role} />
+              <UploadFab role={role} />
               <LogoutButton />
             </>
           ) : null}


### PR DESCRIPTION
## 📌 관련 이슈

- #74

---

## 🧹 작업 내용

> 수동 QA를 실제 백엔드(joka-api + MinIO) 연동으로 전 기능 돌려벼, 단위 테스트로 가려졌던 프론트-백엔드 계약/UX 이슈를 수정했습니다. 

**인증 / 권한**
- 로그아웃 시 stale `/me` refetch로 로그인 상태가 되살아나던 문제 수정 (`f346f17`)
- role이 `/me`→`/albums`(앨범별)로 이동 → 현재 앨범 role 기준 권한 판정으로 전환, +버튼·수정/삭제 노출 복구 (`513ae1c`)
- 인증/4xx 에러 시 쿼리 재시도 폭주 → 4xx 회로차단, 408·429만 예외 (`bc28721`)

**업로드**
- contents 단계 400 → presigned에서 쿼리 제거한 절대 URL 전달 (`e63924f`)
- 재시도 시 진행률 0%부터 시작 (`78ad6f9`)
- 시트 닫기(딤·ESC)·취소 동작 정리 (`24b2a2c`), 완료 사진 X 숨김 (`9999d52`)
- 업로드 후 시트에서 설명 저장, 저장 버튼 3상태·자동이동 제거 (`4e4b719`)
- 상태별 썸네일 시각 구분(대기/완료/취소) (`c8d97cf`)
- 취소한 사진 재개 가능 + 취소 상태 일관화 (`238fe5e`)

**다운로드 / 에러**
- 다운로드 fetch 실패 시 URL 이동 대신 에러 토스트 (`71f7bd4`)
- 일괄 다운로드 실패 메시지를 사유별로 개선 (`058c2ea`)
- 라우트 에러 폴백 "다시 시도"가 실제 복구되도록 수정 (`88eccff`)

**기타**
- 토스트 위치·노출 시간 조정 (`a5cd4a5`)

---

## 🛠️ 테스트

- [x] 단위 테스트 통과 
- [x] 수동 테스트 완료 
- [x] 기존 기능 영향 없음 확인 

---

## 🔍 고민 / 결정 사항

- **권한 소스**
  - role을 `user`(=/me, 미제공)에서 현재 앨범 role로 일원화
  - `/upload` 직접 진입 시 앨범 로드 전엔 스켈레톤으로 판정 보류해 섣부른 리다이렉트 방지
- **재시도 정책**: 4xx는 재요청해도 결과가 같아 중단. 단 408·429는 일시적이라 예외
- **다운로드 실패**: cross-origin presigned URL은 `a[download]`가 무시돼 navigate로 새므로, fallback을 제거하고 에러로 표면화
- **라우트 폴백**: 데이터를 react-query로 가져와 `revalidate`(loader)는 no-op → `reload`로 통일
- **업로드 설명**
  - 자동이동 제거 후 업로드 완료분만 설명 입력·저장 허용
  - 취소는 큐를 비우지 않고 `canceled`로 두어 리스트 유지·재개 가능