### PR TITLE
[Fix] 사진 삭제 시 목록 캐시 동기화 및 토스트 정책 정리

### DIFF
--- a/apps/web/src/app/index.tsx
+++ b/apps/web/src/app/index.tsx
@@ -6,13 +6,13 @@ import { ErrorBoundary } from '@/app/providers/error-boundary';
 import { queryClient } from '@/app/providers/query-client';
 import { AppRouter } from '@/app/providers/router';
 import { initSentry } from '@/app/providers/sentry';
+import { AppToaster } from '@/app/providers/toaster';
 import { hideSplash, hideSplashWithFloor } from '@/app/splash';
 import { useAlbumStore } from '@/entities/album';
 import { useAuthStore } from '@/features/auth';
 import { initTheme } from '@/features/theme';
 import { initAnalytics, setRoleResolver } from '@/shared/lib/analytics';
 import { hasConsent } from '@/shared/lib/consent';
-import { Toaster } from '@/shared/ui/toast';
 import './styles/globals.css';
 
 initSentry();
@@ -29,7 +29,7 @@ if (root) {
     <QueryClientProvider client={queryClient}>
       <ErrorBoundary>
         <AppRouter />
-        <Toaster />
+        <AppToaster />
       </ErrorBoundary>
     </QueryClientProvider>,
   );

--- a/apps/web/src/app/providers/toaster.tsx
+++ b/apps/web/src/app/providers/toaster.tsx
@@ -1,0 +1,9 @@
+import { useTheme } from '@/features/theme';
+import { Toaster } from '@/shared/ui/toast';
+
+/** 앱의 테마 토글 값을 토스트에 전달한다(shared는 features를 모르므로 app에서 주입) */
+export function AppToaster() {
+  const theme = useTheme();
+
+  return <Toaster theme={theme} />;
+}

--- a/apps/web/src/entities/photo/api/mutations.test.ts
+++ b/apps/web/src/entities/photo/api/mutations.test.ts
@@ -1,12 +1,16 @@
 import { MutationObserver, QueryClient } from '@tanstack/react-query';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { photoKeys } from './keys';
 import {
   buildDeletePhotoOptions,
   buildUpdatePhotoMetaOptions,
+  isAlreadyDeleted,
 } from './mutations';
-import { photoKeys } from './keys';
-import type { MediaDto, Photo } from '../model/types';
+import { selectPhotos } from './queries';
+import type { MediaDto, MediaPagination, Photo } from '../model/types';
+
+import { ApiError } from '@/shared/api/error';
 
 const mocks = vi.hoisted(() => ({
   patch: vi.fn(),
@@ -44,6 +48,23 @@ function mediaDto(description: string): MediaDto {
     },
     created: { at: '2026-01-01T00:00:00.000Z', by: photo().createdBy },
   };
+}
+
+function otherDto(id: string): MediaDto {
+  return { ...mediaDto('다른 사진'), id };
+}
+
+const pagination: MediaPagination = {
+  size: 20,
+  sortBy: 'CREATED_AT',
+  order: 'DESC',
+  hasNext: false,
+};
+
+function listIds(qc: QueryClient): string[] {
+  return selectPhotos(qc.getQueryData(photoKeys.list({ order: 'desc' }))).map(
+    (p) => p.id,
+  );
 }
 
 function runUpdate(qc: QueryClient, vars: { id: string; description: string }) {
@@ -142,12 +163,20 @@ describe('buildUpdatePhotoMetaOptions', () => {
 });
 
 describe('buildDeletePhotoOptions', () => {
-  beforeEach(() => mocks.del.mockReset());
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    mocks.del.mockReset();
+    qc = new QueryClient();
+    qc.setQueryData(photoKeys.detail('p1'), photo());
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [{ items: [mediaDto('설명'), otherDto('p2')], pagination }],
+      pageParams: [undefined],
+    });
+  });
 
   test('성공 시 상세 캐시를 제거하고 목록을 무효화한다', async () => {
     mocks.del.mockResolvedValueOnce(undefined);
-    const qc = new QueryClient();
-    qc.setQueryData(photoKeys.detail('p1'), photo());
 
     const remove = vi.spyOn(qc, 'removeQueries');
     const invalidate = vi.spyOn(qc, 'invalidateQueries');
@@ -157,5 +186,40 @@ describe('buildDeletePhotoOptions', () => {
     expect(mocks.del).toHaveBeenCalledWith('/v1/media/p1');
     expect(remove).toHaveBeenCalledWith({ queryKey: photoKeys.detail('p1') });
     expect(invalidate).toHaveBeenCalledWith({ queryKey: photoKeys.lists() });
+  });
+
+  // invalidate만으로는 enabled:false 옵저버뿐인 목록이 리페치되지 않아 유령 카드가 남는다.
+  test('성공 시 목록 캐시에서도 즉시 제거한다', async () => {
+    mocks.del.mockResolvedValueOnce(undefined);
+
+    await runDelete(qc, 'p1');
+
+    expect(listIds(qc)).toEqual(['p2']);
+  });
+
+  test('404(이미 삭제됨)면 실패로 두지 않고 캐시를 동일하게 정리한다', async () => {
+    mocks.del.mockRejectedValueOnce(new ApiError({ status: 404 }));
+
+    await expect(runDelete(qc, 'p1')).rejects.toBeInstanceOf(ApiError);
+
+    expect(listIds(qc)).toEqual(['p2']);
+    expect(qc.getQueryData(photoKeys.detail('p1'))).toBeUndefined();
+  });
+
+  test('403 같은 다른 실패는 캐시를 건드리지 않는다', async () => {
+    mocks.del.mockRejectedValueOnce(new ApiError({ status: 403 }));
+
+    await expect(runDelete(qc, 'p1')).rejects.toBeInstanceOf(ApiError);
+
+    expect(listIds(qc)).toEqual(['p1', 'p2']);
+    expect(qc.getQueryData(photoKeys.detail('p1'))).toBeDefined();
+  });
+});
+
+describe('isAlreadyDeleted', () => {
+  test('404 ApiError만 이미 삭제됨으로 본다', () => {
+    expect(isAlreadyDeleted(new ApiError({ status: 404 }))).toBe(true);
+    expect(isAlreadyDeleted(new ApiError({ status: 403 }))).toBe(false);
+    expect(isAlreadyDeleted(new Error('boom'))).toBe(false);
   });
 });

--- a/apps/web/src/entities/photo/api/mutations.ts
+++ b/apps/web/src/entities/photo/api/mutations.ts
@@ -5,11 +5,13 @@ import {
   type UseMutationOptions,
 } from '@tanstack/react-query';
 
-import { http } from '@/shared/api';
-
+import { photoKeys } from './keys';
+import { removeMediaFromLists } from './queries';
 import { toPhoto } from '../lib/mapper';
 import type { MediaDto, Photo } from '../model/types';
-import { photoKeys } from './keys';
+
+import { http } from '@/shared/api';
+import { ApiError } from '@/shared/api/error';
 
 export interface UpdatePhotoMetaVars {
   id: string;
@@ -64,6 +66,20 @@ export function useUpdatePhotoMetaMutation() {
   return useMutation(buildUpdatePhotoMetaOptions(queryClient));
 }
 
+/** 404는 "이미 삭제됨"이다. 실패가 아니라 목표 상태에 도달한 것으로 본다(멱등). */
+export function isAlreadyDeleted(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 404;
+}
+
+/**
+ * 삭제된 사진의 상세/목록 캐시를 즉시 정리하고, 최종 정합은 invalidate로 위임한다.
+ */
+function purgeDeletedPhoto(queryClient: QueryClient, id: string): void {
+  queryClient.removeQueries({ queryKey: photoKeys.detail(id) });
+  removeMediaFromLists(queryClient, id);
+  queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
+}
+
 export function buildDeletePhotoOptions(
   queryClient: QueryClient,
 ): UseMutationOptions<void, Error, string> {
@@ -71,9 +87,12 @@ export function buildDeletePhotoOptions(
     mutationFn: (id) => http.delete(`/v1/media/${id}`),
     meta: { operationId: 'deleteMedia' },
 
-    onSuccess: (_data, id) => {
-      queryClient.removeQueries({ queryKey: photoKeys.detail(id) });
-      queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
+    onSuccess: (_data, id) => purgeDeletedPhoto(queryClient, id),
+
+    onError: (error, id) => {
+      if (isAlreadyDeleted(error)) {
+        purgeDeletedPhoto(queryClient, id);
+      }
     },
   };
 }

--- a/apps/web/src/entities/photo/api/queries.test.ts
+++ b/apps/web/src/entities/photo/api/queries.test.ts
@@ -1,9 +1,14 @@
 import { QueryClient } from '@tanstack/react-query';
 import { describe, expect, test } from 'vitest';
 
-import type { MediaDto, MediaListResponse } from '../model/types';
 import { photoKeys } from './keys';
-import { findPhotoInListCache, nextCursorOf, selectPhotos } from './queries';
+import {
+  findPhotoInListCache,
+  nextCursorOf,
+  removeMediaFromLists,
+  selectPhotos,
+} from './queries';
+import type { MediaDto, MediaListResponse } from '../model/types';
 
 function page(
   items: MediaDto[],
@@ -95,7 +100,7 @@ describe('findPhotoInListCache', () => {
       pages: [page([dto('a'), dto('b')])],
     });
 
-    expect(findPhotoInListCache(qc, 'b')?.id).toBe('b');
+    expect(findPhotoInListCache(qc, 'b')?.photo.id).toBe('b');
   });
 
   test('정렬이 다른 여러 list 캐시를 순회해 찾는다', () => {
@@ -107,7 +112,7 @@ describe('findPhotoInListCache', () => {
       pages: [page([dto('b')])],
     });
 
-    expect(findPhotoInListCache(qc, 'b')?.id).toBe('b');
+    expect(findPhotoInListCache(qc, 'b')?.photo.id).toBe('b');
   });
 
   test('data가 비어있는 캐시 항목이 섞여 있어도 안전하게 넘어간다', () => {
@@ -117,7 +122,7 @@ describe('findPhotoInListCache', () => {
       pages: [page([dto('b')])],
     });
 
-    expect(findPhotoInListCache(qc, 'b')?.id).toBe('b');
+    expect(findPhotoInListCache(qc, 'b')?.photo.id).toBe('b');
   });
 
   test('캐시에 id가 없으면 undefined(직접 진입 → normal fetch)', () => {
@@ -133,5 +138,107 @@ describe('findPhotoInListCache', () => {
     const qc = new QueryClient();
 
     expect(findPhotoInListCache(qc, 'a')).toBeUndefined();
+  });
+
+  // 상세 쿼리가 initialDataUpdatedAt으로 쓴다.
+  // staleTime 동안 리페치를 건너뛰기 위함
+  test('사진을 담고 있던 목록 캐시의 dataUpdatedAt을 함께 반환한다', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a')])],
+    });
+
+    const updatedAt = qc.getQueryState(
+      photoKeys.list({ order: 'desc' }),
+    )?.dataUpdatedAt;
+
+    expect(findPhotoInListCache(qc, 'a')?.dataUpdatedAt).toBe(updatedAt);
+  });
+});
+
+describe('removeMediaFromLists', () => {
+  test('모든 페이지에서 해당 id를 걷어낸다', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a'), dto('b')]), page([dto('c')])],
+      pageParams: [undefined, 'c2'],
+    });
+
+    removeMediaFromLists(qc, 'b');
+
+    expect(
+      selectPhotos(qc.getQueryData(photoKeys.list({ order: 'desc' }))).map(
+        (p) => p.id,
+      ),
+    ).toEqual(['a', 'c']);
+  });
+
+  test('정렬이 다른 여러 list 캐시에서 모두 제거한다', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a'), dto('b')])],
+      pageParams: [undefined],
+    });
+    qc.setQueryData(photoKeys.list({ order: 'asc' }), {
+      pages: [page([dto('b'), dto('a')])],
+      pageParams: [undefined],
+    });
+
+    removeMediaFromLists(qc, 'b');
+
+    expect(findPhotoInListCache(qc, 'b')).toBeUndefined();
+    expect(findPhotoInListCache(qc, 'a')?.photo.id).toBe('a');
+  });
+
+  test('pageParams는 보존한다(다음 페이지 요청이 깨지지 않게)', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a')]), page([dto('b')])],
+      pageParams: [undefined, 'c2'],
+    });
+
+    removeMediaFromLists(qc, 'b');
+
+    const data = qc.getQueryData<{ pages: unknown[]; pageParams: unknown[] }>(
+      photoKeys.list({ order: 'desc' }),
+    );
+    expect(data?.pageParams).toEqual([undefined, 'c2']);
+    expect(data?.pages).toHaveLength(2);
+  });
+
+  test('해당 사진이 없는 페이지는 참조를 그대로 둔다(불필요한 리렌더 방지)', () => {
+    const qc = new QueryClient();
+    const untouched = page([dto('a')]);
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [untouched, page([dto('b')])],
+      pageParams: [undefined, 'c2'],
+    });
+
+    removeMediaFromLists(qc, 'b');
+
+    const data = qc.getQueryData<{ pages: MediaListResponse[] }>(
+      photoKeys.list({ order: 'desc' }),
+    );
+    expect(data?.pages[0]).toBe(untouched);
+    expect(data?.pages[1].items).toEqual([]);
+  });
+
+  test('없는 id면 캐시 참조를 그대로 둔다(불필요한 리렌더 방지)', () => {
+    const qc = new QueryClient();
+    const before = {
+      pages: [page([dto('a')])],
+      pageParams: [undefined],
+    };
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), before);
+
+    removeMediaFromLists(qc, 'zzz');
+
+    expect(qc.getQueryData(photoKeys.list({ order: 'desc' }))).toBe(before);
+  });
+
+  test('list 캐시가 없어도 안전하다', () => {
+    const qc = new QueryClient();
+
+    expect(() => removeMediaFromLists(qc, 'a')).not.toThrow();
   });
 });

--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -52,23 +52,48 @@ async function fetchPhotoPage(
   return response;
 }
 
+/** 목록 캐시에서 찾은 Photo와, 그 데이터를 받아온 시각. */
+export interface PhotoCacheHit {
+  photo: Photo;
+  dataUpdatedAt: number;
+}
+
+function isMediaListPage(value: unknown): value is MediaListResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'items' in value &&
+    Array.isArray(value.items)
+  );
+}
+
+function isPagedMedia(value: unknown): value is { pages: MediaListResponse[] } {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('pages' in value)) return false;
+
+  return Array.isArray(value.pages) && value.pages.every(isMediaListPage);
+}
+
 /**
- * 이미 로드된 목록 캐시(모든 list 쿼리)에서 id에 해당하는 Photo를 찾는다.
- * - 목록 → 상세 진입 시 단건 요청을 기다리지 않고 즉시 표시한다.
- * - 직접 진입(새로고침)처럼 캐시가 없으면 undefined를 반환해 정상 fetch로 넘어간다.
+ * 이미 로드된 목록 캐시에서 id에 해당하는 Photo를 찾는다.
+ * - 캐시가 없으면 undefined를 반환함
+ * - dataUpdatedAt을 함께 반환해 호출자가 캐시 신선도를 판단할 수 있음
  */
 export function findPhotoInListCache(
   queryClient: QueryClient,
   id: string,
-): Photo | undefined {
-  const entries = queryClient.getQueriesData<{ pages: MediaListResponse[] }>({
-    queryKey: photoKeys.lists(),
-  });
+): PhotoCacheHit | undefined {
+  const queries = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: photoKeys.lists() });
 
-  for (const [, data] of entries) {
+  for (const query of queries) {
+    const { data, dataUpdatedAt } = query.state;
+    if (!isPagedMedia(data)) continue;
+
     const found = selectPhotos(data).find((photo) => photo.id === id);
     if (found) {
-      return found;
+      return { photo: found, dataUpdatedAt };
     }
   }
 
@@ -104,6 +129,36 @@ export function prependMediaToLists(
   );
 }
 
+/**
+ * 삭제된 사진을 목록 캐시 전 페이지에서 즉시 걷어낸다.
+ * - 삭제 후 목록으로 돌아왔을 때 백그라운드 리페치를 기다리며 유령 카드가 보이는 걸 막음
+ * - 서버가 이미 404를 주는 상태(다른 기기에서 삭제됨)에서도 정리
+ */
+export function removeMediaFromLists(
+  queryClient: QueryClient,
+  id: string,
+): void {
+  queryClient.setQueriesData<InfiniteMedia>(
+    { queryKey: photoKeys.lists() },
+    (data) => {
+      if (!data) return data;
+
+      const exists = data.pages.some((page) =>
+        page.items.some((it) => it.id === id),
+      );
+      if (!exists) return data;
+
+      // 해당 사진이 없는 페이지는 참조를 유지해 불필요한 리렌더를 막는다.
+      const pages = data.pages.map((page) =>
+        page.items.some((it) => it.id === id)
+          ? { ...page, items: page.items.filter((it) => it.id !== id) }
+          : page,
+      );
+      return { ...data, pages };
+    },
+  );
+}
+
 async function fetchPhotoDetail(id: string): Promise<Photo> {
   const dto = await http.get<MediaDto>(`/v1/media/${id}`);
   return toPhoto(dto);
@@ -116,7 +171,9 @@ export function usePhotoDetail(id: string, options?: { enabled?: boolean }) {
     queryKey: photoKeys.detail(id),
     queryFn: () => fetchPhotoDetail(id),
     enabled: (options?.enabled ?? true) && !!id,
-    initialData: () => findPhotoInListCache(queryClient, id),
+    initialData: () => findPhotoInListCache(queryClient, id)?.photo,
+    initialDataUpdatedAt: () =>
+      findPhotoInListCache(queryClient, id)?.dataUpdatedAt,
     staleTime: 60_000,
     throwOnError: true,
     meta: { operationId: 'getMedia' },

--- a/apps/web/src/entities/photo/index.ts
+++ b/apps/web/src/entities/photo/index.ts
@@ -4,12 +4,15 @@ export {
   usePhotoDetail,
   findPhotoInListCache,
   prependMediaToLists,
+  removeMediaFromLists,
   selectPhotos,
   nextCursorOf,
+  type PhotoCacheHit,
 } from './api/queries';
 export {
   useUpdatePhotoMetaMutation,
   useDeletePhotoMutation,
+  isAlreadyDeleted,
   type UpdatePhotoMetaVars,
 } from './api/mutations';
 

--- a/apps/web/src/features/photo-upload/ui/upload-dropzone.tsx
+++ b/apps/web/src/features/photo-upload/ui/upload-dropzone.tsx
@@ -1,12 +1,12 @@
-import { useRef, useState, type ChangeEvent, type DragEvent } from 'react';
 import { ImagePlus } from 'lucide-react';
-import { toast } from 'sonner';
-
-import { Button } from '@/shared/ui/button';
-import { cn } from '@/shared/lib/utils/cn';
+import { useRef, useState, type ChangeEvent, type DragEvent } from 'react';
 
 import { validateFile } from '../lib/validate';
 import { useUploadQueueStore } from '../model/store';
+
+import { cn } from '@/shared/lib/utils/cn';
+import { Button } from '@/shared/ui/button';
+import { toast } from '@/shared/ui/toast';
 
 export function UploadDropzone() {
   const inputRef = useRef<HTMLInputElement>(null);

--- a/apps/web/src/pages/auth/ui/page.tsx
+++ b/apps/web/src/pages/auth/ui/page.tsx
@@ -9,7 +9,7 @@ import { toast } from '@/shared/ui/toast';
 
 function InviteButton() {
   const handleClick = () => {
-    toast('초대 코드 기능은 아직 준비 중이에요.');
+    toast.info('초대 코드 기능은 아직 준비 중이에요.');
   };
 
   return (

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ErrorBoundary } from '@/app/providers/error-boundary';
 import { useAlbumStore, useCurrentAlbumRole } from '@/entities/album';
 import {
+  isAlreadyDeleted,
   PhotoMeta,
   PhotoProgressiveImage,
   selectPhotos,
@@ -221,15 +222,22 @@ function DeletePhotoButton({ photo }: { photo: Photo }) {
       },
 
       onError: (err) => {
+        if (isAlreadyDeleted(err)) {
+          toast.info('이미 삭제된 사진이에요.');
+          navigate('/photos');
+          return;
+        }
+
         if (err instanceof ApiError && err.status === 403) {
           recordForbidden({
             userRole: role ?? 'unknown',
             operationId: 'deleteMedia',
           });
           toast.error('삭제 권한이 없어요.');
-        } else {
-          toast.error('삭제에 실패했어요.');
+          return;
         }
+
+        toast.error('삭제에 실패했어요.');
       },
     });
   };

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -200,12 +200,11 @@ export function PhotoListPage() {
 }
 
 const TABS = [
-  { key: 'all', label: '전체', enabled: true },
-  { key: 'recent', label: '최근', enabled: false },
-  { key: 'favorite', label: '즐겨찾기', enabled: false },
+  { key: 'all', label: '전체', ready: true },
+  { key: 'favorite', label: '즐겨찾기', ready: false },
 ] as const;
 
-// TODO: 최근/즐겨찾기 필터 API 연결 (연결되면 active를 상태로 변경)
+// TODO: 즐겨찾기 필터 API 연결 (연결되면 ready: true + active를 상태로 변경, 안내 토스트 제거)
 function FilterTabs() {
   const active = 'all';
 
@@ -217,12 +216,14 @@ function FilterTabs() {
           <button
             key={tab.key}
             type="button"
-            disabled={!tab.enabled}
             aria-current={isActive ? 'page' : undefined}
+            onClick={() => {
+              if (!tab.ready) toast.info('즐겨찾기는 준비 중이에요.');
+            }}
             className={cn(
               'text-[22px] tracking-tight',
               isActive ? 'text-primary' : 'text-foreground',
-              !tab.enabled && 'opacity-25',
+              !tab.ready && 'opacity-25',
             )}
           >
             {tab.label}

--- a/apps/web/src/shared/ui/toast/index.ts
+++ b/apps/web/src/shared/ui/toast/index.ts
@@ -1,2 +1,2 @@
 export { Toaster } from './toaster';
-export { toast } from 'sonner';
+export { toast, TOAST_DURATION } from './toast';

--- a/apps/web/src/shared/ui/toast/toast.stories.tsx
+++ b/apps/web/src/shared/ui/toast/toast.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TOAST_DURATION, toast } from './toast';
+import { Toaster } from './toaster';
+
+import { Button } from '@/shared/ui/button';
+
+const meta: Meta<typeof Toaster> = {
+  title: 'shared/ui/Toast',
+  component: Toaster,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story, ctx) => (
+      <>
+        <Toaster theme={ctx.globals.theme === 'dark' ? 'dark' : 'light'} />
+        <Story />
+      </>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 유형별 색·아이콘과 노출 시간을 한 화면에서 비교한다. 툴바 Theme으로 라이트/다크를 확인한다. */
+export const AllTypes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant="outline"
+          onClick={() => toast.success('사진을 삭제했어요.')}
+        >
+          성공 {TOAST_DURATION.success / 1000}초
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => toast.info('이미 삭제된 사진이에요.')}
+        >
+          안내 {TOAST_DURATION.info / 1000}초
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => toast.warning('3장 완료 · 1장 실패')}
+        >
+          경고 {TOAST_DURATION.warning / 1000}초
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => toast.error('삭제에 실패했어요.')}
+        >
+          실패 {TOAST_DURATION.error / 1000}초
+        </Button>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        실패 토스트만 닫기 버튼이 있고, 가장 오래 노출된다.
+      </p>
+    </div>
+  ),
+};
+
+/** 실패 토스트: 6초 노출 + 사용자가 직접 닫을 수 있다. */
+export const Error: Story = {
+  render: () => (
+    <Button
+      variant="destructive"
+      onClick={() => toast.error('삭제에 실패했어요.')}
+    >
+      실패 토스트 띄우기
+    </Button>
+  ),
+};
+
+/** 성공 토스트: 3초 후 자동으로 사라진다. */
+export const Success: Story = {
+  render: () => (
+    <Button onClick={() => toast.success('사진을 삭제했어요.')}>
+      성공 토스트 띄우기
+    </Button>
+  ),
+};
+
+/** 여러 개가 쌓였을 때의 정렬·간격을 본다. */
+export const Stacked: Story = {
+  render: () => (
+    <Button
+      variant="outline"
+      onClick={() => {
+        toast.success('사진을 삭제했어요.');
+        toast.warning('3장 완료 · 1장 실패');
+        toast.error('삭제에 실패했어요.');
+      }}
+    >
+      한꺼번에 띄우기
+    </Button>
+  ),
+};

--- a/apps/web/src/shared/ui/toast/toast.ts
+++ b/apps/web/src/shared/ui/toast/toast.ts
@@ -1,0 +1,37 @@
+import { toast as sonner, type ExternalToast } from 'sonner';
+
+/**
+ * 토스트 노출 시간 정책
+ * - 성공/안내는 짧게: 읽지 못해도 흐름에 지장이 없다.
+ * - 실패는 길게: 원인을 읽고 다음 행동을 정할 시간이 필요하다.
+ */
+export const TOAST_DURATION = {
+  success: 3000,
+  info: 3000,
+  warning: 4000,
+  error: 6000,
+} as const;
+
+type Message = Parameters<typeof sonner.success>[0];
+
+/** sonner의 toast에 노출 시간·닫기 버튼 기본값만 입힌 래퍼 */
+export const toast = {
+  success: (message: Message, options?: ExternalToast) =>
+    sonner.success(message, { duration: TOAST_DURATION.success, ...options }),
+
+  info: (message: Message, options?: ExternalToast) =>
+    sonner.info(message, { duration: TOAST_DURATION.info, ...options }),
+
+  warning: (message: Message, options?: ExternalToast) =>
+    sonner.warning(message, { duration: TOAST_DURATION.warning, ...options }),
+
+  // 오래 떠 있는 만큼 사용자가 직접 닫을 수 있어야 한다.
+  error: (message: Message, options?: ExternalToast) =>
+    sonner.error(message, {
+      duration: TOAST_DURATION.error,
+      closeButton: true,
+      ...options,
+    }),
+
+  dismiss: sonner.dismiss,
+};

--- a/apps/web/src/shared/ui/toast/toaster.tsx
+++ b/apps/web/src/shared/ui/toast/toaster.tsx
@@ -1,16 +1,22 @@
 import { Toaster as Sonner, type ToasterProps } from 'sonner';
 
+import { TOAST_DURATION } from './toast';
+
+/**
+ * - toast 배경·글자색은 richColors 팔레트를 덮어쓰므로 지정하지 않는다.
+ * - theme은 앱의 수동 토글 값을 주입한다('system'은 OS 설정만 봄).
+ */
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       className="toaster group"
       position="top-center"
+      richColors
       toastOptions={{
-        duration: 2000,
+        duration: TOAST_DURATION.info,
+        closeButtonAriaLabel: '닫기',
         classNames: {
-          toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-          description: 'group-[.toast]:text-muted-foreground',
+          toast: 'group toast group-[.toaster]:shadow-lg',
           actionButton:
             'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
           cancelButton:

--- a/apps/web/src/widgets/top-bar/ui/top-bar.tsx
+++ b/apps/web/src/widgets/top-bar/ui/top-bar.tsx
@@ -1,6 +1,5 @@
 import { LogOut, Plus } from 'lucide-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { useCurrentAlbumRole } from '@/entities/album';
 import type { UserRole } from '@/entities/user';
@@ -14,6 +13,7 @@ import { SelectToggle } from '@/features/photo-select';
 import { ThemeToggle } from '@/features/theme';
 import { cn } from '@/shared/lib/utils/cn';
 import { Button } from '@/shared/ui/button';
+import { toast } from '@/shared/ui/toast';
 
 /**
  * 모든 라우트에 상시 노출되는 상단 바


### PR DESCRIPTION
## 📌 관련 이슈

* Closed #131

---

## 🧹 작업 내용

### **1. 사진 삭제 후 목록에 유령 카드가 남던 문제 (핵심)**

문제: 사진 삭제 후 뒤로가기 하면 삭제된 사진이 목록에 그대로 보임

원인 흐름
```text
삭제 성공 → invalidateQueries(목록) 호출
         → 근데 기본 동작은 "활성 화면만" 리페치
         → 삭제 시점엔 상세 화면이라 목록 컴포넌트는 비활성 상태
         → 리페치 안 나감 → 캐시는 옛날 데이터 그대로
         → 뒤로가기 → 유령 카드 노출
```

해결
서버 응답 기다리지 않고, 클라이언트 캐시에서 해당 사진을 직접 제거
(추가 요청 없이 즉시 반영, 서버 정합은 기존 invalidate가 백그라운드로 마저 처리)

### 2. 404를 "이미 삭제됨"으로 멱등 처리

문제: 다른 기기에서 이미 지운 사진을 삭제하면 generic "삭제에 실패했어요" 노출

원인 흐름
```text
삭제 요청 → 서버는 이미 없는 사진이라 404 응답
         → 그냥 에러로 처리 → "삭제에 실패했어요" (사실과 다른 안내)
```

해결
```text
404 → isAlreadyDeleted로 판별 → 성공과 동일하게 캐시 정리
   → "이미 삭제된 사진이에요" 안내 후 목록으로 복귀
(단, 요청 자체는 여전히 실패로 남겨서 호출부가 성공/이미삭제를 구분 가능)
```


### 3. 상세 진입 시 오래된 캐시가 리페치되지 않던 문제

문제: 목록에서 상세로 들어가면 오래된 캐시가 그대로 보임(자동 갱신 안 됨)

원인 흐름
```text
목록 캐시를 상세 화면의 initialData로 재사용
→ initialDataUpdatedAt을 안 넘겨줌
→ React Query가 "방금 막 받은 데이터"로 오인
→ staleTime(60초) 동안 리페치를 건너뜀
→ 목록 캐시가 오래됐어도 상세에서 그대로 보임
```

해결
```text
findPhotoInListCache가 dataUpdatedAt(목록을 받아온 시각)도 같이 반환
→ initialDataUpdatedAt으로 넘겨줌
→ React Query가 "이 데이터는 언제 받은 거다"를 정확히 알게 됨
→ 오래된 캐시면 staleTime 계산이 맞아서 즉시 백그라운드 리페치
```

### **4. 토스트 정책 정리** 

- 스크린샷 참고

---

## 🛠️  테스트

* [x] 단위 테스트 통과 (`removeMediaFromLists`, `isAlreadyDeleted`, `findPhotoInListCache`의`dataUpdatedAt` 반환에 대한 케이스 추가)
* [ ] 수동 테스트 완료
* [x] 기존 기능 영향 없음 확인 (타입체크·ESLint 통과)

---

## 📷 스크린샷


https://github.com/user-attachments/assets/1c8242d4-b55f-4fe1-bb8d-dec881de67e7

