### PR TITLE
[Feat] 앨범 여러 개일 때 선택해 진입하는 화면 추가

### DIFF
--- a/apps/web/src/app/providers/auth-guard.tsx
+++ b/apps/web/src/app/providers/auth-guard.tsx
@@ -68,13 +68,14 @@ export function AuthGuard() {
   useEffect(() => {
     if (!albumsQuery.isSuccess) return;
 
-    const first = albumsQuery.data[0] ?? null;
-    const shouldUpdate = first !== null && first.id !== currentAlbum?.id;
-
-    if (shouldUpdate) {
-      setAlbum(first);
+    // 앨범 접근권을 잃었으면(강퇴/삭제) 선택 해제
+    if (currentAlbum) {
+      const stillExists = albumsQuery.data.some(
+        (a) => a.id === currentAlbum.id,
+      );
+      if (!stillExists) setAlbum(null);
     }
-  }, [albumsQuery.isSuccess, albumsQuery.data, currentAlbum?.id, setAlbum]);
+  }, [albumsQuery.isSuccess, albumsQuery.data, currentAlbum, setAlbum]);
 
   const isPublic = PUBLIC_PATHS.has(location.pathname);
 
@@ -95,6 +96,19 @@ export function AuthGuard() {
   const isAlreadyLoggedIn = status === 'authenticated' && isPublic;
   if (isAlreadyLoggedIn) {
     return <Navigate to="/photos" replace />;
+  }
+
+  // /albums는 제외 — 안 그러면 무한 리다이렉트
+  const isAlbumSelectRoute = location.pathname === '/albums';
+  const needsAlbumSelection =
+    status === 'authenticated' &&
+    !isPublic &&
+    !isAlbumSelectRoute &&
+    !currentAlbum;
+
+  if (needsAlbumSelection) {
+    if (albumsQuery.isPending) return <GuardFallback />;
+    return <Navigate to="/albums" replace />;
   }
 
   const isEditorRoute = isEditorOnly(location.pathname);

--- a/apps/web/src/app/providers/router.tsx
+++ b/apps/web/src/app/providers/router.tsx
@@ -8,6 +8,7 @@ import {
 import { AuthGuard } from './auth-guard';
 import { RouteErrorFallback } from './route-error-fallback';
 
+import { AlbumSelectPage } from '@/pages/album-select';
 import { AuthPage } from '@/pages/auth';
 import { PhotoDetailPage } from '@/pages/photo-detail';
 import { PhotoListPage } from '@/pages/photo-list';
@@ -68,6 +69,11 @@ const router = createBrowserRouter([
             path: '/login',
             element: <AuthPage />,
             errorElement: <RouteErrorFallback backTo="/login" />,
+          },
+          {
+            path: '/albums',
+            element: <AlbumSelectPage />,
+            errorElement: <RouteErrorFallback backTo="/albums" />,
           },
           {
             element: <PhotoListLayout />,

--- a/apps/web/src/app/styles/globals.css
+++ b/apps/web/src/app/styles/globals.css
@@ -28,6 +28,9 @@
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
 
+  /* 메인(즐겨찾기) 앨범 별 — 라이트 핑크 / 다크 옐로우 */
+  --color-favorite: var(--favorite);
+
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -59,6 +62,7 @@
   --ring: #0066ff;
   --brand: #1a6bff;
   --brand-foreground: #ffffff;
+  --favorite: #ff4081;
   --radius: 0.875rem; /* 14px — 시안 버튼 곡률 기준 */
 }
 
@@ -84,6 +88,7 @@
   --ring: #00f0ff;
   --brand: #1a6bff;
   --brand-foreground: #ffffff;
+  --favorite: #ffd600;
 }
 
 @layer base {

--- a/apps/web/src/entities/album/index.ts
+++ b/apps/web/src/entities/album/index.ts
@@ -3,4 +3,5 @@ export { useAlbums } from './api/queries';
 
 export type { Album } from './model/types';
 export { useAlbumStore } from './model/store';
+export { useMainAlbumStore } from './model/main-store';
 export { useCurrentAlbumRole } from './model/selectors';

--- a/apps/web/src/entities/album/model/main-store.ts
+++ b/apps/web/src/entities/album/model/main-store.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+interface MainAlbumState {
+  mainAlbumId: string | null;
+  setMain: (albumId: string | null) => void;
+}
+
+const STORAGE_KEY = 'joka-main-album';
+const isBrowser = typeof window !== 'undefined';
+
+function getInitial(): string | null {
+  return isBrowser ? localStorage.getItem(STORAGE_KEY) : null;
+}
+
+// TODO: 서버 영속화 API가 생기면 localStorage 대신 사용자 계정에 저장
+export const useMainAlbumStore = create<MainAlbumState>((set) => ({
+  mainAlbumId: getInitial(),
+  setMain: (albumId) => {
+    set({ mainAlbumId: albumId });
+
+    if (!isBrowser) return;
+    if (albumId) localStorage.setItem(STORAGE_KEY, albumId);
+    else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  },
+}));

--- a/apps/web/src/pages/album-select/index.ts
+++ b/apps/web/src/pages/album-select/index.ts
@@ -1,0 +1,1 @@
+export { AlbumSelectPage } from './ui/page';

--- a/apps/web/src/pages/album-select/model/use-delayed-enter.ts
+++ b/apps/web/src/pages/album-select/model/use-delayed-enter.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import type { Album } from '@/entities/album';
+
+/**
+ * enterAlbum을 지연 실행한다.
+ * - 재예약/언마운트 시 이전 타이머를 취소한다.
+ */
+export function useDelayedEnter(enterAlbum: (album: Album) => void) {
+  const timerRef = useRef<number | undefined>(undefined);
+
+  const cancel = useCallback(() => {
+    window.clearTimeout(timerRef.current);
+  }, []);
+
+  const schedule = useCallback(
+    (album: Album, delay: number) => {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => enterAlbum(album), delay);
+    },
+    [enterAlbum],
+  );
+
+  useEffect(() => cancel, [cancel]);
+
+  return { schedule, cancel };
+}

--- a/apps/web/src/pages/album-select/ui/album-card.stories.tsx
+++ b/apps/web/src/pages/album-select/ui/album-card.stories.tsx
@@ -1,0 +1,48 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
+
+import { AlbumCard } from './album-card';
+
+import type { Album } from '@/entities/album';
+
+const editable: Album = { id: '1', name: '민준이네 가족', role: 'EDITOR' };
+const viewer: Album = { id: '2', name: '외갓집 사진첩', role: 'VIEWER' };
+
+const constrainWidth: Decorator = (Story) => (
+  <div style={{ maxWidth: 360 }}>
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: 'pages/AlbumSelect/AlbumCard',
+  component: AlbumCard,
+  parameters: { layout: 'padded' },
+  decorators: [constrainWidth],
+  args: {
+    isMain: false,
+    isSelected: false,
+    onSelect: () => {},
+    onToggleMain: () => {},
+  },
+} satisfies Meta<typeof AlbumCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Editable: Story = { args: { album: editable } };
+
+export const Viewer: Story = { args: { album: viewer } };
+
+export const MainStarred: Story = { args: { album: editable, isMain: true } };
+
+export const Selected: Story = { args: { album: editable, isSelected: true } };
+
+export const LongName: Story = {
+  args: {
+    album: {
+      id: '3',
+      name: '정말 길고 긴 우리 가족 사진첩 이름 테스트용',
+      role: 'ADMIN',
+    },
+  },
+};

--- a/apps/web/src/pages/album-select/ui/album-card.tsx
+++ b/apps/web/src/pages/album-select/ui/album-card.tsx
@@ -1,0 +1,91 @@
+import { Check, ChevronRight, Star } from 'lucide-react';
+
+import type { Album } from '@/entities/album';
+import { canUpload } from '@/features/auth';
+import { cn } from '@/shared/lib/utils/cn';
+
+interface AlbumCardProps {
+  album: Album;
+  isMain: boolean;
+  isSelected: boolean;
+  onSelect: () => void;
+  onToggleMain: () => void;
+}
+
+export function AlbumCard({
+  album,
+  isMain,
+  isSelected,
+  onSelect,
+  onToggleMain,
+}: AlbumCardProps) {
+  const editable = canUpload(album.role);
+
+  return (
+    <div className="relative">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onSelect();
+          }
+        }}
+        className="flex w-full cursor-pointer items-center justify-between gap-3.5 rounded-[20px] bg-muted p-5 transition-transform duration-[140ms] ease-[cubic-bezier(.2,0,0,1)] active:scale-[0.98]"
+      >
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <span className="truncate text-[17px] font-semibold leading-[25.5px] tracking-[-0.432px] text-foreground">
+            {album.name}
+          </span>
+          <span
+            className={cn(
+              'inline-flex w-fit self-start whitespace-nowrap rounded-full px-2.5 py-[3px] text-[13px] font-medium',
+              editable
+                ? 'bg-primary/15 text-primary'
+                : 'bg-background text-muted-foreground',
+            )}
+          >
+            {editable ? '편집 가능' : '열람 전용'}
+          </span>
+        </div>
+
+        <div className="flex flex-shrink-0 items-center gap-2">
+          <button
+            type="button"
+            aria-label={isMain ? '메인 앨범으로 지정됨' : '메인 앨범으로 지정'}
+            aria-pressed={isMain}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleMain();
+            }}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full transition-transform duration-[140ms] ease-[cubic-bezier(.2,0,0,1)] active:scale-[0.88]"
+          >
+            <Star
+              className={cn(
+                'h-5 w-5',
+                isMain
+                  ? 'fill-favorite text-favorite'
+                  : 'fill-none text-muted-foreground/70',
+              )}
+              strokeWidth={1.5}
+            />
+          </button>
+
+          {isSelected ? (
+            <span className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-full bg-primary text-primary-foreground">
+              <Check className="h-3.5 w-3.5" strokeWidth={3} />
+            </span>
+          ) : (
+            <ChevronRight className="h-[18px] w-[18px] text-muted-foreground/70" />
+          )}
+        </div>
+      </div>
+
+      {isSelected && (
+        <div className="pointer-events-none absolute -inset-0.5 rounded-[22px] border-2 border-primary" />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/album-select/ui/page.stories.tsx
+++ b/apps/web/src/pages/album-select/ui/page.stories.tsx
@@ -1,0 +1,85 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import { AlbumSelectPage } from './page';
+
+import { albumKeys, type Album } from '@/entities/album';
+
+const ALBUMS: Album[] = [
+  { id: '1', name: '민준이네 가족', role: 'EDITOR' },
+  { id: '2', name: '외갓집 사진첩', role: 'VIEWER' },
+  { id: '3', name: '이모네랑 함께', role: 'ADMIN' },
+  { id: '4', name: '돌잔치 기록', role: 'VIEWER' },
+];
+
+// MSW 대신 story별로 fetch/캐시를 직접 제어
+function withClient(seed?: (queryClient: QueryClient) => void): Decorator {
+  return (Story) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    seed?.(queryClient);
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/albums']}>
+          <Story />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const seededWith = (data: Album[]) => (queryClient: QueryClient) => {
+  queryClient.setQueryData(albumKeys.list(), data);
+};
+
+const meta = {
+  title: 'pages/AlbumSelect/Page',
+  component: AlbumSelectPage,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof AlbumSelectPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Multiple: Story = {
+  name: 'Multiple Albums',
+  decorators: [withClient(seededWith(ALBUMS))],
+};
+
+export const Single: Story = {
+  name: 'Single Album',
+  decorators: [withClient(seededWith([ALBUMS[0]]))],
+};
+
+export const Empty: Story = {
+  name: 'Empty State',
+  decorators: [withClient(seededWith([]))],
+};
+
+export const Loading: Story = {
+  name: 'Loading State',
+  decorators: [withClient()],
+  async beforeEach() {
+    const originalFetch = window.fetch;
+    // pending 상태를 영구 유지해 로딩 UI를 고정
+    window.fetch = () => new Promise<Response>(() => {});
+    return () => {
+      window.fetch = originalFetch;
+    };
+  },
+};
+
+export const Errored: Story = {
+  name: 'Error State',
+  decorators: [withClient()],
+  async beforeEach() {
+    const originalFetch = window.fetch;
+
+    window.fetch = () => Promise.reject(new Error('network unavailable'));
+    return () => {
+      window.fetch = originalFetch;
+    };
+  },
+};

--- a/apps/web/src/pages/album-select/ui/page.tsx
+++ b/apps/web/src/pages/album-select/ui/page.tsx
@@ -1,0 +1,147 @@
+import { RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { AlbumCard } from './album-card';
+import { EmptyState, ErrorState, LoadingState } from './states';
+import { useDelayedEnter } from '../model/use-delayed-enter';
+
+import {
+  useAlbums,
+  useAlbumStore,
+  useMainAlbumStore,
+  type Album,
+} from '@/entities/album';
+import { canUpload } from '@/features/auth';
+import { track } from '@/shared/lib/analytics';
+
+// 탭 후 배너를 잠깐 보여준 뒤 진입
+const NAV_DELAY_MS = 450;
+const SINGLE_AUTO_ENTER_MS = 1500;
+
+export function AlbumSelectPage() {
+  const navigate = useNavigate();
+  const albumsQuery = useAlbums();
+
+  const setCurrent = useAlbumStore((s) => s.setCurrent);
+  const mainAlbumId = useMainAlbumStore((s) => s.mainAlbumId);
+  const setMain = useMainAlbumStore((s) => s.setMain);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const enteredRef = useRef(false);
+
+  // 메인 앨범을 맨 위로, 나머지는 이름 가나다순
+  const albums = useMemo(() => {
+    const list = albumsQuery.data ?? [];
+    return [...list].sort((a, b) => {
+      if (a.id === mainAlbumId) return -1;
+      if (b.id === mainAlbumId) return 1;
+      return a.name.localeCompare(b.name, 'ko');
+    });
+  }, [albumsQuery.data, mainAlbumId]);
+
+  const enterAlbum = useCallback(
+    (album: Album) => {
+      if (enteredRef.current) return;
+      enteredRef.current = true;
+
+      track('album.select', { editable: canUpload(album.role) });
+
+      setCurrent(album);
+      navigate('/photos', { replace: true });
+    },
+    [setCurrent, navigate],
+  );
+
+  const { schedule: scheduleEnter, cancel: cancelEnter } =
+    useDelayedEnter(enterAlbum);
+
+  const isSingle = albumsQuery.isSuccess && albums.length === 1;
+  const singleAlbum = isSingle ? albums[0] : null;
+
+  const listViewTracked = useRef(false);
+  useEffect(() => {
+    if (albumsQuery.isSuccess && !listViewTracked.current) {
+      listViewTracked.current = true;
+      track('album.list_view', { count: albumsQuery.data.length });
+    }
+  }, [albumsQuery.isSuccess, albumsQuery.data]);
+
+  // 앨범이 하나뿐이면 안내 배너를 최소 1.5초 보여준 뒤 자동 진입
+  useEffect(() => {
+    if (!singleAlbum) return;
+
+    scheduleEnter(singleAlbum, SINGLE_AUTO_ENTER_MS);
+    return cancelEnter;
+  }, [singleAlbum, scheduleEnter, cancelEnter]);
+
+  const handleSelect = (album: Album) => {
+    if (selectedId || enteredRef.current) return; // 중복 트리거 방지
+
+    setSelectedId(album.id);
+    scheduleEnter(album, NAV_DELAY_MS);
+  };
+
+  // 앨범이 하나뿐이면 선택 연출 생략하고 즉시 진입, 여러 개면 선택 표시 후 진입
+  const handleAlbumTap = (album: Album) => {
+    if (isSingle) {
+      enterAlbum(album);
+    } else {
+      handleSelect(album);
+    }
+  };
+
+  if (albumsQuery.isLoading) return <LoadingState />;
+  if (albumsQuery.isError) {
+    return <ErrorState onRetry={() => albumsQuery.refetch()} />;
+  }
+  if (albums.length === 0) return <EmptyState />;
+
+  const selected = albums.find((album) => album.id === selectedId) ?? null;
+
+  return (
+    <section className="mx-auto w-full max-w-md px-6 pt-6">
+      <header className="mb-5">
+        <h1 className="text-[22px] font-bold leading-[33px] text-foreground">
+          앨범을 선택해주세요
+        </h1>
+        <p className="mt-1 text-[15px] leading-[22.5px] tracking-[-0.2px] text-muted-foreground">
+          {isSingle
+            ? '들어갈 앨범을 골라주세요'
+            : '속한 앨범 중 하나를 골라 들어가요'}
+        </p>
+      </header>
+
+      {isSingle && (
+        <div className="mb-4 flex items-center gap-2.5 rounded-[14px] bg-muted px-3.5 py-3">
+          <RefreshCw className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+          <span className="text-[13px] leading-[19.5px] text-muted-foreground">
+            앨범이 하나뿐이라 바로 들어갈게요
+          </span>
+        </div>
+      )}
+
+      <ul className="flex flex-col gap-3">
+        {albums.map((album) => (
+          <li key={album.id}>
+            <AlbumCard
+              album={album}
+              isMain={album.id === mainAlbumId}
+              isSelected={album.id === selectedId}
+              onSelect={() => handleAlbumTap(album)}
+              onToggleMain={() => setMain(album.id)}
+            />
+          </li>
+        ))}
+      </ul>
+
+      {selected && (
+        <div className="mt-4 flex items-center gap-2.5 rounded-[14px] bg-primary/10 px-4 py-3.5">
+          <p className="text-[13px] font-medium leading-[19.5px] text-primary">
+            {selected.name} 앨범으로 이동 중이에요
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/pages/album-select/ui/states.tsx
+++ b/apps/web/src/pages/album-select/ui/states.tsx
@@ -1,0 +1,95 @@
+import { ImageIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { Button } from '@/shared/ui/button';
+import { Skeleton } from '@/shared/ui/skeleton';
+
+/** 로딩 — 스켈레톤 카드 3개가 순차 딜레이로 펄스 */
+export function LoadingState() {
+  return (
+    <section className="mx-auto w-full max-w-md px-6 pt-6">
+      <header className="mb-5">
+        <h1 className="text-[22px] font-bold leading-[33px] text-foreground">
+          앨범을 불러오는 중
+        </h1>
+        <p className="mt-1 text-[15px] leading-[22.5px] tracking-[-0.2px] text-muted-foreground">
+          잠시만 기다려주세요
+        </p>
+      </header>
+      <div className="flex flex-col gap-3">
+        {[0, 0.15, 0.3].map((delay, index) => (
+          <Skeleton
+            key={index}
+            className="h-[84px] rounded-[20px]"
+            style={{ animationDelay: `${delay}s` }}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/** 에러 — 재시도 가능 */
+export function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <CenteredState
+      title="앨범을 불러오지 못했어요"
+      description={
+        <>
+          네트워크 연결을 확인하고
+          <br />
+          다시 시도해주세요
+        </>
+      }
+      action={
+        <Button variant="secondary" size="sm" onClick={onRetry}>
+          다시 시도
+        </Button>
+      }
+    />
+  );
+}
+
+/** 빈 상태 — 앨범은 운영자가 수동 생성하므로 사용자용 생성 CTA 없음(초대되면 나타남) */
+export function EmptyState() {
+  return (
+    <CenteredState
+      title="아직 함께한 앨범이 없어요"
+      description={
+        <>
+          가족에게 초대를 받으면
+          <br />이 자리에 앨범이 나타나요
+        </>
+      }
+    />
+  );
+}
+
+/** 아이콘 원 + 제목 + 본문(+선택적 액션)을 중앙 정렬하는 빈/에러 공통 레이아웃 */
+function CenteredState({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <section className="mx-auto flex min-h-[70vh] w-full max-w-md flex-col items-center justify-center gap-[22px] px-6 text-center">
+      <div className="flex h-[88px] w-[88px] items-center justify-center rounded-[28px] bg-muted">
+        <ImageIcon
+          className="h-[34px] w-[34px] text-muted-foreground/60"
+          strokeWidth={1.75}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="text-[17px] font-semibold text-foreground">{title}</p>
+        <p className="text-[15px] leading-[22.5px] text-muted-foreground">
+          {description}
+        </p>
+      </div>
+      {action}
+    </section>
+  );
+}

--- a/apps/web/src/shared/lib/analytics/types.ts
+++ b/apps/web/src/shared/lib/analytics/types.ts
@@ -3,6 +3,8 @@ import type { UserRole } from '@/entities/user';
 export type AnalyticsEvent =
   | 'auth.login_success'
   | 'auth.logout'
+  | 'album.list_view'
+  | 'album.select'
   | 'list.view'
   | 'list.scroll_depth'
   | 'detail.view'


### PR DESCRIPTION
## 📌 관련 이슈

* #118

---

## 🧹 작업 내용

원하는 앨범을 골라 진입하는 `/albums` 화면을 추가

* **선택 화면(`/albums`)**: 목록/한 개/빈/로딩/에러 상태 + 카드 탭 시 "이동 중" 배너 후 진입
* **앨범 1개**: 안내 배너("앨범이 하나뿐이라 바로 들어갈게요")를 1.5초 노출 후 자동 진입

---

  ## 🛠️  테스트

  * [x] 단위/스토리 테스트 통과 (Storybook 인터랙션 테스트 포함)
  * [x] 수동 테스트 완료 (Storybook에서 5개 상태 확인)
  * [x] 기존 기능 영향 없음 확인 (전체 테스트 통과)

---

## 📸 스크린샷


https://github.com/user-attachments/assets/5eb5e138-de55-4e06-8337-2466f1fb1a45


---

  ## 🔍 고민 / 결정 사항

> [!NOTE]
> 프론트에서 가나다순 정렬 및 메인 앨범(`localStoarge`) 지정으로 처리.  
> 서버 API 생기면 서버값으로 교체 예정.

  ---

  ## 💬 참고 사항

> [!NOTE]
> 앨범 생성은 **운영자가 수동으로 하는 정책**이기 때문에  
> 사용자용 **앨범 만들기** CTA는 생성하지 않음.  
