### PR TITLE
[Feat] 행동 이벤트 수집 레이어 배선 및 화면 계측

### DIFF
--- a/apps/web/src/app/index.tsx
+++ b/apps/web/src/app/index.tsx
@@ -5,12 +5,16 @@ import { ErrorBoundary } from '@/app/providers/error-boundary';
 import { queryClient } from '@/app/providers/query-client';
 import { AppRouter } from '@/app/providers/router';
 import { initSentry } from '@/app/providers/sentry';
+import { useAlbumStore } from '@/entities/album';
 import { initTheme } from '@/features/theme';
+import { initAnalytics, setRoleResolver } from '@/shared/lib/analytics';
 import { Toaster } from '@/shared/ui/toast';
 import './styles/globals.css';
 
 initSentry();
 initTheme();
+initAnalytics();
+setRoleResolver(() => useAlbumStore.getState().current?.role ?? null);
 
 const root = document.getElementById('root');
 if (root) {

--- a/apps/web/src/app/providers/auth-guard.tsx
+++ b/apps/web/src/app/providers/auth-guard.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import { useAlbums, useAlbumStore } from '@/entities/album';
 import { useAuthStore, useMe, canUpload } from '@/features/auth';
 import { authTokenStore } from '@/shared/api/auth-token';
 import { readCookie } from '@/shared/api/cookie';
+import { setAnalyticsUser, track } from '@/shared/lib/analytics';
 import { Skeleton } from '@/shared/ui/skeleton';
 
 const PUBLIC_PATHS = new Set(['/login']);
@@ -35,6 +36,8 @@ export function AuthGuard() {
   const clearAlbum = useAlbumStore((s) => s.clear);
   const currentAlbum = useAlbumStore((s) => s.current);
 
+  const loginTrackedRef = useRef(false);
+
   useEffect(() => {
     bootstrapAccessToken();
   }, []);
@@ -45,9 +48,18 @@ export function AuthGuard() {
   useEffect(() => {
     if (meQuery.isSuccess) {
       setUser(meQuery.data);
+
+      void setAnalyticsUser(meQuery.data.id).then(() => {
+        // 새 탭/새로고침 시 /me가 중복 호출되므로, 탭 단위 최초 1회만 로그인으로 집계
+        if (!loginTrackedRef.current) {
+          loginTrackedRef.current = true;
+          track('auth.login_success');
+        }
+      });
     } else if (meQuery.isError) {
       setUser(null);
       clearAlbum();
+      void setAnalyticsUser(null);
     }
   }, [meQuery.isSuccess, meQuery.isError, meQuery.data, setUser, clearAlbum]);
 

--- a/apps/web/src/features/auth/api/mutations.ts
+++ b/apps/web/src/features/auth/api/mutations.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 
 import { useAlbumStore } from '@/entities/album';
 import { http } from '@/shared/api';
+import { setAnalyticsUser, track } from '@/shared/lib/analytics';
 
 export function useLogoutMutation() {
   const clearAlbum = useAlbumStore((s) => s.clear);
@@ -11,6 +12,8 @@ export function useLogoutMutation() {
     meta: { operationId: 'auth_logout' },
     onSuccess: () => {
       clearAlbum();
+      track('auth.logout');
+      void setAnalyticsUser(null);
     },
   });
 }

--- a/apps/web/src/features/photo-download/ui/download-button.tsx
+++ b/apps/web/src/features/photo-download/ui/download-button.tsx
@@ -7,6 +7,7 @@ import { downloadFilename } from '../lib/filename';
 import { useCurrentAlbumRole } from '@/entities/album';
 import type { Photo } from '@/entities/photo';
 import { ApiError } from '@/shared/api/error';
+import { track } from '@/shared/lib/analytics';
 import { recordForbidden } from '@/shared/lib/business-ux-logging';
 import { Button, type ButtonProps } from '@/shared/ui/button';
 import { toast } from '@/shared/ui/toast';
@@ -31,12 +32,15 @@ export function DownloadButton({
     if (!photo.downloadUrl) return;
 
     setBusy(true);
+    track('download.single_start');
     try {
       await downloadOne({
         url: photo.downloadUrl,
         filename: downloadFilename(photo),
       });
+      track('download.single_success');
     } catch (err) {
+      track('download.single_fail');
       if (err instanceof ApiError && err.status === 403) {
         recordForbidden({
           userRole: role ?? 'unknown',

--- a/apps/web/src/features/photo-upload/model/runner.ts
+++ b/apps/web/src/features/photo-upload/model/runner.ts
@@ -7,6 +7,7 @@ import { uploadSinglePhoto } from '../api/mutations';
 
 import { MAX_RETRY_COUNT } from '@/app/providers/constants';
 import { photoKeys } from '@/entities/photo/api/keys';
+import { track } from '@/shared/lib/analytics';
 import { recordNetworkRetryExceeded } from '@/shared/lib/business-ux-logging';
 
 function isAbortError(err: unknown): boolean {
@@ -55,6 +56,8 @@ function handleFailure(id: string, err: unknown): void {
 export function useUploadRunner() {
   const queryClient = useQueryClient();
   const abortersRef = useRef(new Map<string, AbortController>());
+  const sessionStartRef = useRef<number | null>(null);
+  const sessionItemIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     let unmounted = false;
@@ -86,6 +89,38 @@ export function useUploadRunner() {
       }
     }
 
+    function startUploadSession(): void {
+      sessionStartRef.current = Date.now();
+
+      const currentItems = useUploadQueueStore.getState().items;
+      sessionItemIdsRef.current = new Set(currentItems.map((it) => it.id));
+    }
+
+    function maybeEmitSessionComplete(): void {
+      if (sessionStartRef.current === null) return;
+
+      const { items } = useUploadQueueStore.getState();
+      const sessionItems = items.filter((it) =>
+        sessionItemIdsRef.current.has(it.id),
+      );
+
+      const active = sessionItems.some(
+        (it) => it.status === 'pending' || it.status === 'uploading',
+      );
+      if (active) return;
+
+      const ok = sessionItems.filter((it) => it.status === 'success').length;
+      const fail = sessionItems.filter((it) => it.status === 'error').length;
+      track('upload.session_complete', {
+        ok,
+        fail,
+        durMs: Date.now() - sessionStartRef.current,
+      });
+
+      sessionStartRef.current = null;
+      sessionItemIdsRef.current.clear();
+    }
+
     async function processNext(): Promise<void> {
       if (unmounted) return;
 
@@ -93,7 +128,14 @@ export function useUploadRunner() {
       if (state.isRunning) return;
 
       const next = state.items.find((it) => it.status === 'pending');
-      if (!next) return;
+      if (!next) {
+        maybeEmitSessionComplete();
+        return;
+      }
+
+      if (sessionStartRef.current === null) {
+        startUploadSession();
+      }
 
       state.setRunning(true);
       state.setStatus(next.id, { status: 'uploading', step: 'create' });

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeft, ChevronRight, Heart, Trash2, X } from 'lucide-react';
-import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { ErrorBoundary } from '@/app/providers/error-boundary';
 import { useAlbumStore, useCurrentAlbumRole } from '@/entities/album';
@@ -21,6 +21,7 @@ import { DownloadButton } from '@/features/photo-download';
 import { EditMetaForm } from '@/features/photo-edit-meta';
 import { usePhotoSortStore } from '@/features/photo-sort';
 import { ApiError } from '@/shared/api/error';
+import { track } from '@/shared/lib/analytics';
 import { recordForbidden } from '@/shared/lib/business-ux-logging';
 import { errorFallbackMessage } from '@/shared/lib/error-fallback';
 import { cn } from '@/shared/lib/utils/cn';
@@ -65,8 +66,23 @@ function usePrevNext(currentId: string) {
   };
 }
 
+/** 라우터 state에서 진입 경로(source)를 안전하게 읽는다. 없으면 'direct'. */
+function readNavSource(state: unknown): string {
+  if (
+    typeof state === 'object' &&
+    state !== null &&
+    'source' in state &&
+    typeof state.source === 'string'
+  ) {
+    return state.source;
+  }
+  return 'direct';
+}
+
 export function PhotoDetailPage() {
   const { id = '' } = useParams<{ id: string }>();
+  const { state } = useLocation();
+  const source = readNavSource(state);
 
   const albumId = useAlbumStore((s) => s.current?.id);
   const user = useAuthUser();
@@ -75,6 +91,10 @@ export function PhotoDetailPage() {
   const query = usePhotoDetail(id, { enabled: !!albumId && !!id });
   const photo = query.data;
   const { prevId, nextId } = usePrevNext(id);
+
+  useEffect(() => {
+    track('detail.view', { source });
+  }, [id, source]);
 
   if (query.isLoading || !photo) {
     return <DetailSkeleton />;
@@ -166,7 +186,10 @@ function NavArrow({
       size="icon"
       aria-label={isPrev ? '이전' : '다음'}
       disabled={!targetId}
-      onClick={() => targetId && navigate(`/photos/${targetId}`)}
+      onClick={() =>
+        targetId &&
+        navigate(`/photos/${targetId}`, { state: { source: 'nav' } })
+      }
       className={cn(
         'absolute top-1/2 -translate-y-1/2 rounded-full bg-black/40 text-white hover:bg-black/60 hover:text-white',
         isPrev ? 'left-2' : 'right-2',

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { ErrorBoundary } from '@/app/providers/error-boundary';
@@ -24,6 +24,7 @@ import {
 } from '@/features/photo-select';
 import { SortSheet, usePhotoSortStore } from '@/features/photo-sort';
 import { ApiError } from '@/shared/api/error';
+import { track } from '@/shared/lib/analytics';
 import { recordForbidden } from '@/shared/lib/business-ux-logging';
 import { errorFallbackMessage } from '@/shared/lib/error-fallback';
 import { cn } from '@/shared/lib/utils/cn';
@@ -107,6 +108,17 @@ export function PhotoListPage() {
   );
   const photos = selectPhotos(query.data);
 
+  useEffect(() => {
+    track('list.view');
+  }, []);
+
+  const pagesLoaded = query.data?.pages.length ?? 0;
+  useEffect(() => {
+    if (pagesLoaded > 1) {
+      track('list.scroll_depth', { pagesLoaded });
+    }
+  }, [pagesLoaded]);
+
   const { downloading, run: runBatchDownload } = useBatchDownload(
     photos,
     selectedIds,
@@ -114,16 +126,21 @@ export function PhotoListPage() {
   );
 
   const handleBatchDownload = async () => {
+    track('download.bulk_start', { count: selectedIds.size });
+
     const result = await runBatchDownload();
     if (!result) return;
 
     const { ok, failed, errors } = result;
 
     if (failed === 0) {
+      track('download.bulk_success', { ok });
       toast.success(`${ok}장 다운로드 완료`);
     } else if (ok === 0) {
+      track('download.bulk_fail', { failed });
       toast.error(allFailMessage(errors));
     } else {
+      track('download.bulk_success', { ok, failed });
       toast.warning(`${ok}장 완료 · ${failed}장 실패`);
     }
   };
@@ -158,7 +175,9 @@ export function PhotoListPage() {
             <GridCard
               key={photo.id}
               photo={photo}
-              onOpen={(id) => navigate(`/photos/${id}`)}
+              onOpen={(id) =>
+                navigate(`/photos/${id}`, { state: { source: 'grid' } })
+              }
             />
           )}
         />


### PR DESCRIPTION
 ## 📌 관련 이슈

  * Closes #103  

  ---

  ## 🧹 작업 내용

  * `app/index.tsx`에 `initAnalytics()` +`setRoleResolver()` 등 분석 라이브러리 연결
  * 로그인 성공 1회(ref 가드) +`mutations.ts` 로그아웃 시 `auth.logout` + anonId 초기화
  * 화면 이벤트 7개 진입점 계측
    - `photo-list`: `list.view` (마운트), `list.scroll_depth`(2페이지~), `download.bulk_*` (시작/성공/실패)
    - `photo-detail`: `detail.view` (id 변경마다, source='grid'|'nav'|'direct')
    - `photo-download`: `download.single_start/success/fail`
    - `photo-upload`: `upload.session_complete` (ok/fail 수, 총 소요 ms)
  
  ---

  ## 🔍 고민 / 결정 사항

  * **`as` 캐스트 제거**: `readNavSource` 타입 가드로 대체
     * 브라우저에 어떤 `state`를 넣을지는 개발자의 선택인데, 그 state 값을 알 턱이 없으니... 이런 경우는 `as`를 쓰는게 맞는지, 아니면 `readNavSource` 처럼 어떻게든 단언을 회피해야하는지 아직 감이 잘 안 옴. 
     * 이것도 휴먼에러니까 최대한 피해야하나, 이런건 보일러 플레이트로 안 치나🥲

```js
// 수정 전
export function PhotoDetailPage() {
  // ...
  const location = useLocation();
  const source =
    (location.state as { source?: string } | null)?.source ?? 'direct';

  // ... 하단 로직
}

// 수정 후
function readNavSource(state: unknown): string {
  if (
    typeof state === 'object' &&
    state !== null &&
    'source' in state &&
    typeof state.source === 'string'
  ) {
    return state.source; 
  }
  return 'direct';
}

export function PhotoDetailPage() {
  // ...  
  const { state } = useLocation();
  const source = readNavSource(state);

  // ... 하단 로직
}
```
  
  ---

  ## 💬 참고 사항

  * `POST /v1/events` 서버 싱크(R2 적재)는 별도 백엔드 작업 예정 
     * 그 전까지 `flush()`는 요청을 보내지만 404 응답
  * `VITE_APP_VERSION`은 CI에서 주입 필요 (`apps/web/.env.example` 참고)

>  참고사항과 관련된 부분은 주말까지 문서화해 전달 후 브리핑 예정