### PR TITLE
[Fix] 업로드/목록/다운로드 QA 발견 버그 3건 수정

### DIFF
--- a/apps/web/src/features/photo-download/lib/filename.test.ts
+++ b/apps/web/src/features/photo-download/lib/filename.test.ts
@@ -69,6 +69,36 @@ describe('downloadFilename', () => {
     ).toBe('x.jpg');
   });
 
+  test('description에 확장자가 포함돼도 중복으로 붙지 않는다', () => {
+    expect(
+      downloadFilename({
+        id: 'm1',
+        description: 'photo.jpg',
+        mimeType: 'image/jpeg',
+      }),
+    ).toBe('photo.jpg');
+  });
+
+  test('description 확장자와 mimeType이 달라도 mimeType 확장자를 쓴다', () => {
+    expect(
+      downloadFilename({
+        id: 'm1',
+        description: 'photo.jpeg',
+        mimeType: 'image/png',
+      }),
+    ).toBe('photo.png');
+  });
+
+  test('알 수 없는 확장자는 베이스명의 일부로 유지한다', () => {
+    expect(
+      downloadFilename({
+        id: 'm1',
+        description: '버전 1.2',
+        mimeType: 'image/png',
+      }),
+    ).toBe('버전 1.2.png');
+  });
+
   test('베이스명이 100자를 넘으면 자른다', () => {
     const long = 'a'.repeat(150);
 

--- a/apps/web/src/features/photo-download/lib/filename.ts
+++ b/apps/web/src/features/photo-download/lib/filename.ts
@@ -12,8 +12,38 @@ const MIME_EXTENSION: Record<string, string> = {
 
 const MAX_BASE_LENGTH = 100;
 
+const KNOWN_EXTENSIONS = new Set([
+  'jpg',
+  'jpeg',
+  'png',
+  'webp',
+  'gif',
+  'avif',
+  'heic',
+]);
+
 function extensionFromMime(mimeType?: string): string {
   return (mimeType && MIME_EXTENSION[mimeType]) || 'jpg';
+}
+
+/**
+ * 파일 이름에서 알려진 확장자(예: .jpg, .png)가 포함되어 있다면 이를 제거합니다.
+ * - 확장자가 없거나 등록되지 않은 확장자일 경우 원본 이름을 그대로 반환합니다.
+ * @example
+ * stripExtension('photo.jpg'); // 이름이 'photo'로 반환 (KNOWN_EXTENSIONS에 있는 경우)
+ * stripExtension('.gitignore'); // 숨김 파일 형태는 원본 그대로 '.gitignore' 반환
+ * stripExtension('archive.tar.gz'); // 'archive.tar' 반환 (마지막 확장자만 제거)
+ */
+function stripExtension(name: string): string {
+  const lastDotIndex = name.lastIndexOf('.');
+
+  const hasNoExtension = lastDotIndex <= 0;
+  if (hasNoExtension) return name;
+
+  const extension = name.slice(lastDotIndex + 1).toLowerCase();
+  const nameWithoutExtension = name.slice(0, lastDotIndex);
+
+  return KNOWN_EXTENSIONS.has(extension) ? nameWithoutExtension : name;
 }
 
 function sanitize(name: string): string {
@@ -27,7 +57,7 @@ function sanitize(name: string): string {
 export function downloadFilename(
   photo: Pick<Photo, 'id' | 'description' | 'mimeType'>,
 ): string {
-  const base = sanitize(photo.description) || photo.id;
+  const base = stripExtension(sanitize(photo.description)) || photo.id;
 
   return `${base}.${extensionFromMime(photo.mimeType)}`;
 }

--- a/apps/web/src/features/photo-upload/ui/upload-item.tsx
+++ b/apps/web/src/features/photo-upload/ui/upload-item.tsx
@@ -128,7 +128,9 @@ export function UploadItem({
         )}
       </div>
 
-      <p className="truncate text-xs text-muted-foreground">{item.file.name}</p>
+      <p className="truncate text-xs text-muted-foreground">
+        {item.description.trim() || item.file.name}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { ErrorBoundary } from '@/app/providers/error-boundary';
@@ -99,7 +99,6 @@ export function PhotoListPage() {
   const order = usePhotoSortStore((s) => s.order);
   const enabled = useSelectEnabled();
   const selectedIds = useSelectedIds();
-  const clearSelection = usePhotoSelectStore((s) => s.clear);
 
   const albumId = useAlbumStore((s) => s.current?.id);
   const query = usePhotosInfinite(
@@ -113,14 +112,6 @@ export function PhotoListPage() {
     selectedIds,
     role,
   );
-
-  const prevOrder = useRef(order);
-  useEffect(() => {
-    if (prevOrder.current !== order) {
-      prevOrder.current = order;
-      clearSelection();
-    }
-  }, [order, clearSelection]);
 
   const handleBatchDownload = async () => {
     const result = await runBatchDownload();


### PR DESCRIPTION
 ## 📌 관련 이슈

  * #96 

  ---

  ## 🧹 작업 내용

  QA에서 발견한 업로드/목록/다운로드 버그 3건 수정.

  * **업로드창 이름 표시** — 썸네일 라벨이 원본 `file.name`만 보여 이름(설명) 변경이 반영되지 않던 문제. 
      * `description` 우선 표시, 없으면`file.name`으로 폴백
  * **정렬 시 선택 유지** — `order` 변경을 감지해 선택을 비우던 `useEffect` 제거.
      * 선택은 id 기반이라 순서만 바뀌면 해제할 이유가 없다고 판단함.
  * **다운로드 확장자 중복** — 설명이 파일명(`photo.jpg`)이면`.jpg.jpg`로 저장되던 문제. 
      * 확장자 부여 전 알려진 이미지 확장자를 한 번 제거하는\`stripExtension` 추가

  ---

  ## 🛠️  테스트

  * [x] 단위 테스트 통과 (`filename.test.ts` 12개, 중복/불일치/일반 점
  케이스 추가)
  * [x] 수동 테스트 완료 (이름 입력 반영 · 정렬 후 선택 유지 ·
  다운로드 파일명 확인)
  * [x] 기존 기능 영향 없음 확인 (타입체크 클린)

  ---

  ## 🔍 고민 / 결정 사항

  * **확장자 중복 — 다운로드 측에서 처리**: 업로드 시 설명 기본값으로
  `file.name`을
    넣는 지점(`mutations.ts`)을 고치는 대안도 있었으나, 이미 확장자
  포함으로 저장된
  * **`stripExtension`은 알려진 이미지 확장자만 제거**: `버전 1.2`
  같은 일반 점 포함
    이름이 잘리지 않도록 `KNOWN_EXTENSIONS` 화이트리스트로 한정.
  mime과 설명의 확장자가
    달라도(`photo.jpeg` + `image/png`) mime 기준으로 부여
  * **정렬 시 선택 초기화 제거**: 의도된 초기화였을 수 있어, 선택이 id
  기반이라
    순서 변경과 무관함을 근거로 제거. 리뷰 시 이 동작 변경 의도가
  맞는지 확인 부탁
  
  ---
  
  ## 💬 참고 사항

  * 업로드창 입력칸 placeholder("…남기실 말이 있으신가요?")는 *설명* 톤이라, 이 입력을 "이름"으로 쓰면 안 될 것 같음.
  * UI 자체가 title에 가까운 느낌이라, 보완을 해야할 것 같기에 한 번 대화를 나눠봐야할 필요가 있음.