### PR TITLE
[Feat] 사진 목록·상세에 썸네일·blurhash placeholder 연동

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@sentry/react": "^10.40.0",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-query": "^5.90.21",
+    "blurhash": "^2.0.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.16.0",

--- a/apps/web/src/entities/photo/index.ts
+++ b/apps/web/src/entities/photo/index.ts
@@ -24,4 +24,5 @@ export type {
 
 export { PhotoCard } from './ui/photo-card';
 export { PhotoThumbnail } from './ui/photo-thumbnail';
+export { PhotoProgressiveImage } from './ui/photo-progressive-image';
 export { PhotoMeta } from './ui/photo-meta';

--- a/apps/web/src/entities/photo/lib/blurhash.test.ts
+++ b/apps/web/src/entities/photo/lib/blurhash.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+
+import { blurhashToDataUrl } from './blurhash';
+
+describe('blurhashToDataUrl', () => {
+  test('유효하지 않은 해시는 예외 없이 undefined', () => {
+    expect(blurhashToDataUrl('not-a-blurhash')).toBeUndefined();
+  });
+
+  test('빈 문자열도 안전하게 undefined', () => {
+    expect(blurhashToDataUrl('')).toBeUndefined();
+  });
+});

--- a/apps/web/src/entities/photo/lib/blurhash.ts
+++ b/apps/web/src/entities/photo/lib/blurhash.ts
@@ -1,0 +1,29 @@
+import { decode, isBlurhashValid } from 'blurhash';
+
+/**
+ * blurhash 문자열을 작은 canvas에 그려 data URL로 변환한다.
+ */
+export function blurhashToDataUrl(
+  blurhash: string,
+  size = 32,
+): string | undefined {
+  if (typeof document === 'undefined') return undefined; // SSR 등 document 없는 환경에서는 canvas 사용 불가 → 조용히 스킵
+  if (!isBlurhashValid(blurhash).result) return undefined;
+
+  const pixels = decode(blurhash, size, size);
+
+  // 32x32 임시 캔버스 준비 (그리기 도구인 2d context 확보)
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return undefined; // canvas 미지원/차단 환경 방어
+
+  // decode()가 만든 RGBA 픽셀 배열을 캔버스에 그대로 찍어넣는다
+  const imageData = ctx.createImageData(size, size);
+  imageData.data.set(pixels);
+  ctx.putImageData(imageData, 0, 0);
+
+  // 캔버스 내용을 <img src>에 바로 쓸 수 있는 base64 문자열로 변환
+  return canvas.toDataURL();
+}

--- a/apps/web/src/entities/photo/lib/mapper.test.ts
+++ b/apps/web/src/entities/photo/lib/mapper.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
-import type { MediaContent, MediaDto } from '../model/types';
 import { toPhoto } from './mapper';
+import type { MediaContent, MediaDto } from '../model/types';
 
 function baseDto(overrides: Partial<MediaDto> = {}): MediaDto {
   return {
@@ -51,21 +51,33 @@ describe('toPhoto', () => {
     expect('imageUrl' in photo).toBe(false);
   });
 
-  test('thumbnail이 있어도 원본 accessUrl을 쓴다 (썸네일 미사용 정책)', () => {
-    const withThumb = {
+  test('thumbnail이 있으면 목록용 thumbnailUrl·blurhash를 채우고 원본은 그대로 둔다', () => {
+    const withThumb: MediaContent = {
       ...content,
       thumbnail: {
         location: { url: 's3://t', accessUrl: 'https://signed/thumb.jpg' },
         size: 100,
         eTag: 'te',
-        mimeType: 'image/jpeg',
-        blurhash: 'abc',
+        mimeType: 'image/webp',
+        blurhash: 'LKO2?U',
       },
     };
     const photo = toPhoto(baseDto({ content: withThumb }));
 
+    // 목록 표시는 썸네일, 상세·다운로드는 원본
+    expect(photo.thumbnailUrl).toBe('https://signed/thumb.jpg');
+    expect(photo.blurhash).toBe('LKO2?U');
     expect(photo.imageUrl).toBe('https://signed/x.jpg');
     expect(photo.downloadUrl).toBe('https://signed/x.jpg');
+  });
+
+  test('thumbnail이 없으면(추출 전) thumbnailUrl/blurhash 키를 만들지 않는다', () => {
+    const photo = toPhoto(baseDto({ content }));
+
+    expect('thumbnailUrl' in photo).toBe(false);
+    expect('blurhash' in photo).toBe(false);
+    // 폴백: 목록도 원본 imageUrl을 쓸 수 있어야 한다
+    expect(photo.imageUrl).toBe('https://signed/x.jpg');
   });
 
   test('공통 필드(createdAt/createdBy/isFavorite/state)를 매핑한다', () => {

--- a/apps/web/src/entities/photo/lib/mapper.ts
+++ b/apps/web/src/entities/photo/lib/mapper.ts
@@ -3,11 +3,14 @@ import type { MediaDto, Photo } from '../model/types';
 /**
  * GET /v1/media item(MediaDto) → Photo.
  * - content가 없으면(DRAFT/PREPARING) imageUrl/downloadUrl/mimeType/size를 생략한다.
- * - 썸네일은 현재 백엔드 미지원이므로 원본 location.accessUrl을 표시·다운로드에 함께 사용한다.
+ * - imageUrl(상세)·downloadUrl(다운로드)은 원본 location.accessUrl을 쓴다.
+ * - thumbnail이 있으면(추출 완료) 목록 표시용 thumbnailUrl·blurhash를 채운다.
+ * - 추출은 비동기라 없을 수 있고, 그때 목록은 imageUrl로 폴백한다.
  */
 export function toPhoto(dto: MediaDto): Photo {
   const { at: createdAt, by: createdBy } = dto.created;
   const accessUrl = dto.content?.location.accessUrl;
+  const thumbnail = dto.content?.thumbnail;
 
   return {
     id: dto.id,
@@ -17,6 +20,10 @@ export function toPhoto(dto: MediaDto): Photo {
     createdAt,
     createdBy,
     ...(accessUrl && { imageUrl: accessUrl, downloadUrl: accessUrl }),
+    ...(thumbnail && {
+      thumbnailUrl: thumbnail.location.accessUrl,
+      blurhash: thumbnail.blurhash,
+    }),
     ...(dto.content && {
       mimeType: dto.content.mimeType,
       size: dto.content.size,

--- a/apps/web/src/entities/photo/model/types.ts
+++ b/apps/web/src/entities/photo/model/types.ts
@@ -9,15 +9,22 @@ export interface UserSummary {
 /**
  * 목록/그리드에서 사용하는 프론트 도메인 모델.
  *
- * 현재 썸네일/blurhash를 생성하지 않으므로
- *   - content.thumbnail === null
- *   - 표시·다운로드 모두 원본 content.location.accessUrl(presigned)을 사용
+ * URL 3종은 용도가 다르다(모두 presigned accessUrl)
+ *   - thumbnailUrl: 목록/그리드 표시용 경량 썸네일. 추출은 비동기라 없을 수 있음.
+ *   - imageUrl: 상세 화면 표시용 원본.
+ *   - downloadUrl: 다운로드용 원본.
+ *
+ * 썸네일이 아직 없으면(추출 전) 목록은 imageUrl로 폴백한다.
+ *
+ * blurhash는 썸네일 로드 전 placeholder 렌더용.
  */
 export interface Photo {
   id: string;
   description: string;
   state: PhotoState;
   imageUrl?: string;
+  thumbnailUrl?: string;
+  blurhash?: string;
   downloadUrl?: string;
   mimeType?: string;
   size?: number;

--- a/apps/web/src/entities/photo/ui/photo-card.stories.tsx
+++ b/apps/web/src/entities/photo/ui/photo-card.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
-import type { Photo } from '../model/types';
 import { PhotoCard } from './photo-card';
+import type { Photo } from '../model/types';
 
 const fixturePhoto: Photo = {
   id: 'p1',
@@ -35,6 +35,43 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+/**
+ * 썸네일 추출 완료 상태
+ * - 목록은 경량 thumbnailUrl 사용
+ * - 로드 전 blurhash placeholder가 깔림
+ */
+export const WithThumbnail: Story = {
+  args: {
+    photo: {
+      ...fixturePhoto,
+      thumbnailUrl: 'https://placehold.co/200x200/1d4ed8/fff?text=thumb',
+      blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+    },
+  },
+  // 썸네일이 있으면 목록 이미지가 원본이 아니라 썸네일 accessUrl을 쓴다
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const img = canvas.getByRole('img', { name: '바닷가 사진' });
+    await expect(img).toHaveAttribute('src', args.photo.thumbnailUrl);
+    await expect(img).not.toHaveAttribute('src', args.photo.imageUrl);
+  },
+};
+
+/**
+ * 썸네일 추출 전(비동기 대기)
+ * - thumbnailUrl이 없어 원본 imageUrl로 폴백.
+ * - fixturePhoto에는 썸네일 키가 없으므로 그대로 사용한다.
+ */
+export const ThumbnailPending: Story = {
+  args: { photo: fixturePhoto },
+  // 썸네일이 없으면 원본 imageUrl로 폴백해 여전히 표시된다
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const img = canvas.getByRole('img', { name: '바닷가 사진' });
+    await expect(img).toHaveAttribute('src', args.photo.imageUrl);
+  },
+};
 
 export const Selected: Story = {
   args: {

--- a/apps/web/src/entities/photo/ui/photo-card.tsx
+++ b/apps/web/src/entities/photo/ui/photo-card.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
-import type { Photo } from '../model/types';
 import { PhotoThumbnail } from './photo-thumbnail';
+import type { Photo } from '../model/types';
 
 interface PhotoCardProps {
   photo: Photo;
@@ -26,7 +26,11 @@ export function PhotoCard({
         aria-label={photo.description}
         className="block w-full overflow-hidden rounded-2xl text-left ring-offset-background transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        <PhotoThumbnail src={photo.imageUrl} alt={photo.description} />
+        <PhotoThumbnail
+          src={photo.thumbnailUrl ?? photo.imageUrl}
+          alt={photo.description}
+          blurhash={photo.blurhash}
+        />
         {selected && (
           <span
             aria-hidden

--- a/apps/web/src/entities/photo/ui/photo-progressive-image.stories.tsx
+++ b/apps/web/src/entities/photo/ui/photo-progressive-image.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { PhotoProgressiveImage } from './photo-progressive-image';
+
+const meta = {
+  title: 'entities/photo/PhotoProgressiveImage',
+  component: PhotoProgressiveImage,
+  parameters: { layout: 'centered' },
+  args: {
+    src: 'https://placehold.co/800x800/222/fff?text=original',
+    previewSrc: 'https://placehold.co/300x300/1d4ed8/fff?text=thumb',
+    blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+    alt: '바닷가 사진',
+  },
+  // 상세 뷰어와 동일한 정사각형 다크 스테이지를 흉내 낸다
+  decorators: [
+    (Story) => (
+      <div className="relative flex aspect-square w-72 items-center justify-center overflow-hidden rounded-2xl bg-black">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PhotoProgressiveImage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 3단계 모두 제공(원본까지 로드되면 최종 표시) */
+export const Default: Story = {};
+
+/** 원본 로드 전 단계(썸네일 프리뷰가 blurhash 위에 표시) */
+export const PreviewOverBlur: Story = {
+  args: { src: undefined },
+};
+
+/** 썸네일도 없을 때(blurhash placeholder만) */
+export const BlurhashOnly: Story = {
+  args: { src: undefined, previewSrc: undefined },
+};

--- a/apps/web/src/entities/photo/ui/photo-progressive-image.tsx
+++ b/apps/web/src/entities/photo/ui/photo-progressive-image.tsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from 'react';
+
+import { blurhashToDataUrl } from '../lib/blurhash';
+
+import { cn } from '@/shared/lib/utils/cn';
+
+interface PhotoProgressiveImageProps {
+  /** 원본(최종 표시 픽셀) */
+  src?: string | undefined;
+  /** 썸네일(중간 프리뷰). 목록을 거쳐 왔다면 이미 캐시됐을 가능성이 높다 */
+  previewSrc?: string | undefined;
+  /** blurhash(초기 placeholder) */
+  blurhash?: string | undefined;
+  alt: string;
+}
+
+/**
+ * 상세 뷰어용 3단계 progressive 이미지: blurhash → 썸네일 → 원본
+ *
+ * - 세 레이어를 겹쳐 두고, 위 레이어가 로드되면 페이드인 → 종료 후 아래를 언마운트
+ * - 포지셔닝된 부모를 꽉 채우는 absolute 레이어로 렌더한다(부모가 크기·배경 담당)
+ * - 최종 픽셀은 원본
+ *
+ * 상세는 크게 띄우므로 최종 표시는 원본이어야 한다.
+ */
+export function PhotoProgressiveImage({
+  src,
+  previewSrc,
+  blurhash,
+  alt,
+}: PhotoProgressiveImageProps) {
+  const [previewLoaded, setPreviewLoaded] = useState(false);
+  const [fullLoaded, setFullLoaded] = useState(false);
+  const [blurGone, setBlurGone] = useState(false);
+  const [previewGone, setPreviewGone] = useState(false);
+
+  const blurUrl = useMemo(
+    () => (blurhash ? blurhashToDataUrl(blurhash) : undefined),
+    [blurhash],
+  );
+
+  return (
+    <>
+      {/* 1단계: blurhash (object-contain 여백(레터박스)까지 blur로 채운다) */}
+      {blurUrl && !blurGone && (
+        <img
+          src={blurUrl}
+          alt=""
+          aria-hidden
+          className="absolute inset-0 h-full w-full scale-105 object-cover blur-xl"
+        />
+      )}
+
+      {/* 2단계: 썸네일 (원본 도착 전까지의 빠른 저해상 프리뷰) */}
+      {previewSrc && !previewGone && (
+        <img
+          src={previewSrc}
+          alt=""
+          aria-hidden
+          decoding="async"
+          data-clarity-mask="True"
+          onLoad={() => setPreviewLoaded(true)}
+          onTransitionEnd={(e) => {
+            if (e.propertyName === 'opacity' && previewLoaded)
+              setBlurGone(true);
+          }}
+          className={cn(
+            'absolute inset-0 h-full w-full object-contain transition-opacity duration-300',
+            previewLoaded ? 'opacity-100' : 'opacity-0',
+          )}
+        />
+      )}
+
+      {/* 3단계: 원본 (로드되면 위로 페이드인하며 아래를 정리) */}
+      {src && (
+        <img
+          src={src}
+          alt={alt}
+          decoding="async"
+          data-clarity-mask="True"
+          onLoad={() => setFullLoaded(true)}
+          onTransitionEnd={(e) => {
+            if (e.propertyName === 'opacity' && fullLoaded) {
+              setBlurGone(true);
+              setPreviewGone(true);
+            }
+          }}
+          className={cn(
+            'absolute inset-0 h-full w-full object-contain transition-opacity duration-300',
+            fullLoaded ? 'opacity-100' : 'opacity-0',
+          )}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
+++ b/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
@@ -18,6 +18,7 @@ export function PhotoThumbnail({
   className,
 }: PhotoThumbnailProps) {
   const [loaded, setLoaded] = useState(false);
+  const [blurGone, setBlurGone] = useState(false);
 
   // blurhash → data URL 디코딩은 비용이 있으므로 hash가 바뀔 때만 계산한다.
   const blurUrl = useMemo(
@@ -34,7 +35,7 @@ export function PhotoThumbnail({
         className,
       )}
     >
-      {blurUrl && !loaded && (
+      {blurUrl && !blurGone && (
         <img
           src={blurUrl}
           alt=""
@@ -49,6 +50,10 @@ export function PhotoThumbnail({
           loading="lazy"
           decoding="async"
           onLoad={() => setLoaded(true)}
+          // 페이드(opacity) 종료 시점에 뒤의 블러를 제거 → 회색 깜빡임 없이 정리
+          onTransitionEnd={(e) => {
+            if (e.propertyName === 'opacity' && loaded) setBlurGone(true);
+          }}
           className={cn(
             'relative block h-auto w-full transition-opacity duration-300',
             loaded ? 'opacity-100' : 'opacity-0',

--- a/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
+++ b/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
@@ -1,15 +1,29 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+
+import { blurhashToDataUrl } from '../lib/blurhash';
 
 import { cn } from '@/shared/lib/utils/cn';
 
 interface PhotoThumbnailProps {
   src?: string | undefined;
   alt: string;
+  blurhash?: string | undefined;
   className?: string | undefined;
 }
 
-export function PhotoThumbnail({ src, alt, className }: PhotoThumbnailProps) {
+export function PhotoThumbnail({
+  src,
+  alt,
+  blurhash,
+  className,
+}: PhotoThumbnailProps) {
   const [loaded, setLoaded] = useState(false);
+
+  // blurhash → data URL 디코딩은 비용이 있으므로 hash가 바뀔 때만 계산한다.
+  const blurUrl = useMemo(
+    () => (blurhash ? blurhashToDataUrl(blurhash) : undefined),
+    [blurhash],
+  );
 
   return (
     <div
@@ -20,6 +34,14 @@ export function PhotoThumbnail({ src, alt, className }: PhotoThumbnailProps) {
         className,
       )}
     >
+      {blurUrl && !loaded && (
+        <img
+          src={blurUrl}
+          alt=""
+          aria-hidden
+          className="absolute inset-0 h-full w-full scale-105 object-cover blur-md"
+        />
+      )}
       {src && (
         <img
           src={src}
@@ -28,7 +50,7 @@ export function PhotoThumbnail({ src, alt, className }: PhotoThumbnailProps) {
           decoding="async"
           onLoad={() => setLoaded(true)}
           className={cn(
-            'block h-auto w-full transition-opacity duration-300',
+            'relative block h-auto w-full transition-opacity duration-300',
             loaded ? 'opacity-100' : 'opacity-0',
           )}
         />

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -116,8 +116,6 @@ export function PhotoDetailPage() {
             previewSrc={photo.thumbnailUrl}
             blurhash={photo.blurhash}
             alt={photo.description}
-            data-clarity-mask="True"
-            className="size-full object-contain"
           />
         )}
 

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from '@/app/providers/error-boundary';
 import { useAlbumStore, useCurrentAlbumRole } from '@/entities/album';
 import {
   PhotoMeta,
+  PhotoProgressiveImage,
   selectPhotos,
   useDeletePhotoMutation,
   usePhotoDetail,
@@ -107,12 +108,14 @@ export function PhotoDetailPage() {
       <DetailHeader photo={photo} canWrite={canWrite} />
 
       {/* 이미지 뷰어 스테이지: 다크 배경 + object-contain + 좌우 네비 화살표 */}
+      {/* 3단계 progressive: blurhash → 썸네일(캐시) → 원본 */}
       <div className="relative flex aspect-square items-center justify-center overflow-hidden rounded-2xl bg-black">
         {photo.imageUrl && (
-          <img
+          <PhotoProgressiveImage
             src={photo.imageUrl}
+            previewSrc={photo.thumbnailUrl}
+            blurhash={photo.blurhash}
             alt={photo.description}
-            className="size-full object-contain"
           />
         )}
 

--- a/apps/web/src/widgets/photo-grid/ui/photo-grid.stories.tsx
+++ b/apps/web/src/widgets/photo-grid/ui/photo-grid.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
 
-import { PhotoCard, type Photo } from '@/entities/photo';
-
 import { PhotoGrid } from './photo-grid';
+
+import { PhotoCard, type Photo } from '@/entities/photo';
 
 function makePhoto(id: string): Photo {
   return {
@@ -11,6 +11,8 @@ function makePhoto(id: string): Photo {
     description: `사진 ${id}`,
     state: 'COMPLETE',
     imageUrl: 'https://placehold.co/400x400',
+    thumbnailUrl: 'https://placehold.co/200x200',
+    blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
     downloadUrl: 'https://placehold.co/400x400',
     mimeType: 'image/jpeg',
     size: 1000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
+      blurhash:
+        specifier: ^2.0.5
+        version: 2.0.5
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
## 📌 관련 이슈

* Closes #127
* Related: #113 

---

## 🧹 작업 내용

* 백엔드가 내려주는 `content.thumbnail`(presigned `accessUrl` + `blurhash`)을 프론트 **목록/그리드**에 연동
* `Photo` 모델·매퍼에 `thumbnailUrl`·`blurhash` 추가 → 목록 카드는 **썸네일 우선, 아직 추출 전이면 원본 `imageUrl`로 폴백**.
* 공식 `blurhash` 패키지로 로드 전 **blurhash placeholder** 렌더, 페이드 종료 후 정리
* **상세·다운로드는 원본 유지**(화질·기존 동작 보존) (목록만 경량화)

---

* **목록:** `Photo` 모델·매퍼에 `thumbnailUrl`·`blurhash` 추가 
* **상세:** 뷰어에 **3단계 progressive**(blurhash → 썸네일 → 원본) 적용
   * 목록에서 캐시된 썸네일로 즉시 프리뷰 후 원본으로 스왑

---

## 🛠️  테스트

* [x] 단위 테스트 통과 (mapper 썸네일 유/무 매핑, blurhash 래퍼 가드)
* [x] 수동 테스트 완료 (스토리북 `PhotoCard/WithThumbnail`·`ThumbnailPending`, `PhotoGrid`)
* [x] 기존 기능 영향 없음 확인 (상세/다운로드 원본 유지, 썸네일 없을 때 폴백)

---

## 📸 스크린샷


https://github.com/user-attachments/assets/e7c55787-a9b7-4a70-b293-f9ba5f03b129


https://github.com/user-attachments/assets/4a416084-3a95-4bc1-a925-9ee1112542a7


---

## 🔍 고민 / 결정 사항

* **placeholder 제거 타이밍** 
  * `loaded` 즉시 언마운트하면 이미지가 반투명한 동안 회색 배경이 새어 깜빡임 
  * → `onTransitionEnd`(opacity)로 **페이드 종료 후** 언마운트