### PR TITLE
[Feat] Clarity 세션 분석 도입 및 API 타이밍 수집 파이프라인

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -3,3 +3,4 @@ VITE_API_BASE_URL=your-base-url
 VITE_AUTH_REFRESH_PATH=your-auth-refresh-path
 VITE_APP_VERSION=0.0.0
 CHROMATIC_PROJECT_TOKEN=your-chromatic-token
+VITE_CLARITY_PROJECT_ID=your-clarity-project-id

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-storybook": "^10.4.2",
     "jsdom": "^25.0.1",
     "playwright": "^1.60.0",
+    "rollup-plugin-visualizer": "^7.0.1",
     "storybook": "^10.4.2",
     "typescript": "^5.9.3",
     "vite": "^6.0.3",

--- a/apps/web/src/app/index.tsx
+++ b/apps/web/src/app/index.tsx
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createRoot } from 'react-dom/client';
 
+import { initClarity } from '@/app/providers/clarity';
 import { ErrorBoundary } from '@/app/providers/error-boundary';
 import { queryClient } from '@/app/providers/query-client';
 import { AppRouter } from '@/app/providers/router';
@@ -10,6 +11,7 @@ import { useAlbumStore } from '@/entities/album';
 import { useAuthStore } from '@/features/auth';
 import { initTheme } from '@/features/theme';
 import { initAnalytics, setRoleResolver } from '@/shared/lib/analytics';
+import { hasConsent } from '@/shared/lib/consent';
 import { Toaster } from '@/shared/ui/toast';
 import './styles/globals.css';
 
@@ -17,6 +19,9 @@ initSentry();
 initTheme();
 initAnalytics();
 setRoleResolver(() => useAlbumStore.getState().current?.role ?? null);
+if (hasConsent()) {
+  initClarity();
+}
 
 const root = document.getElementById('root');
 if (root) {

--- a/apps/web/src/app/providers/auth-guard.tsx
+++ b/apps/web/src/app/providers/auth-guard.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
+import { initClarity } from '@/app/providers/clarity';
 import { useAlbums, useAlbumStore } from '@/entities/album';
 import { useAuthStore, useMe, canUpload } from '@/features/auth';
+import { CLARITY_PENDING_KEY } from '@/features/auth/ui/login-form';
 import { authTokenStore } from '@/shared/api/auth-token';
 import { readCookie } from '@/shared/api/cookie';
 import { setAnalyticsUser, track } from '@/shared/lib/analytics';
+import { grantConsent, revokeConsent } from '@/shared/lib/consent';
 import { Skeleton } from '@/shared/ui/skeleton';
 
 const PUBLIC_PATHS = new Set(['/login']);
@@ -54,12 +57,19 @@ export function AuthGuard() {
         if (!loginTrackedRef.current) {
           loginTrackedRef.current = true;
           track('auth.login_success');
+
+          if (sessionStorage.getItem(CLARITY_PENDING_KEY)) {
+            sessionStorage.removeItem(CLARITY_PENDING_KEY);
+            grantConsent();
+            initClarity();
+          }
         }
       });
     } else if (meQuery.isError) {
       setUser(null);
       clearAlbum();
       void setAnalyticsUser(null);
+      revokeConsent();
     }
   }, [meQuery.isSuccess, meQuery.isError, meQuery.data, setUser, clearAlbum]);
 

--- a/apps/web/src/app/providers/clarity.ts
+++ b/apps/web/src/app/providers/clarity.ts
@@ -1,0 +1,27 @@
+type ClarityFn = ((...args: unknown[]) => void) & { q?: unknown[][] };
+
+declare global {
+  interface Window {
+    clarity?: ClarityFn;
+  }
+}
+
+export function initClarity(): void {
+  const projectId = import.meta.env.VITE_CLARITY_PROJECT_ID;
+  if (!projectId || window.clarity) return;
+
+  const q: unknown[][] = [];
+
+  // 스크립트 로딩 전 호출을 큐에 쌓아두는 스텁 (로딩 후 Clarity가 q를 읽어 처리)
+  window.clarity = Object.assign(
+    (...args: unknown[]) => {
+      (window.clarity!.q ??= []).push(args);
+    },
+    { q },
+  );
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.clarity.ms/tag/${projectId}`;
+  document.head.appendChild(script);
+}

--- a/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
+++ b/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
@@ -26,6 +26,7 @@ export function PhotoThumbnail({ src, alt, className }: PhotoThumbnailProps) {
           alt={alt}
           loading="lazy"
           decoding="async"
+          data-clarity-mask="True"
           onLoad={() => setLoaded(true)}
           className={cn(
             'block h-auto w-full transition-opacity duration-300',

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -13,3 +13,4 @@ export {
 } from './model/selectors';
 
 export { LoginForm } from './ui/login-form';
+export { AnalyticsConsent } from './ui/analytics-consent';

--- a/apps/web/src/features/auth/ui/analytics-consent.stories.tsx
+++ b/apps/web/src/features/auth/ui/analytics-consent.stories.tsx
@@ -7,6 +7,7 @@ import { AnalyticsConsent } from './analytics-consent';
 const meta = {
   title: 'features/auth/AnalyticsConsent',
   component: AnalyticsConsent,
+  args: { checked: false, onCheckedChange: () => {} },
   parameters: { layout: 'centered' },
 } satisfies Meta<typeof AnalyticsConsent>;
 

--- a/apps/web/src/features/auth/ui/analytics-consent.stories.tsx
+++ b/apps/web/src/features/auth/ui/analytics-consent.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { AnalyticsConsent } from './analytics-consent';
+
+const meta = {
+  title: 'features/auth/AnalyticsConsent',
+  component: AnalyticsConsent,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof AnalyticsConsent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ControlledConsent() {
+  const [checked, setChecked] = useState(false);
+  return <AnalyticsConsent checked={checked} onCheckedChange={setChecked} />;
+}
+
+// 기본: 미체크 상태로 시작
+export const Default: Story = {
+  render: () => <ControlledConsent />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('checkbox')).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  },
+};
+
+// 체크 토글 동작
+export const Checked: Story = {
+  render: () => <ControlledConsent />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('checkbox'));
+    await expect(canvas.getByRole('checkbox')).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  },
+};
+
+// 자세히(i) 클릭 시 안내 팝오버 노출
+export const WithTooltip: Story = {
+  render: () => <ControlledConsent />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '자세히' }));
+    await expect(canvas.getByRole('tooltip')).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/features/auth/ui/analytics-consent.tsx
+++ b/apps/web/src/features/auth/ui/analytics-consent.tsx
@@ -1,0 +1,93 @@
+import { Check, Info } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { cn } from '@/shared/lib/utils/cn';
+
+interface AnalyticsConsentProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export function AnalyticsConsent({
+  checked,
+  onCheckedChange,
+}: AnalyticsConsentProps) {
+  const [open, setOpen] = useState(false);
+  const toggle = () => onCheckedChange(!checked);
+
+  // Esc로 팝오버 닫기
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  return (
+    <div className="flex w-full items-start justify-center gap-2">
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked={checked}
+        aria-label="앱 개선을 위한 화면 분석에 동의"
+        onClick={toggle}
+        className={cn(
+          'mt-px flex size-[18px] shrink-0 items-center justify-center rounded-[5px] border transition-colors',
+          checked
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-[#d1d1d6] bg-transparent dark:border-border',
+        )}
+      >
+        {checked && <Check className="size-3" strokeWidth={3} />}
+      </button>
+
+      <label
+        onClick={toggle}
+        className="text-[13px] leading-[18px] tracking-[-0.08px] text-[#9a9aa0] dark:text-muted-foreground"
+      >
+        앱 개선을 위한 화면 분석에 동의합니다{' '}
+        <span className="whitespace-nowrap">(사진 제외)</span>
+      </label>
+
+      {/* 자세히 (i) — 팝오버 트리거 */}
+      <div className="relative">
+        <button
+          type="button"
+          aria-label="자세히"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          className="mt-px flex size-[18px] items-center justify-center rounded-full text-[#b3b3b8] transition-colors hover:text-[#7a7a80] dark:text-muted-foreground dark:hover:text-foreground/70"
+        >
+          <Info className="size-[15px]" />
+        </button>
+
+        {open && (
+          <>
+            {/* 바깥 클릭 닫기 */}
+            <button
+              type="button"
+              aria-hidden="true"
+              tabIndex={-1}
+              onClick={() => setOpen(false)}
+              className="fixed inset-0 z-40 cursor-default"
+            />
+            <div
+              role="tooltip"
+              className="absolute bottom-full right-0 z-50 mb-2 w-[240px] rounded-xl border border-border bg-card p-3 text-left text-[12px] leading-[17px] tracking-[-0.05px] text-card-foreground shadow-[0_6px_24px_rgba(60,70,120,0.18)]"
+            >
+              <p>
+                어떤 화면을 보고 어디서 헤매시는지 참고해서 앱을 개선합니다.
+              </p>
+              <p className="mt-1.5 text-muted-foreground">
+                사진(썸네일·상세 이미지)은 자동으로 가려져서 절대 수집되지
+                않아요.
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/auth/ui/login-form.tsx
+++ b/apps/web/src/features/auth/ui/login-form.tsx
@@ -1,9 +1,8 @@
 import { env } from '@/shared/config/env';
 import { Button } from '@/shared/ui/button';
 
-/**
- * 카카오 말풍선 아이콘.
- */
+export const CLARITY_PENDING_KEY = 'joka_clarity_pending';
+
 function KakaoIcon() {
   return (
     <svg
@@ -20,8 +19,15 @@ function KakaoIcon() {
 /**
  * 카카오 OAuth 시작 버튼.
  */
-export function LoginForm() {
+interface LoginFormProps {
+  clarityConsent?: boolean;
+}
+
+export function LoginForm({ clarityConsent = false }: LoginFormProps) {
   const handleKakaoLogin = () => {
+    if (clarityConsent) {
+      sessionStorage.setItem(CLARITY_PENDING_KEY, '1');
+    }
     window.location.href = `${env.VITE_API_BASE_URL}/v1/auth/kakao`;
   };
 

--- a/apps/web/src/pages/auth/ui/page.tsx
+++ b/apps/web/src/pages/auth/ui/page.tsx
@@ -1,9 +1,10 @@
 import { Lock } from 'lucide-react';
+import { useState } from 'react';
 
 import bgDark from '@/assets/bg-dark.webp';
 import bgLight from '@/assets/bg-light.webp';
 import character from '@/assets/character.webp';
-import { LoginForm } from '@/features/auth';
+import { AnalyticsConsent, LoginForm } from '@/features/auth';
 import { toast } from '@/shared/ui/toast';
 
 function InviteButton() {
@@ -24,6 +25,8 @@ function InviteButton() {
 }
 
 export function AuthPage() {
+  const [analyticsConsent, setAnalyticsConsent] = useState(false);
+
   return (
     <main className="relative flex min-h-screen flex-col overflow-hidden bg-muted">
       {/* 라이트는 슬로우 줌, 다크는 매달린 별 스웨이+밝기 맥동 */}
@@ -58,7 +61,7 @@ export function AuthPage() {
             aria-hidden="true"
           />
 
-          <LoginForm />
+          <LoginForm clarityConsent={analyticsConsent} />
 
           {/* 또는 구분선 */}
           <div className="flex w-full items-center gap-3">
@@ -78,6 +81,11 @@ export function AuthPage() {
             </span>
             에 동의하게 됩니다
           </p>
+
+          <AnalyticsConsent
+            checked={analyticsConsent}
+            onCheckedChange={setAnalyticsConsent}
+          />
         </div>
       </section>
     </main>

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -112,6 +112,7 @@ export function PhotoDetailPage() {
           <img
             src={photo.imageUrl}
             alt={photo.description}
+            data-clarity-mask="True"
             className="size-full object-contain"
           />
         )}

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -1,12 +1,14 @@
-import { env } from '@/shared/config/env';
-import { ApiError, reportApiError, toApiError } from './error';
-import { createRefresher } from './refresh';
 import { authTokenStore } from './auth-token';
+import { ApiError, reportApiError, toApiError } from './error';
 import {
   type ApiRequest,
   attachAuthHeader,
   attachAlbumHeader,
 } from './interceptors';
+import { createRefresher } from './refresh';
+
+import { env } from '@/shared/config/env';
+import { trackApiTiming } from '@/shared/lib/analytics';
 
 const DEFAULT_BASE_URL = env.VITE_API_BASE_URL;
 const DEFAULT_REFRESH_PATH = env.VITE_AUTH_REFRESH_PATH;
@@ -84,9 +86,17 @@ async function parseResponse(response: Response): Promise<unknown> {
 }
 
 async function sendRequest(ctx: ApiRequest): Promise<Response> {
+  const method = ctx.options.method ?? 'GET';
+  const start = performance.now();
+
   try {
-    return await fetch(ctx.url, ctx.options);
+    const response = await fetch(ctx.url, ctx.options);
+    trackApiTiming(ctx.url, method, performance.now() - start, response.status);
+    return response;
   } catch (cause) {
+    // 네트워크 실패도 status 0으로 계측 (이상치 분석에 포함)
+    trackApiTiming(ctx.url, method, performance.now() - start, 0);
+
     const err = new ApiError({
       status: 0,
       code: 'NETWORK',

--- a/apps/web/src/shared/lib/analytics/api-timing.ts
+++ b/apps/web/src/shared/lib/analytics/api-timing.ts
@@ -15,7 +15,7 @@ export function apiPathPattern(pathname: string): string {
  * API 호출 1건의 소요시간을 자체 이벤트 파이프라인으로 전량 수집한다.
  *
  * - path는 정규화하여 개인정보(원본 ID)를 배제하고 통계 그룹 키로만 사용.
- * - bypassRateLimit: 분당 상한에 걸려 계측이 유실되지 않도록 예외 처리.
+ * - raw: 전량 수집이 목적이므로 dedup·분당 상한을 모두 건너뛴다.
  */
 export function trackApiTiming(
   url: string,
@@ -25,7 +25,7 @@ export function trackApiTiming(
 ): void {
   let path: string;
   try {
-    path = apiPathPattern(new URL(url).pathname);
+    path = apiPathPattern(new URL(url, window.location.origin).pathname);
   } catch {
     path = url;
   }
@@ -33,6 +33,6 @@ export function trackApiTiming(
   track(
     'api.timing',
     { path, method, ms: Math.round(durationMs), status },
-    { bypassRateLimit: true },
+    { raw: true },
   );
 }

--- a/apps/web/src/shared/lib/analytics/api-timing.ts
+++ b/apps/web/src/shared/lib/analytics/api-timing.ts
@@ -1,0 +1,38 @@
+import { track } from './track';
+
+// API 경로의 UUID·숫자 세그먼트를 :id로 정규화
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function apiPathPattern(pathname: string): string {
+  return pathname
+    .split('/')
+    .map((seg) => (UUID_RE.test(seg) || /^\d+$/.test(seg) ? ':id' : seg))
+    .join('/');
+}
+
+/**
+ * API 호출 1건의 소요시간을 자체 이벤트 파이프라인으로 전량 수집한다.
+ *
+ * - path는 정규화하여 개인정보(원본 ID)를 배제하고 통계 그룹 키로만 사용.
+ * - bypassRateLimit: 분당 상한에 걸려 계측이 유실되지 않도록 예외 처리.
+ */
+export function trackApiTiming(
+  url: string,
+  method: string,
+  durationMs: number,
+  status: number,
+): void {
+  let path: string;
+  try {
+    path = apiPathPattern(new URL(url).pathname);
+  } catch {
+    path = url;
+  }
+
+  track(
+    'api.timing',
+    { path, method, ms: Math.round(durationMs), status },
+    { bypassRateLimit: true },
+  );
+}

--- a/apps/web/src/shared/lib/analytics/index.ts
+++ b/apps/web/src/shared/lib/analytics/index.ts
@@ -1,3 +1,4 @@
 export { track, flush, initAnalytics } from './track';
+export { trackApiTiming } from './api-timing';
 export { setAnalyticsUser, setRoleResolver } from './identity';
 export type { AnalyticsEvent, AnalyticsProps, EventEnvelope } from './types';

--- a/apps/web/src/shared/lib/analytics/track.test.ts
+++ b/apps/web/src/shared/lib/analytics/track.test.ts
@@ -63,10 +63,50 @@ describe('track / flush', () => {
   test('버퍼 임계치(20) 도달 시 자동 전송', () => {
     const fetchSpy = mockFetch();
 
-    for (let i = 0; i < 20; i += 1) track('list.view');
+    // props를 다르게 줘 dedup에 걸리지 않는 서로 다른 이벤트 20개
+    for (let i = 0; i < 20; i += 1) track('list.view', { i });
 
     expect(fetchSpy).toHaveBeenCalledOnce();
     expect(lastFetchBody(fetchSpy).events).toHaveLength(20);
+  });
+
+  // 정상 유저의 우발적 중복(StrictMode 이중 마운트·빠른 재렌더)과
+  // 코드 버그로 인한 폭주를 걸러, DB·서버리스 호출이 불필요하게 쌓이지 않게 한다
+  test('동일 이벤트 연타는 우발적 중복으로 접어 1건만 집계', () => {
+    const fetchSpy = mockFetch();
+
+    track('list.view');
+    track('list.view');
+    track('list.view');
+    flush();
+
+    expect(lastFetchBody(fetchSpy).events).toHaveLength(1);
+  });
+
+  test('dedup 창(500ms)이 지나면 같은 이벤트도 다시 집계', () => {
+    vi.useFakeTimers();
+    const fetchSpy = mockFetch();
+
+    track('list.view');
+    vi.advanceTimersByTime(600);
+    track('list.view');
+    flush();
+
+    expect(lastFetchBody(fetchSpy).events).toHaveLength(2);
+  });
+
+  test('분당 상한(120)을 넘는 폭주는 조용히 드롭', () => {
+    const fetchSpy = mockFetch();
+
+    // props를 달리해 dedup은 피하면서 상한 초과를 시도
+    for (let i = 0; i < 200; i += 1) track('list.view', { i });
+    flush();
+
+    const total = fetchSpy.mock.calls.reduce(
+      (n, c) => n + JSON.parse(c[1]?.body as string).events.length,
+      0,
+    );
+    expect(total).toBe(120);
   });
 
   test('인터벌 경과 시 자동 flush', () => {

--- a/apps/web/src/shared/lib/analytics/track.test.ts
+++ b/apps/web/src/shared/lib/analytics/track.test.ts
@@ -70,8 +70,7 @@ describe('track / flush', () => {
     expect(lastFetchBody(fetchSpy).events).toHaveLength(20);
   });
 
-  // 정상 유저의 우발적 중복(StrictMode 이중 마운트·빠른 재렌더)과
-  // 코드 버그로 인한 폭주를 걸러, DB·서버리스 호출이 불필요하게 쌓이지 않게 한다
+  // 정상 유저의 우발적 중복과 코드 버그로 인한 폭주를 걸러, DB·서버리스 호출이 불필요하게 쌓이지 않게 한다
   test('동일 이벤트 연타는 우발적 중복으로 접어 1건만 집계', () => {
     const fetchSpy = mockFetch();
 
@@ -107,6 +106,34 @@ describe('track / flush', () => {
       0,
     );
     expect(total).toBe(120);
+  });
+
+  test('raw 이벤트는 dedup·분당 상한을 모두 건너뛰어 전량 수집', () => {
+    const fetchSpy = mockFetch();
+
+    // 동일 props를 150번(상한 120 초과)
+    const props = { path: '/v1/photos/:id', method: 'GET', ms: 1, status: 200 };
+    for (let i = 0; i < 150; i += 1) track('api.timing', props, { raw: true });
+    flush();
+
+    const total = fetchSpy.mock.calls.reduce(
+      (n, c) => n + JSON.parse(c[1]?.body as string).events.length,
+      0,
+    );
+    expect(total).toBe(150);
+  });
+
+  test('raw 이벤트는 일반 이벤트의 dedup 상태를 오염시키지 않음', () => {
+    const fetchSpy = mockFetch();
+
+    track('list.view');
+    track('api.timing', { ms: 1 }, { raw: true });
+    track('list.view'); // 직전 list.view와 동일 → 여전히 dedup에 걸려야
+    flush();
+
+    const events = lastFetchBody(fetchSpy).events as { event: string }[];
+    const listViews = events.filter((e) => e.event === 'list.view');
+    expect(listViews).toHaveLength(1);
   });
 
   test('인터벌 경과 시 자동 flush', () => {

--- a/apps/web/src/shared/lib/analytics/track.ts
+++ b/apps/web/src/shared/lib/analytics/track.ts
@@ -12,8 +12,20 @@ const EVENTS_PATH = '/v1/events';
 const MAX_BUFFER = 20;
 const FLUSH_INTERVAL_MS = 10_000;
 
+// 우발적 중복 접기 (StrictMode 이중 마운트, 빠른 재렌더 등)
+const DEDUP_WINDOW_MS = 500;
+// 분당 상한 (렌더 루프 같은 버그 폭주)
+const RATE_WINDOW_MS = 60_000;
+const MAX_EVENTS_PER_MINUTE = 120;
+
 const buffer: EventEnvelope[] = [];
 let timer: ReturnType<typeof setTimeout> | null = null;
+
+let lastKey: string | null = null;
+let lastKeyAt = 0;
+
+let windowStart = 0;
+let windowCount = 0;
 
 export function initAnalytics(): void {
   window.addEventListener('pagehide', () => flush(true));
@@ -25,6 +37,24 @@ export function initAnalytics(): void {
 }
 
 export function track(event: AnalyticsEvent, props?: AnalyticsProps): void {
+  const now = Date.now();
+
+  const key = `${event}|${routePattern()}|${props ? JSON.stringify(props) : ''}`;
+  if (key === lastKey && now - lastKeyAt < DEDUP_WINDOW_MS) {
+    return;
+  }
+  lastKey = key;
+  lastKeyAt = now;
+
+  if (now - windowStart >= RATE_WINDOW_MS) {
+    windowStart = now;
+    windowCount = 0;
+  }
+  if (windowCount >= MAX_EVENTS_PER_MINUTE) {
+    return;
+  }
+  windowCount += 1;
+
   buffer.push(buildEnvelope(event, props));
 
   if (buffer.length >= MAX_BUFFER) {
@@ -91,4 +121,8 @@ export function resetForTests(): void {
     timer = null;
   }
   buffer.length = 0;
+  lastKey = null;
+  lastKeyAt = 0;
+  windowStart = 0;
+  windowCount = 0;
 }

--- a/apps/web/src/shared/lib/analytics/track.ts
+++ b/apps/web/src/shared/lib/analytics/track.ts
@@ -8,6 +8,10 @@ import type { AnalyticsEvent, AnalyticsProps, EventEnvelope } from './types';
 
 import { env } from '@/shared/config/env';
 
+export interface TrackOptions {
+  bypassRateLimit?: boolean;
+}
+
 const EVENTS_PATH = '/v1/events';
 const MAX_BUFFER = 20;
 const FLUSH_INTERVAL_MS = 10_000;
@@ -36,7 +40,11 @@ export function initAnalytics(): void {
   });
 }
 
-export function track(event: AnalyticsEvent, props?: AnalyticsProps): void {
+export function track(
+  event: AnalyticsEvent,
+  props?: AnalyticsProps,
+  options?: TrackOptions,
+): void {
   const now = Date.now();
 
   const key = `${event}|${routePattern()}|${props ? JSON.stringify(props) : ''}`;
@@ -46,14 +54,10 @@ export function track(event: AnalyticsEvent, props?: AnalyticsProps): void {
   lastKey = key;
   lastKeyAt = now;
 
-  if (now - windowStart >= RATE_WINDOW_MS) {
-    windowStart = now;
-    windowCount = 0;
-  }
-  if (windowCount >= MAX_EVENTS_PER_MINUTE) {
+  // 전량 수집이 목적인 계측 이벤트는 상한을 건너뜀
+  if (!options?.bypassRateLimit && isRateLimited(now)) {
     return;
   }
-  windowCount += 1;
 
   buffer.push(buildEnvelope(event, props));
 
@@ -62,6 +66,18 @@ export function track(event: AnalyticsEvent, props?: AnalyticsProps): void {
     return;
   }
   scheduleFlush();
+}
+
+function isRateLimited(now: number): boolean {
+  if (now - windowStart >= RATE_WINDOW_MS) {
+    windowStart = now;
+    windowCount = 0;
+  }
+  if (windowCount >= MAX_EVENTS_PER_MINUTE) {
+    return true;
+  }
+  windowCount += 1;
+  return false;
 }
 
 function buildEnvelope(

--- a/apps/web/src/shared/lib/analytics/track.ts
+++ b/apps/web/src/shared/lib/analytics/track.ts
@@ -9,7 +9,7 @@ import type { AnalyticsEvent, AnalyticsProps, EventEnvelope } from './types';
 import { env } from '@/shared/config/env';
 
 export interface TrackOptions {
-  bypassRateLimit?: boolean;
+  raw?: boolean;
 }
 
 const EVENTS_PATH = '/v1/events';
@@ -47,15 +47,18 @@ export function track(
 ): void {
   const now = Date.now();
 
-  const key = `${event}|${routePattern()}|${props ? JSON.stringify(props) : ''}`;
-  if (key === lastKey && now - lastKeyAt < DEDUP_WINDOW_MS) {
-    return;
+  // raw 계측 이벤트는 dedup을 건너뛰고 lastKey도 오염시키지 않음
+  if (!options?.raw) {
+    const key = `${event}|${routePattern()}|${props ? JSON.stringify(props) : ''}`;
+    if (key === lastKey && now - lastKeyAt < DEDUP_WINDOW_MS) {
+      return;
+    }
+    lastKey = key;
+    lastKeyAt = now;
   }
-  lastKey = key;
-  lastKeyAt = now;
 
-  // 전량 수집이 목적인 계측 이벤트는 상한을 건너뜀
-  if (!options?.bypassRateLimit && isRateLimited(now)) {
+  // raw 계측 이벤트는 분당 상한 건너뜀
+  if (!options?.raw && consumeRateLimit(now)) {
     return;
   }
 
@@ -68,7 +71,7 @@ export function track(
   scheduleFlush();
 }
 
-function isRateLimited(now: number): boolean {
+function consumeRateLimit(now: number): boolean {
   if (now - windowStart >= RATE_WINDOW_MS) {
     windowStart = now;
     windowCount = 0;

--- a/apps/web/src/shared/lib/analytics/types.ts
+++ b/apps/web/src/shared/lib/analytics/types.ts
@@ -8,6 +8,7 @@ export type AnalyticsEvent =
   | 'list.view'
   | 'list.scroll_depth'
   | 'detail.view'
+  | 'api.timing'
   | 'upload.session_complete'
   | 'download.single_start'
   | 'download.single_success'

--- a/apps/web/src/shared/lib/consent/index.ts
+++ b/apps/web/src/shared/lib/consent/index.ts
@@ -1,0 +1,13 @@
+const KEY = 'joka_analytics_consent';
+
+export function grantConsent(): void {
+  localStorage.setItem(KEY, 'granted');
+}
+
+export function revokeConsent(): void {
+  localStorage.removeItem(KEY);
+}
+
+export function hasConsent(): boolean {
+  return localStorage.getItem(KEY) === 'granted';
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string;
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_AUTH_REFRESH_PATH?: string;
+  readonly VITE_CLARITY_PROJECT_ID?: string;
 }
 
 interface ImportMeta {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,11 +6,18 @@ import path from 'path';
 import { fileURLToPath } from 'node:url';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    // 번들 분석 리포트 생성
+    process.env['VITE_VISUALIZE'] === 'true' &&
+      visualizer({ open: true, filename: 'dist/stats.html', gzipSize: true }),
+  ],
   resolve: {
     alias: {
       '@': path.resolve(dirname, './src'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       playwright:
         specifier: ^1.60.0
         version: 1.60.0
+      rollup-plugin-visualizer:
+        specifier: ^7.0.1
+        version: 7.0.1(rollup@4.59.0)
       storybook:
         specifier: ^10.4.2
         version: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2991,6 +2994,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -3919,6 +3926,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
@@ -4579,6 +4590,10 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
   openapi-fetch@0.14.1:
     resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
 
@@ -4749,6 +4764,10 @@ packages:
     resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
     engines: {node: '>=12'}
 
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4906,6 +4925,19 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rollup-plugin-visualizer@7.0.1:
+    resolution: {integrity: sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==}
+    engines: {node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      rolldown: 1.x || ^1.0.0-beta || ^1.0.0-rc
+      rollup: 2.x || 3.x || 4.x
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -5038,6 +5070,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -5645,6 +5681,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -5671,9 +5711,17 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -8198,6 +8246,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      wrap-ansi: 9.0.2
+
   clsx@2.1.1: {}
 
   co@4.6.0: {}
@@ -9151,6 +9205,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-in-ssh@1.0.0: {}
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
@@ -9960,6 +10016,15 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
   openapi-fetch@0.14.1:
     dependencies:
       openapi-typescript-helpers: 0.0.15
@@ -10157,6 +10222,8 @@ snapshots:
 
   postgres@3.4.8: {}
 
+  powershell-utils@0.1.0: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.1:
@@ -10318,6 +10385,15 @@ snapshots:
       signal-exit: 4.1.0
 
   rfdc@1.4.1: {}
+
+  rollup-plugin-visualizer@7.0.1(rollup@4.59.0):
+    dependencies:
+      open: 11.0.0
+      picomatch: 4.0.3
+      source-map: 0.7.6
+      yargs: 18.0.0
+    optionalDependencies:
+      rollup: 4.59.0
 
   rollup@4.59.0:
     dependencies:
@@ -10513,6 +10589,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
 
   split2@4.2.0: {}
 
@@ -11103,6 +11181,11 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -11117,6 +11200,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -11126,6 +11211,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## 📌 관련 이슈

* #104

---

## 🧹 작업 내용

앱 개선을 위한 **관측(analytics) 기반**을 세 갈래로 추가했습니다.

**1. Clarity 세션 분석 (동의 기반)**
  * 로그인 화면에 "화면 분석 동의" 체크박스(기본 off) + 수집범위 팝오버
  * 동의 시에만 Clarity 로드, 로그아웃 시 해제 (grant/revoke 라이프사이클)
  * 사진(썸네일·상세)에 `data-clarity-mask` → 세션 리플레이에서 가족 사진 원천 차단

**2. API 응답시간 전량 수집 파이프라인**
  * `sendRequest` 단일 병목에서 fetch 왕복시간을 `api.timing`으로 기록
  * path 정규화(`:id`)로 엔드포인트별 이상치 분석이 가능하도록 그룹화
  * `raw` 옵션으로 dedup·분당 상한을 우회해 계측 유실 방지 (전량 수집)

**3. 번들 분석 도구**
  * `VITE_VISUALIZE=true` 빌드 시에만 `dist/stats.html` 생성 (평소·배포 영향 없음)

---
  
## 🛠️  테스트

* [x] 단위 테스트 통과 (analytics track 14/14, api client 27/27)
* [ ] 수동 테스트 — 동의 체크 → 카카오 OAuth 왕복 → Clarity 초기화 흐름 실기기 확인 필요
* [x] 기존 기능 영향 없음 (호출부 무수정 additive 변경, track 옵션은 하위호환)

---

## 🔍 고민 / 결정 사항

* **성능 계측을 Sentry가 아닌 자체 파이프라인(track/events)로 일원화** 
> 대시보드를 상시 볼 계획이 없고, 3주 수집분을 AI로 분석할 자체 `/v1/events`가 있어 데이터를 한곳에 모음

* **프라이버시:** 동의 기본 off, 사진 마스킹, `anonUserId` SHA-256 해싱, path 정규화로 원본 ID 미기록.

---

## 💬 참고 사항

### `api.timing` 이벤트 추가

FE 계측에 `api.timing` 이벤트가 하나 추가됐습니다.

JSON 구조상 대부분 영향 없을 것 같은데, 혹시 `event`를 allowlist로 막고 계시면 `api.timing` 추가... 부탁드려요!  
아니면 API 완성 후 해당 필드만 허용하도록 BE 코드 수정...해두겠습니다...ㅎㅎ 지송 ><

**추가된 payload**
```json
{
  "events": [
    {
      "event": "api.timing",
      "timestamp": 1720500000000,
      "sessionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
      "anonUserId": "9f3c8a1d2e4b5f60",
      "userRole": "VIEWER",
      "route": "/photos/:id",
      "appVersion": "1.2.3",
      "props": {
        "path": "/api/v1/photos/:id",
        "method": "GET",
        "ms": 214,
        "status": 200
      }
    }
  ]
}
```
