### PR TITLE
[Fix] Vercel 배포 SPA 라우팅 404 해결 

### DIFF
--- a/apps/web/public/site.webmanifest
+++ b/apps/web/public/site.webmanifest
@@ -1,6 +1,9 @@
 {
   "name": "JOKA",
   "short_name": "JOKA",
+  "id": "/",
+  "start_url": "/",
+  "scope": "/",
   "icons": [
     { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## 📌 관련 이슈

 * #106

  ---

  ## 🧹 작업 내용

  * `createBrowserRouter` 기반 SPA라 Vercel 정적 호스팅에서 미존재 경로 진입·새로고침 시 404 발생
      * `apps/web/vercel.json` 추가
      * 모든 경로를 `/index.html`로 rewrite (정적 파일은 우선 매칭되어 영향 없음)
  * `site.webmanifest`에 `id`/`start_url`/`scope`(`/`) 추가
      * PWA 설치 시작점 고정 (404와 별개, 같은 배포 묶음이라 동봉)