### PR TITLE
[Feat] 제품 행동 로그 수집 기반 작업(이벤트 봉투·track 전송)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,5 @@
 VITE_SENTRY_DSN=your-sentry-dsn
 VITE_API_BASE_URL=your-base-url
 VITE_AUTH_REFRESH_PATH=your-auth-refresh-path
+VITE_APP_VERSION=0.0.0
 CHROMATIC_PROJECT_TOKEN=your-chromatic-token

--- a/apps/web/src/shared/config/env.ts
+++ b/apps/web/src/shared/config/env.ts
@@ -1,9 +1,15 @@
 import { z } from 'zod';
+
 import { log } from '@/shared/lib/logger';
 
 const EnvSchema = z.object({
   VITE_API_BASE_URL: z.string().min(1, 'API 주소가 설정되어 있지 않습니다.'),
   VITE_AUTH_REFRESH_PATH: z.string().min(1).default('/v1/auth/refresh'),
+  /**
+   * @description 분석 이벤트(appVersion) 및 Sentry 연동에 사용되는 앱 버전입니다.
+   * @note CI 빌드 단계에서 package.json 버전을 환경 변수로 주입해야 합니다.
+   */
+  VITE_APP_VERSION: z.string().default('0.0.0'),
 });
 
 const parsed = EnvSchema.safeParse(import.meta.env);

--- a/apps/web/src/shared/lib/analytics/identity.test.ts
+++ b/apps/web/src/shared/lib/analytics/identity.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  getAnonUserId,
+  getSessionId,
+  getUserRole,
+  routePattern,
+  setAnalyticsUser,
+  setRoleResolver,
+} from './identity';
+
+beforeEach(async () => {
+  sessionStorage.clear();
+  await setAnalyticsUser(null);
+  setRoleResolver(() => null);
+});
+
+describe('getSessionId', () => {
+  test('처음 호출 시 생성하고 sessionStorage에 보관', () => {
+    const id = getSessionId();
+    expect(id).toBeTruthy();
+    expect(sessionStorage.getItem('joka.sid')).toBe(id);
+  });
+
+  test('같은 세션에서 동일 값 반환', () => {
+    expect(getSessionId()).toBe(getSessionId());
+  });
+});
+
+describe('setAnalyticsUser / anonUserId', () => {
+  test('userId를 16자 해시로 변환 (원본 노출 X)', async () => {
+    await setAnalyticsUser('user-123');
+    const hash = getAnonUserId();
+
+    expect(hash).toHaveLength(16);
+    expect(hash).not.toBe('user-123');
+    expect(hash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test('같은 userId는 같은 해시 (결정적)', async () => {
+    await setAnalyticsUser('user-123');
+    const first = getAnonUserId();
+    await setAnalyticsUser('user-123');
+    expect(getAnonUserId()).toBe(first);
+  });
+
+  test('null이면 anonUserId 초기화', async () => {
+    await setAnalyticsUser('user-123');
+    await setAnalyticsUser(null);
+    expect(getAnonUserId()).toBeNull();
+  });
+});
+
+describe('setRoleResolver / userRole', () => {
+  test('resolver가 emit 시점의 현재 앨범 role을 반환', () => {
+    let current: string | null = 'EDITOR';
+    setRoleResolver(() => current as never);
+
+    expect(getUserRole()).toBe('EDITOR');
+
+    current = 'VIEWER';
+    expect(getUserRole()).toBe('VIEWER');
+  });
+
+  test('미주입(기본) 시 null', () => {
+    expect(getUserRole()).toBeNull();
+  });
+});
+
+describe('routePattern', () => {
+  test('사진 상세는 :id로 정규화', () => {
+    expect(routePattern('/photos/abc123')).toBe('/photos/:id');
+  });
+
+  test('목록·정적 경로는 그대로', () => {
+    expect(routePattern('/photos')).toBe('/photos');
+    expect(routePattern('/login')).toBe('/login');
+    expect(routePattern('/upload')).toBe('/upload');
+  });
+
+  test('중첩 경로는 정규화하지 않음', () => {
+    expect(routePattern('/photos/abc/edit')).toBe('/photos/abc/edit');
+  });
+});

--- a/apps/web/src/shared/lib/analytics/identity.ts
+++ b/apps/web/src/shared/lib/analytics/identity.ts
@@ -1,0 +1,62 @@
+import type { UserRole } from '@/entities/user';
+
+const SESSION_KEY = 'joka.sid';
+const ANON_ID_LENGTH = 16;
+
+let anonUserId: string | null = null;
+let roleResolver: () => UserRole | null = () => null;
+
+export function getSessionId(): string {
+  let id = sessionStorage.getItem(SESSION_KEY);
+  if (!id) {
+    id = crypto.randomUUID();
+    sessionStorage.setItem(SESSION_KEY, id);
+  }
+
+  return id;
+}
+
+export async function setAnalyticsUser(userId: string | null): Promise<void> {
+  anonUserId = userId ? await sha256hex(userId) : null;
+}
+
+export function getAnonUserId(): string | null {
+  return anonUserId;
+}
+
+async function sha256hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, ANON_ID_LENGTH);
+}
+
+/**
+ * 앨범별 유저 권한(UserRole)을 동적으로 가져오는 함수를 주입합니다.
+ * - 앱 초기화 시점(app 레이어)에서 이 함수를 통해 album store의 권한 조회 로직을 주입받아 의존성을 역전합니다.
+ * - Note: 유저 권한은 머무르는 앨범에 따라 실시간으로 변하므로, 이벤트가 전송(emit)되는 순간에 이 함수를 실행해 최신 값을 읽어옵니다.
+ */
+export function setRoleResolver(resolver: () => UserRole | null): void {
+  roleResolver = resolver;
+}
+
+export function getUserRole(): UserRole | null {
+  return roleResolver();
+}
+
+/**
+ * 분석 통계 그룹화를 위해 실제 URL 경로를 라우트 패턴으로 정규화합니다.
+ * @example
+ * /photos/abc, /photos/123 ➔ '/photos/:id'
+ */
+export function routePattern(
+  pathname: string = window.location.pathname,
+): string {
+  if (/^\/photos\/[^/]+$/.test(pathname)) {
+    return '/photos/:id';
+  }
+  return pathname;
+}

--- a/apps/web/src/shared/lib/analytics/identity.ts
+++ b/apps/web/src/shared/lib/analytics/identity.ts
@@ -3,8 +3,13 @@ import type { UserRole } from '@/entities/user';
 const SESSION_KEY = 'joka.sid';
 const ANON_ID_LENGTH = 16;
 
-let anonUserId: string | null = null;
-let roleResolver: () => UserRole | null = () => null;
+const state: {
+  anonUserId: string | null;
+  roleResolver: () => UserRole | null;
+} = {
+  anonUserId: null,
+  roleResolver: () => null,
+};
 
 export function getSessionId(): string {
   let id = sessionStorage.getItem(SESSION_KEY);
@@ -17,11 +22,11 @@ export function getSessionId(): string {
 }
 
 export async function setAnalyticsUser(userId: string | null): Promise<void> {
-  anonUserId = userId ? await sha256hex(userId) : null;
+  state.anonUserId = userId ? await sha256hex(userId) : null;
 }
 
 export function getAnonUserId(): string | null {
-  return anonUserId;
+  return state.anonUserId;
 }
 
 async function sha256hex(input: string): Promise<string> {
@@ -40,11 +45,11 @@ async function sha256hex(input: string): Promise<string> {
  * - Note: 유저 권한은 머무르는 앨범에 따라 실시간으로 변하므로, 이벤트가 전송(emit)되는 순간에 이 함수를 실행해 최신 값을 읽어옵니다.
  */
 export function setRoleResolver(resolver: () => UserRole | null): void {
-  roleResolver = resolver;
+  state.roleResolver = resolver;
 }
 
 export function getUserRole(): UserRole | null {
-  return roleResolver();
+  return state.roleResolver();
 }
 
 /**

--- a/apps/web/src/shared/lib/analytics/index.ts
+++ b/apps/web/src/shared/lib/analytics/index.ts
@@ -1,0 +1,3 @@
+export { track, flush, initAnalytics } from './track';
+export { setAnalyticsUser, setRoleResolver } from './identity';
+export type { AnalyticsEvent, AnalyticsProps, EventEnvelope } from './types';

--- a/apps/web/src/shared/lib/analytics/track.test.ts
+++ b/apps/web/src/shared/lib/analytics/track.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@/shared/config/env', () => ({
+  env: { VITE_API_BASE_URL: 'http://test.local', VITE_APP_VERSION: 'test' },
+}));
+
+import { flush, initAnalytics, resetForTests, track } from './track';
+
+const ENDPOINT = 'http://test.local/v1/events';
+
+function mockFetch() {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue(new Response(null, { status: 204 }));
+}
+
+function lastFetchBody(spy: ReturnType<typeof mockFetch>) {
+  const calls = spy.mock.calls;
+  const init = calls[calls.length - 1]?.[1];
+  return JSON.parse(init?.body as string);
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  resetForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('track / flush', () => {
+  test('flush 시 버퍼된 이벤트를 배치로 전송', () => {
+    const fetchSpy = mockFetch();
+
+    track('list.view');
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    flush();
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy.mock.calls[0][0]).toBe(ENDPOINT);
+    const payload = lastFetchBody(fetchSpy);
+    expect(payload.events).toHaveLength(1);
+    expect(payload.events[0].event).toBe('list.view');
+  });
+
+  test('봉투에 공통 필드 포함', () => {
+    const fetchSpy = mockFetch();
+
+    track('detail.view', { source: 'grid' });
+    flush();
+
+    const e = lastFetchBody(fetchSpy).events[0];
+    expect(e.sessionId).toBeTruthy();
+    expect(e.route).toBeTruthy();
+    expect(e.appVersion).toBe('test');
+    expect(e.props).toEqual({ source: 'grid' });
+    expect(typeof e.timestamp).toBe('number');
+  });
+
+  test('버퍼 임계치(20) 도달 시 자동 전송', () => {
+    const fetchSpy = mockFetch();
+
+    for (let i = 0; i < 20; i += 1) track('list.view');
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(lastFetchBody(fetchSpy).events).toHaveLength(20);
+  });
+
+  test('인터벌 경과 시 자동 flush', () => {
+    vi.useFakeTimers();
+    const fetchSpy = mockFetch();
+
+    track('list.view');
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(10_000);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  test('빈 버퍼 flush는 아무것도 전송 안 함', () => {
+    const fetchSpy = mockFetch();
+    flush();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('flush 후 버퍼가 비워져 재전송 안 함', () => {
+    const fetchSpy = mockFetch();
+
+    track('list.view');
+    flush();
+    flush(); // 두 번째는 빈 버퍼라 전송 없어야 함
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  test('useBeacon=true면 fetch 대신 sendBeacon 사용', () => {
+    const fetchSpy = mockFetch();
+    const beacon = vi.fn((_url: string, _body?: BodyInit) => true);
+    vi.stubGlobal('navigator', { sendBeacon: beacon });
+
+    track('auth.logout');
+    flush(true);
+
+    expect(beacon).toHaveBeenCalledOnce();
+    expect(beacon.mock.calls[0][0]).toBe(ENDPOINT);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('initAnalytics', () => {
+  test('pagehide·visibilitychange 리스너 등록', () => {
+    const winSpy = vi.spyOn(window, 'addEventListener');
+    const docSpy = vi.spyOn(document, 'addEventListener');
+
+    initAnalytics();
+
+    expect(winSpy).toHaveBeenCalledWith('pagehide', expect.any(Function));
+    expect(docSpy).toHaveBeenCalledWith(
+      'visibilitychange',
+      expect.any(Function),
+    );
+  });
+
+  test('pagehide 발생 시 beacon으로 flush', () => {
+    const beacon = vi.fn((_url: string, _body?: BodyInit) => true);
+    vi.stubGlobal('navigator', { sendBeacon: beacon });
+
+    initAnalytics();
+    track('list.view');
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(beacon).toHaveBeenCalledOnce();
+    expect(beacon.mock.calls[0][0]).toBe(ENDPOINT);
+  });
+});

--- a/apps/web/src/shared/lib/analytics/track.ts
+++ b/apps/web/src/shared/lib/analytics/track.ts
@@ -1,0 +1,94 @@
+import {
+  getAnonUserId,
+  getSessionId,
+  getUserRole,
+  routePattern,
+} from './identity';
+import type { AnalyticsEvent, AnalyticsProps, EventEnvelope } from './types';
+
+import { env } from '@/shared/config/env';
+
+const EVENTS_PATH = '/v1/events';
+const MAX_BUFFER = 20;
+const FLUSH_INTERVAL_MS = 10_000;
+
+const buffer: EventEnvelope[] = [];
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+export function initAnalytics(): void {
+  window.addEventListener('pagehide', () => flush(true));
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      flush(true);
+    }
+  });
+}
+
+export function track(event: AnalyticsEvent, props?: AnalyticsProps): void {
+  buffer.push(buildEnvelope(event, props));
+
+  if (buffer.length >= MAX_BUFFER) {
+    flush();
+    return;
+  }
+  scheduleFlush();
+}
+
+function buildEnvelope(
+  event: AnalyticsEvent,
+  props?: AnalyticsProps,
+): EventEnvelope {
+  return {
+    event,
+    timestamp: Date.now(),
+    sessionId: getSessionId(),
+    anonUserId: getAnonUserId(),
+    userRole: getUserRole(),
+    route: routePattern(),
+    appVersion: env.VITE_APP_VERSION,
+    ...(props && { props }),
+  };
+}
+
+export function flush(useBeacon = false): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  if (buffer.length === 0) return;
+
+  const events = buffer.splice(0, buffer.length);
+  send(events, useBeacon);
+}
+
+function scheduleFlush(): void {
+  if (timer) return;
+  timer = setTimeout(() => flush(), FLUSH_INTERVAL_MS);
+}
+
+function send(events: EventEnvelope[], useBeacon: boolean): void {
+  const url = `${env.VITE_API_BASE_URL}${EVENTS_PATH}`;
+  const body = JSON.stringify({ events });
+
+  if (useBeacon && typeof navigator.sendBeacon === 'function') {
+    // sendBeacon은 헤더 설정이 불가능하므로, Content-Type 지정을 위해 데이터 타입 정보가 내장된 Blob으로 감싸 전송
+    navigator.sendBeacon(url, new Blob([body], { type: 'application/json' }));
+    return;
+  }
+
+  // 탭이 닫혀도 백그라운드 배달을 보장하는 keepalive 활성화
+  void fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch(() => {});
+}
+
+export function resetForTests(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  buffer.length = 0;
+}

--- a/apps/web/src/shared/lib/analytics/types.ts
+++ b/apps/web/src/shared/lib/analytics/types.ts
@@ -1,0 +1,41 @@
+import type { UserRole } from '@/entities/user';
+
+export type AnalyticsEvent =
+  | 'auth.login_success'
+  | 'auth.logout'
+  | 'list.view'
+  | 'list.scroll_depth'
+  | 'detail.view'
+  | 'upload.session_complete'
+  | 'download.single_start'
+  | 'download.single_success'
+  | 'download.single_fail'
+  | 'download.bulk_start'
+  | 'download.bulk_success'
+  | 'download.bulk_fail';
+
+/**
+ * 이벤트별 추가 데이터 (Key-Value)
+ *
+ * - 프라이버시 보호를 위해 개인정보(이메일, 이름, 파일명 등) 포함을 엄격히 금지합니다.
+ * - 통계 분석을 위한 원시 데이터(크기, 개수, 타입, ON/OFF 플래그 등)만 허용합니다.
+ */
+export type AnalyticsProps = Record<string, string | number | boolean | null>;
+
+/**
+ * 자체 수집 서버(POST /v1/events)로 전송할 공통 이벤트 포맷
+ *
+ * - anonUserId: 프라이버시 보호를 위해 user.id를 SHA-256(16hex)으로 해싱한 값 (원본 ID/이메일 포함 금지)
+ * - userRole: 앨범별로 권한이 다르므로, Album Store의 Resolver를 통해 동적으로 주입
+ * - route: 통계 그룹화를 위해 실제 URL이 아닌 라우트 패턴(예: /photos/:id) 형태로 정규화하여 기록
+ */
+export interface EventEnvelope {
+  event: AnalyticsEvent;
+  timestamp: number;
+  sessionId: string;
+  anonUserId: string | null;
+  userRole: UserRole | null;
+  route: string;
+  appVersion: string;
+  props?: AnalyticsProps;
+}


### PR DESCRIPTION
## 📌 관련 이슈

  * Closes #99 
  * Closes #100 

  ---

  ## 🧹 작업 내용

  * 가족 실사용 **행동 로그 수집의 데이터 스키마·전송 레이어**(클라이언트) 추가. (UI/UX 개선용) 
  > 에러 추적(Sentry)과 분리된 별도 채널
  * **봉투 포맷** + 이벤트명 union 타입 정의
  * **익명 식별**
      * sessionId(탭 단위), anonUserId(user.id SHA-25616hex 해시), 앨범별 role 주입(resolver), route 패턴 정규화(`/photos/:id`)
  * **전송(track)**: 버퍼링(20개·10초·탭 이탈) 후 배치 전송
      * 평소`fetch(keepalive)`, 이탈 시 `sendBeacon`
  * 앱 부트에 `initAnalytics`·role resolver 배선 + appVersion용 env 추가

  ---

  ## 🛠️  테스트

  * [x] 단위 테스트 통과 (identity 8 · track 9)
  * [x] 기존 기능 영향 없음 확인 (신규 모듈 + env + 부트 호출만, 기존 동작 변경 없음)
  * [ ] 수동 테스트 — 해당 없음 (수신 서버 미구현 · UI 변화 없음)

  ---

  ## 🔍 고민 / 결정 사항

  * **Sentry와 분리된 별도 채널**
       * 제품 이벤트를 Sentry에 태우면 무료 쿼터 소진 + 퍼널 분석 부적합 → 자체 싱크로 분리
  * **익명화**: 가족 사진 서비스라 user.id를 단방향 해시로만 전송(원본·이메일 미포함)
  * **Fire-and-forget**: 분석용 데이터라 던지고 기다리진 않음

  ---

  ## 💬 참고 사항

  * 기술 부채: `appVersion`은 CI에서 `package.json` 버전 주입 필요 (현재 기본값 `0.0.0`)
     * 관련 서버 작업 및 전체 이슈 문서화 후 전달 예정 