### PR TITLE
[Fix] 모바일 1차 QA (업로드 크래시·정렬·로딩 UX 수정)

### DIFF
--- a/apps/web/src/app/providers/auth-guard.tsx
+++ b/apps/web/src/app/providers/auth-guard.tsx
@@ -78,6 +78,10 @@ export function AuthGuard() {
 
   const isPublic = PUBLIC_PATHS.has(location.pathname);
 
+  if (isPublic && status !== 'authenticated') {
+    return <Outlet />;
+  }
+
   const isCheckingSession = status === 'idle' && meQuery.isPending;
   if (isCheckingSession) {
     return <GuardFallback />;

--- a/apps/web/src/app/providers/router.tsx
+++ b/apps/web/src/app/providers/router.tsx
@@ -5,14 +5,14 @@ import {
   RouterProvider,
 } from 'react-router-dom';
 
+import { AuthGuard } from './auth-guard';
+import { RouteErrorFallback } from './route-error-fallback';
+
 import { AuthPage } from '@/pages/auth';
 import { PhotoDetailPage } from '@/pages/photo-detail';
 import { PhotoListPage } from '@/pages/photo-list';
 import { UploadPage } from '@/pages/upload';
 import { TopBar } from '@/widgets/top-bar';
-
-import { AuthGuard } from './auth-guard';
-import { RouteErrorFallback } from './route-error-fallback';
 
 /**
  * 모든 라우트 위에 항상 마운트되는 레이아웃.
@@ -24,6 +24,20 @@ function RootLayout() {
       <TopBar />
       <Outlet />
     </div>
+  );
+}
+
+/**
+ * /photos와 /upload가 공유하는 레이아웃.
+ * - 목록을 항상 마운트해 두고 업로드 시트는 Outlet 오버레이로 띄운다.
+ * - /photos ↔ /upload 이동 시 목록이 언마운트되지 않아 사진을 다시 받지 않는다.
+ */
+function PhotoListLayout() {
+  return (
+    <>
+      <PhotoListPage />
+      <Outlet />
+    </>
   );
 }
 
@@ -56,14 +70,12 @@ const router = createBrowserRouter([
             errorElement: <RouteErrorFallback backTo="/login" />,
           },
           {
-            path: '/upload',
-            element: <UploadPage />,
+            element: <PhotoListLayout />,
             errorElement: <RouteErrorFallback backTo="/photos" />,
-          },
-          {
-            path: '/photos',
-            element: <PhotoListPage />,
-            errorElement: <RouteErrorFallback backTo="/photos" />,
+            children: [
+              { path: '/photos' },
+              { path: '/upload', element: <UploadPage /> },
+            ],
           },
           {
             path: '/photos/:id',

--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -5,12 +5,17 @@ import {
   type QueryClient,
 } from '@tanstack/react-query';
 
+import { photoKeys, type PhotoListFilters } from './keys';
+import { toPhoto } from '../lib/mapper';
+import type {
+  InfiniteMedia,
+  MediaDto,
+  MediaListResponse,
+  Photo,
+} from '../model/types';
+
 import { buildQuery, http } from '@/shared/api';
 import { recordMediaListSlow } from '@/shared/lib/business-ux-logging';
-
-import { toPhoto } from '../lib/mapper';
-import type { MediaDto, MediaListResponse, Photo } from '../model/types';
-import { photoKeys, type PhotoListFilters } from './keys';
 
 const PAGE_SIZE = 20;
 
@@ -68,6 +73,35 @@ export function findPhotoInListCache(
   }
 
   return undefined;
+}
+
+/**
+ * 업로드 직후 새 사진을 목록 캐시 맨 앞에 낙관적으로 끼워넣는다.
+ * - 로컬 objectURL을 쓰므로 이 사진에 대한 별도 네트워크 요청은 없다.
+ * - 실제 서버 데이터는 다음 정상 fetch가 교체한다.
+ */
+export function prependMediaToLists(
+  queryClient: QueryClient,
+  dto: MediaDto,
+): void {
+  queryClient.setQueriesData<InfiniteMedia>(
+    { queryKey: photoKeys.lists() },
+    (data) => {
+      const first = data?.pages[0];
+      if (!data || !first) return data;
+
+      const exists = data.pages.some((page) =>
+        page.items.some((it) => it.id === dto.id),
+      );
+      if (exists) return data;
+
+      const updatedFirst: MediaListResponse = {
+        ...first,
+        items: [dto, ...first.items],
+      };
+      return { ...data, pages: [updatedFirst, ...data.pages.slice(1)] };
+    },
+  );
 }
 
 async function fetchPhotoDetail(id: string): Promise<Photo> {

--- a/apps/web/src/entities/photo/index.ts
+++ b/apps/web/src/entities/photo/index.ts
@@ -3,6 +3,7 @@ export {
   usePhotosInfinite,
   usePhotoDetail,
   findPhotoInListCache,
+  prependMediaToLists,
   selectPhotos,
   nextCursorOf,
 } from './api/queries';

--- a/apps/web/src/entities/photo/model/types.ts
+++ b/apps/web/src/entities/photo/model/types.ts
@@ -73,3 +73,9 @@ export interface MediaListResponse {
   items: MediaDto[];
   pagination: MediaPagination;
 }
+
+/** useInfiniteQuery 캐시 형태 (setQueriesData/getQueriesData용) */
+export interface InfiniteMedia {
+  pages: MediaListResponse[];
+  pageParams: unknown[];
+}

--- a/apps/web/src/features/photo-download/lib/downloader.ts
+++ b/apps/web/src/features/photo-download/lib/downloader.ts
@@ -13,6 +13,20 @@ export interface DownloadManyResult {
 
 const BATCH_DELAY_MS = 300; // 연속 다운로드를 브라우저가 차단하지 않도록 항목 간 간격
 
+// iOS Safari는 a[download]를 지원하지 않아 파일이 새 탭에서 열리기만 함 → Web Share로 우회
+function isIOS(): boolean {
+  return /iPhone|iPad|iPod/.test(navigator.userAgent);
+}
+
+function canUseWebShare(file: File): boolean {
+  return (
+    isIOS() &&
+    typeof navigator.share === 'function' &&
+    typeof navigator.canShare === 'function' &&
+    navigator.canShare({ files: [file] })
+  );
+}
+
 function triggerAnchor(href: string, filename: string): void {
   const anchor = document.createElement('a');
   anchor.href = href;
@@ -33,6 +47,18 @@ export async function downloadOne(target: DownloadTarget): Promise<void> {
     }
 
     const blob = await response.blob();
+
+    const file = new File([blob], target.filename, { type: blob.type });
+    if (canUseWebShare(file)) {
+      try {
+        await navigator.share({ files: [file] });
+        return;
+      } catch (err) {
+        // 사용자가 공유 시트를 취소하면 다운로드를 진행하지 않음
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+      }
+    }
+
     const objectUrl = URL.createObjectURL(blob);
 
     triggerAnchor(objectUrl, target.filename);

--- a/apps/web/src/features/photo-upload/model/runner.ts
+++ b/apps/web/src/features/photo-upload/model/runner.ts
@@ -1,4 +1,4 @@
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef } from 'react';
 
 import { useUploadQueueStore } from './store';
@@ -6,9 +6,13 @@ import type { UploadQueueItem } from './types';
 import { uploadSinglePhoto } from '../api/mutations';
 
 import { MAX_RETRY_COUNT } from '@/app/providers/constants';
-import { photoKeys } from '@/entities/photo/api/keys';
+import { prependMediaToLists, type MediaDto } from '@/entities/photo';
+import type { User } from '@/entities/user';
 import { track } from '@/shared/lib/analytics';
 import { recordNetworkRetryExceeded } from '@/shared/lib/business-ux-logging';
+import { toast } from '@/shared/ui/toast';
+
+const ANON_UPLOADER: User = { id: '', name: '', email: '' };
 
 function isAbortError(err: unknown): boolean {
   return err instanceof DOMException && err.name === 'AbortError';
@@ -33,6 +37,34 @@ function handleSuccess(
   store.setProgress(id, 100);
 }
 
+/**
+ * 업로드 성공 시 목록 캐시 맨 앞에 끼워넣을 낙관적 미디어를 만든다.
+ * - 표시 URL은 방금 고른 로컬 File의 objectURL → R2 재요청 없이 즉시 노출
+ * - 썸네일/eTag 등 서버 전용 필드는 비워두고, 실제 값은 다음 정상 fetch가 채운다
+ */
+function buildOptimisticDto(
+  mediaId: string,
+  item: UploadQueueItem,
+  description: string,
+  uploader: User,
+  objectUrl: string,
+): MediaDto {
+  return {
+    id: mediaId,
+    description,
+    state: 'COMPLETE',
+    isFavorite: false,
+    created: { at: new Date().toISOString(), by: uploader },
+    content: {
+      location: { url: objectUrl, accessUrl: objectUrl },
+      size: item.file.size,
+      eTag: '',
+      mimeType: item.file.type || 'application/octet-stream',
+      thumbnail: null,
+    },
+  };
+}
+
 function handleFailure(id: string, err: unknown): void {
   if (isAbortError(err)) return;
 
@@ -53,11 +85,36 @@ function handleFailure(id: string, err: unknown): void {
   });
 }
 
-export function useUploadRunner() {
+function prependUploaded(
+  queryClient: QueryClient,
+  mediaId: string,
+  item: UploadQueueItem,
+  description: string,
+  uploader: User,
+): void {
+  const objectUrl = URL.createObjectURL(item.file);
+  const dto = buildOptimisticDto(
+    mediaId,
+    item,
+    description,
+    uploader,
+    objectUrl,
+  );
+  prependMediaToLists(queryClient, dto);
+}
+
+export function useUploadRunner(
+  currentUser?: User | null,
+  order: 'asc' | 'desc' = 'desc',
+) {
   const queryClient = useQueryClient();
   const abortersRef = useRef(new Map<string, AbortController>());
   const sessionStartRef = useRef<number | null>(null);
   const sessionItemIdsRef = useRef<Set<string>>(new Set());
+  const uploaderRef = useRef<User>(currentUser ?? ANON_UPLOADER);
+  uploaderRef.current = currentUser ?? ANON_UPLOADER;
+  const orderRef = useRef(order);
+  orderRef.current = order;
 
   useEffect(() => {
     let unmounted = false;
@@ -78,6 +135,18 @@ export function useUploadRunner() {
         });
 
         handleSuccess(item.id, mediaId, sentDescription);
+
+        // asc는 맨 앞 prepend가 오배치므로 건너뜀
+        if (orderRef.current === 'desc') {
+          prependUploaded(
+            queryClient,
+            mediaId,
+            item,
+            sentDescription,
+            uploaderRef.current,
+          );
+        }
+
         return true;
       } catch (err) {
         if (!controller.signal.aborted) {
@@ -117,6 +186,11 @@ export function useUploadRunner() {
         durMs: Date.now() - sessionStartRef.current,
       });
 
+      // asc는 prepend를 건너뛰므로 배치 완료 시 1회 토스트
+      if (orderRef.current === 'asc' && ok > 0) {
+        toast.success(`${ok}장 업로드 완료`);
+      }
+
       sessionStartRef.current = null;
       sessionItemIdsRef.current.clear();
     }
@@ -141,12 +215,8 @@ export function useUploadRunner() {
       state.setStatus(next.id, { status: 'uploading', step: 'create' });
       state.setProgress(next.id, 0);
 
-      const success = await runUpload(next);
+      await runUpload(next);
       useUploadQueueStore.getState().setRunning(false);
-
-      if (success) {
-        queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
-      }
 
       if (!unmounted) {
         queueMicrotask(() => void processNext());

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { ErrorBoundary } from '@/app/providers/error-boundary';
-import { useAlbumStore, useCurrentAlbumRole } from '@/entities/album';
+import {
+  useAlbums,
+  useAlbumStore,
+  useCurrentAlbumRole,
+} from '@/entities/album';
 import {
   PhotoCard,
   selectPhotos,
@@ -102,6 +106,10 @@ export function PhotoListPage() {
   const selectedIds = useSelectedIds();
 
   const albumId = useAlbumStore((s) => s.current?.id);
+
+  const albumsQuery = useAlbums();
+  const albumsSettled = albumsQuery.isSuccess || albumsQuery.isError;
+
   const query = usePhotosInfinite(
     { sortBy: 'createdAt', order },
     { enabled: !!albumId },
@@ -157,7 +165,7 @@ export function PhotoListPage() {
       <ErrorBoundary fallback={(error) => <GridErrorFallback error={error} />}>
         <PhotoGrid
           photos={photos}
-          isLoading={!albumId || query.isLoading}
+          isLoading={!albumsSettled || query.isLoading}
           isFetchingNextPage={query.isFetchingNextPage}
           hasNextPage={!!query.hasNextPage}
           onLoadMore={() => query.fetchNextPage()}

--- a/apps/web/src/pages/upload/model/use-description-editor.ts
+++ b/apps/web/src/pages/upload/model/use-description-editor.ts
@@ -1,0 +1,51 @@
+import { useUpdatePhotoMetaMutation } from '@/entities/photo';
+import {
+  useUploadQueueStore,
+  type UploadQueueItem,
+} from '@/features/photo-upload';
+
+/**
+ * 선택된 업로드 항목의 설명 편집
+ * - value/change: 입력값(원본, 미트림)과 갱신
+ * - canEdit: 업로드 성공한 항목만 편집 가능
+ * - canSave/saved: 트림 비교로 저장 가능/이미 저장됨 판정
+ * - save: 서버 반영 후 큐의 syncedDescription을 동기화
+ */
+export function useDescriptionEditor(
+  selectedItem: UploadQueueItem | undefined,
+) {
+  const updateDescription = useUploadQueueStore((s) => s.updateDescription);
+  const setStatus = useUploadQueueStore((s) => s.setStatus);
+  const updateMeta = useUpdatePhotoMetaMutation();
+
+  const value = selectedItem?.description ?? '';
+  const desc = value.trim();
+  const synced = (selectedItem?.syncedDescription ?? '').trim();
+
+  const canEdit = selectedItem?.status === 'success';
+  const canSave = !!selectedItem?.mediaId && desc.length > 0 && desc !== synced;
+  const saved = !!selectedItem?.mediaId && desc.length > 0 && desc === synced;
+
+  const change = (next: string) => {
+    if (selectedItem) updateDescription(selectedItem.id, next);
+  };
+
+  const save = () => {
+    if (!selectedItem?.mediaId || !canSave) return;
+    const id = selectedItem.id;
+    updateMeta.mutate(
+      { id: selectedItem.mediaId, description: desc },
+      { onSuccess: () => setStatus(id, { syncedDescription: desc }) },
+    );
+  };
+
+  return {
+    value,
+    change,
+    canEdit,
+    canSave,
+    saved,
+    save,
+    isSaving: updateMeta.isPending,
+  };
+}

--- a/apps/web/src/pages/upload/model/use-sheet-close.ts
+++ b/apps/web/src/pages/upload/model/use-sheet-close.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useUploadQueueStore } from '@/features/photo-upload';
+
+/**
+ * 업로드 시트 닫기(딤 클릭·ESC·완료 버튼 공용).
+ * - 업로드 중(pending·uploading)이면 무시 — 중단은 "취소" 버튼으로만.
+ * - 닫힐 때 큐를 비우고 /photos로 이동.
+ */
+export function useSheetClose(): () => void {
+  const reset = useUploadQueueStore((s) => s.reset);
+  const navigate = useNavigate();
+
+  const close = useCallback(() => {
+    const flying = useUploadQueueStore
+      .getState()
+      .items.some((i) => i.status === 'pending' || i.status === 'uploading');
+    if (flying) return;
+
+    reset();
+    navigate('/photos');
+  }, [reset, navigate]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [close]);
+
+  return close;
+}

--- a/apps/web/src/pages/upload/ui/page.tsx
+++ b/apps/web/src/pages/upload/ui/page.tsx
@@ -1,86 +1,42 @@
 import { Check } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 
-import { useUpdatePhotoMetaMutation } from '@/entities/photo';
+import { useDescriptionEditor } from '../model/use-description-editor';
+import { useSheetClose } from '../model/use-sheet-close';
+
+import { useAuthUser } from '@/features/auth';
+import { usePhotoSortStore } from '@/features/photo-sort';
 import {
   UploadDropzone,
   UploadItem,
   useUploadQueueStore,
   useUploadRunner,
 } from '@/features/photo-upload';
-import { PhotoListPage } from '@/pages/photo-list'; // TODO: 목록 콘텐츠 widget 추출/라우터 오버레이
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
 
 export function UploadPage() {
   const items = useUploadQueueStore((s) => s.items);
-  const reset = useUploadQueueStore((s) => s.reset);
-  const updateDescription = useUploadQueueStore((s) => s.updateDescription);
-  const setStatus = useUploadQueueStore((s) => s.setStatus);
 
-  const { cancel, cancelAll } = useUploadRunner();
-  const updateMeta = useUpdatePhotoMetaMutation();
+  const user = useAuthUser();
+  const order = usePhotoSortStore((s) => s.order);
+  const { cancel, cancelAll } = useUploadRunner(user, order);
 
-  const navigate = useNavigate();
-
-  // 딤·ESC 닫기 (업로드 중엔 무시, 중단은 "취소" 버튼으로)
-  const close = useCallback(() => {
-    const flying = useUploadQueueStore
-      .getState()
-      .items.some((i) => i.status === 'pending' || i.status === 'uploading');
-    if (flying) return;
-
-    reset();
-    navigate('/photos');
-  }, [reset, navigate]);
+  const close = useSheetClose();
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const selectedItem = items.find((i) => i.id === selectedId) ?? items[0];
-
   const inFlight = items.some(
     (i) => i.status === 'pending' || i.status === 'uploading',
   );
 
-  const canEditDesc = selectedItem?.status === 'success';
-
-  const selectedDesc = (selectedItem?.description ?? '').trim();
-  const selectedSynced = (selectedItem?.syncedDescription ?? '').trim();
-  const canSaveDesc =
-    !!selectedItem?.mediaId &&
-    selectedDesc.length > 0 &&
-    selectedDesc !== selectedSynced;
-  const descSaved =
-    !!selectedItem?.mediaId &&
-    selectedDesc.length > 0 &&
-    selectedDesc === selectedSynced;
-
-  const handleSaveDescription = () => {
-    if (!selectedItem?.mediaId || !canSaveDesc) return;
-    const id = selectedItem.id;
-    updateMeta.mutate(
-      { id: selectedItem.mediaId, description: selectedDesc },
-      { onSuccess: () => setStatus(id, { syncedDescription: selectedDesc }) },
-    );
-  };
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [close]);
+  const desc = useDescriptionEditor(selectedItem);
 
   const hasItems = items.length > 0;
 
   return (
     <>
-      {/* 배경 */}
-      <div aria-hidden className="pointer-events-none">
-        <PhotoListPage />
-      </div>
-      {/* 딤 (클릭 시 닫기) */}
+      {/* 딤 (클릭 시 닫기) — 배경 목록은 라우터 레이아웃이 유지(재마운트/재요청 없음) */}
       <button
         type="button"
         aria-label="닫기"
@@ -124,16 +80,13 @@ export function UploadPage() {
               {/* 설명 + 저장 (선택사항) */}
               <div className="flex items-center gap-2 px-6">
                 <Input
-                  value={selectedItem?.description ?? ''}
-                  onChange={(e) =>
-                    selectedItem &&
-                    updateDescription(selectedItem.id, e.target.value)
-                  }
-                  disabled={!canEditDesc}
+                  value={desc.value}
+                  onChange={(e) => desc.change(e.target.value)}
+                  disabled={!desc.canEdit}
                   placeholder={
                     !selectedItem
                       ? ''
-                      : canEditDesc
+                      : desc.canEdit
                         ? `${selectedItem.file.name}에 남기실 말이 있으신가요?`
                         : '업로드되면 설명을 남길 수 있어요'
                   }
@@ -142,16 +95,16 @@ export function UploadPage() {
                 />
                 <Button
                   type="button"
-                  onClick={handleSaveDescription}
-                  disabled={!canSaveDesc || updateMeta.isPending}
+                  onClick={desc.save}
+                  disabled={!desc.canSave || desc.isSaving}
                   className="h-[45px] shrink-0 gap-1 rounded-[14px] px-4"
                 >
-                  {descSaved ? (
+                  {desc.saved ? (
                     <>
                       <Check className="size-4" />
                       저장됨
                     </>
-                  ) : updateMeta.isPending ? (
+                  ) : desc.isSaving ? (
                     '저장 중…'
                   ) : (
                     '저장'

--- a/apps/web/src/widgets/photo-grid/ui/photo-grid.tsx
+++ b/apps/web/src/widgets/photo-grid/ui/photo-grid.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
 import { ImageIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
 
 import type { Photo } from '@/entities/photo';
 import { useIntersection } from '@/shared/lib/hooks/use-intersection';
@@ -16,25 +16,40 @@ interface PhotoGridProps {
   emptyAction?: ReactNode;
 }
 
-// CSS 멀티컬럼 메이슨리: 2열, 카드 높이는 사진 비율대로 제각각.
-const MASONRY_CLASS = 'columns-2 gap-3';
-const ITEM_CLASS = 'mb-3 break-inside-avoid';
+const COLUMN_COUNT = 2;
+const MASONRY_CLASS = 'flex gap-3';
+const COLUMN_CLASS = 'flex flex-1 flex-col gap-3 min-w-0';
+
+// 라운드로빈으로 열에 나눠 담아 행 우선 읽기 순서 유지
+// [0,1,2,3,4,5] → [[0,2,4],[1,3,5]]
+function toColumns<T>(items: T[], columns: number): T[][] {
+  const buckets: T[][] = Array.from({ length: columns }, () => []);
+  items.forEach((item, i) => buckets[i % columns]!.push(item));
+  return buckets;
+}
 
 // 메이슨리 느낌의 스켈레톤(높이 제각각)
 const SKELETON_HEIGHTS = ['h-40', 'h-56', 'h-44', 'h-64', 'h-48', 'h-52'];
 
 function GridSkeleton({ count = 12 }: { count?: number }) {
+  const columns = toColumns(
+    Array.from({ length: count }, (_, i) => i),
+    COLUMN_COUNT,
+  );
   return (
     <div className={MASONRY_CLASS}>
-      {Array.from({ length: count }, (_, i) => (
-        <Skeleton
-          key={i}
-          className={cn(
-            'w-full rounded-2xl bg-black/5 dark:bg-white/5',
-            ITEM_CLASS,
-            SKELETON_HEIGHTS[i % SKELETON_HEIGHTS.length],
-          )}
-        />
+      {columns.map((col, c) => (
+        <div key={c} className={COLUMN_CLASS}>
+          {col.map((i) => (
+            <Skeleton
+              key={i}
+              className={cn(
+                'w-full rounded-2xl bg-black/5 dark:bg-white/5',
+                SKELETON_HEIGHTS[i % SKELETON_HEIGHTS.length],
+              )}
+            />
+          ))}
+        </div>
       ))}
     </div>
   );
@@ -75,9 +90,9 @@ export function PhotoGrid({
   return (
     <div className="space-y-3">
       <div className={MASONRY_CLASS}>
-        {photos.map((photo) => (
-          <div key={photo.id} className={ITEM_CLASS}>
-            {renderCard(photo)}
+        {toColumns(photos, COLUMN_COUNT).map((col, c) => (
+          <div key={c} className={COLUMN_CLASS}>
+            {col.map((photo) => renderCard(photo))}
           </div>
         ))}
       </div>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,7 +47,7 @@ export default tseslint.config({
       "warn",
       { argsIgnorePattern: "^_" },
     ],
-    eqeqeq: ["error", "always"],
+    eqeqeq: ["error", "always", { null: "ignore" }],
     curly: ["error", "all"],
   },
 }, prettier, storybook.configs["flat/recommended"]);


### PR DESCRIPTION
## 📌 관련 이슈

* #109  

---

## 🧹 작업 내용

배포 모바일 QA(#109) 중 **원인이 규명된 항목**을 1차로 묶어 수정했습니다.

원인이 불명확한
- 탭 전환 시 헤더 먹통
- 업로드시 레이아웃 깨짐
이 작업은 별도 브랜치에서 진행합니다.  

| 문제 | 원인 | 조치 |
|---|---|---|
| 다량 업로드 시 하얀 화면 + 자동 새로고침 (P0) | 인앱 브라우저 메모리 폭증 (업로드마다 목록 전체 재요청·재디코딩) | 전체 invalidate → 로컬 blob 낙관적 prepend / 공통 레이아웃 + Outlet 오버레이로 시트 진입 시 목록 재마운트 제거 |
| 최신순 정렬이 안 먹는 것처럼 보임 | 메이슨리 열 우선 배치 | 행 우선 배치로 변경해 읽는 순서 확보 |
| 로딩 스켈레톤 오노출 | 인증 미확정 상태와 로딩 상태 미분리 | 두 상태 분리해 스켈레톤 오노출 제거 |
| iOS 사진 다운로드 안 됨 | Safari 다운로드 제약 | Web Share로 다운로드 지원 (FE 몫) |
| eqeqeq 린트 충돌 | null/undefined 동시 체크 관용구 차단 | == null / != null만 예외 허용 |

## 🔍 고민 / 결정 사항

- **전체 invalidate 대신 낙관적 prepend**: 업로드당 전체 refetch가 원본 동시 재디코딩을 유발해 크래시
    - 방금 고른 로컬 File `objectURL`로 새 사진만 캐시 앞에 끼워 넣어 회피
    - 실제 서버 데이터는 다음 fetch가 교체
- **오래된순(asc)은 prepend를 하지 않음**: asc에서 새 사진의 제자리는 맨 끝이라 맨 앞 삽입은 오배치
    - 삽입을 생략하고 **배치 완료 시 토스트 1회**로만 안내(장마다 X → 토스트 폭주 방지) 
    - desc는 맨 앞이 제자리라 기존 낙관적 삽입 유지.

## 💬 참고 사항

- **재QA 필요**: 실기기 다량 업로드(10~15장) 크래시 여부, 오래된순 토스트 1회 확인.