### PR TITLE
[Feat] user-events 저장 기능 구현

### DIFF
--- a/apps/joka-api/package.json
+++ b/apps/joka-api/package.json
@@ -13,6 +13,7 @@
     "@joka/core": "workspace:*",
     "@joka/domain-auth": "workspace:*",
     "@joka/domain-media": "workspace:*",
+    "@joka/domain-user-event": "workspace:*",
     "@joka/domain-actor": "workspace:*",
     "@joka/infra-object-storage": "workspace:*",
     "@joka/lib-mime": "workspace:*",

--- a/apps/joka-api/src/application/config/index.ts
+++ b/apps/joka-api/src/application/config/index.ts
@@ -4,6 +4,8 @@ import { ActorService } from '@joka/domain-actor/src/service/actor.service';
 import { AuthService } from '@joka/domain-auth/src/service/auth.service';
 import { MediaRepository } from '@joka/domain-media/src/infrastructure/persistence/media.repository';
 import { MediaService } from '@joka/domain-media/src/service/media.service';
+import { UserEventRepository } from '@joka/domain-user-event/src/infrastructure/persistence/user-event.repository';
+import { UserEventService } from '@joka/domain-user-event/src/service/user-event.service';
 
 class Config {
   private bucketName: string | null = null;
@@ -20,6 +22,11 @@ class Config {
   get mediaService() {
     const mediaRepository = new MediaRepository();
     return new MediaService(mediaRepository);
+  }
+
+  get userEventService() {
+    const userEventRepository = new UserEventRepository();
+    return new UserEventService(userEventRepository);
   }
 
   get mediaBucketName(): string {

--- a/apps/joka-api/src/application/use-case/command/CreateUserEventsImpl.ts
+++ b/apps/joka-api/src/application/use-case/command/CreateUserEventsImpl.ts
@@ -1,0 +1,19 @@
+import {
+  CreateUserEvents,
+  Request,
+  Response,
+} from '../../../domain/use-case/CreateUserEvents';
+import Config from '../../config';
+
+export class CreateUserEventsImpl extends CreateUserEvents {
+  private readonly userEventService = Config.userEventService;
+
+  override async invoke(request: Request): Promise<Response> {
+    const { actor, events } = request;
+    const { album, user } = actor;
+
+    return this.userEventService.create({ album, user }, { events });
+  }
+}
+
+export default new CreateUserEventsImpl();

--- a/apps/joka-api/src/application/use-case/index.ts
+++ b/apps/joka-api/src/application/use-case/index.ts
@@ -5,6 +5,7 @@ export { default as DeleteMedia } from './command/DeleteMediaImpl';
 export { default as CreateUploadUrlForMedia } from './command/CreateUploadUrlForMediaImpl';
 export { default as CreateContent } from './command/CreateContentImpl';
 export { default as ConfirmMedia } from './command/ConfirmMediaImpl';
+export { default as CreateUserEvents } from './command/CreateUserEventsImpl';
 
 // queries
 export { default as GetMedia } from './query/GetMediaImpl';

--- a/apps/joka-api/src/domain/use-case/CreateUserEvents.ts
+++ b/apps/joka-api/src/domain/use-case/CreateUserEvents.ts
@@ -1,0 +1,21 @@
+import { Actor } from '@joka/domain-actor/src/domain/Actor';
+import { Payload } from '@joka/domain-user-event/src/domain/type';
+
+import { UseCase } from './UseCase';
+
+const UseCaseName = 'CreateUserEvents' as const;
+
+export interface Request {
+  actor: Actor;
+  events: Payload[];
+}
+
+export type Response = null;
+
+export abstract class CreateUserEvents implements UseCase<Request, Response> {
+  get name(): string {
+    return UseCaseName;
+  }
+
+  abstract invoke(request: Request): Promise<Response>;
+}

--- a/apps/joka-api/src/index.ts
+++ b/apps/joka-api/src/index.ts
@@ -11,6 +11,7 @@ import albums from './infrastructure/web/v1/albums.controller';
 import authController from './infrastructure/web/v1/auth.controller';
 import me from './infrastructure/web/v1/me.controller';
 import media from './infrastructure/web/v1/media.controller';
+import userEvents from './infrastructure/web/v1/user-events.controller';
 
 const DEFAULT_ALLOWED_ORIGINS = ['http://localhost:5173'];
 
@@ -40,11 +41,13 @@ app.use('*', hyperdrive);
 app.use('*', objectStorage);
 app.use('*', auth);
 app.use('/v1/media/*', actorResolver);
+app.use('/v1/user-events/*', actorResolver);
 
 app.route('/', authController);
 app.route('/', me);
 app.route('/', albums);
 app.route('/', media);
+app.route('/', userEvents);
 
 export default {
   fetch: app.fetch,

--- a/apps/joka-api/src/infrastructure/web/v1/user-events.controller.ts
+++ b/apps/joka-api/src/infrastructure/web/v1/user-events.controller.ts
@@ -1,0 +1,24 @@
+import { InvalidArgumentException } from '@joka/core/src/exception';
+import { Hono } from 'hono';
+
+import type { CloudflareEnv } from '../../../application/model';
+import { CreateUserEvents } from '../../../application/use-case';
+
+const userEvents = new Hono<CloudflareEnv>().basePath('/v1/user-events');
+
+userEvents.post('/', async (c) => {
+  const { events } = await c.req.json();
+  if (!Array.isArray(events)) {
+    throw new InvalidArgumentException('INVALID_ARGUMENT', [
+      'events는 배열이어야 합니다.',
+    ]);
+  }
+
+  const actor = c.get('actor');
+
+  await CreateUserEvents.invoke({ actor, events });
+
+  return c.body(null, 204);
+});
+
+export default userEvents;

--- a/packages/domain-user-event/jest.config.js
+++ b/packages/domain-user-event/jest.config.js
@@ -1,0 +1,8 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+    displayName: 'domain-user-event',
+    rootDir: '.',
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};

--- a/packages/domain-user-event/jest.setup.js
+++ b/packages/domain-user-event/jest.setup.js
@@ -1,0 +1,3 @@
+require('dotenv').config({
+    path: ".local.env",
+});

--- a/packages/domain-user-event/package.json
+++ b/packages/domain-user-event/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@joka/domain-user-event",
+  "version": "0.0.1",
+  "description": "domain-user-event package",
+  "scripts": {
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
+  },
+  "dependencies": {
+    "@joka/core": "workspace:*",
+    "@joka/lib-drizzle": "workspace:*",
+    "drizzle-orm": "^0.45.1",
+    "postgres": "^3.4.8",
+    "uuid": "^13.0.0"
+  }
+}

--- a/packages/domain-user-event/src/domain/UserEvent.ts
+++ b/packages/domain-user-event/src/domain/UserEvent.ts
@@ -1,0 +1,60 @@
+import { Actioned } from '@joka/core/src/model/Actioned';
+import { Album } from '@joka/core/src/model/Album';
+import { User } from '@joka/core/src/model/User';
+import { z } from 'zod';
+
+import { Payload } from './type';
+
+interface ConstructorParameters {
+  album: Album;
+  user: User;
+  event: Payload;
+}
+
+export class UserEvent {
+  static from(params: ConstructorParameters): UserEvent {
+    const created = Actioned.from({ by: params.user });
+    const userEvent = new UserEvent(params.album.id, params.event, created);
+
+    UserEvent.Schema.parse(userEvent.data);
+
+    return userEvent;
+  }
+
+  static get Schema() {
+    return z.object({
+      albumId: z.number().positive(),
+      event: z.looseObject({
+        name: z.string().min(1),
+        timestamp: z.number(),
+        userRole: z.enum(['EDITOR', 'VIEWER', 'ADMIN']),
+      }),
+      created: Actioned.Schema,
+    });
+  }
+
+  private constructor(
+    public readonly albumId: number,
+    public readonly event: Payload,
+    public readonly created: Actioned,
+  ) {}
+
+  get data() {
+    const data = {
+      ...this,
+      created: {
+        at: this.created.at,
+        by: {
+          ...this.created.by,
+          email: this.created.by.email.value,
+        },
+      },
+    };
+
+    UserEvent.Schema.parse(data);
+
+    return data;
+  }
+}
+
+export type UserEventType = z.infer<typeof UserEvent.Schema>;

--- a/packages/domain-user-event/src/domain/UserEvent.ts
+++ b/packages/domain-user-event/src/domain/UserEvent.ts
@@ -5,6 +5,8 @@ import { z } from 'zod';
 
 import { Payload } from './type';
 
+export const MAX_EVENTS_LENGTH = 20 as const;
+
 interface ConstructorParameters {
   album: Album;
   user: User;

--- a/packages/domain-user-event/src/domain/type/index.ts
+++ b/packages/domain-user-event/src/domain/type/index.ts
@@ -1,0 +1,7 @@
+export interface Payload {
+  name: string;
+  timestamp: number;
+  // TODO: Actor Role과 통합 필요해보임
+  userRole: 'EDITOR' | 'VIEWER' | 'ADMIN';
+  [key: string]: unknown;
+}

--- a/packages/domain-user-event/src/infrastructure/persistence/user-event.repository.ts
+++ b/packages/domain-user-event/src/infrastructure/persistence/user-event.repository.ts
@@ -1,0 +1,34 @@
+import { InvalidArgumentException } from '@joka/core/src/exception';
+import ClientFactory from '@joka/lib-drizzle/src/client';
+import * as Schema from '@joka/lib-drizzle/src/schema';
+
+import { UserEvent } from '../../domain/UserEvent';
+
+const { userEvents } = Schema;
+
+export class UserEventRepository {
+  constructor() {}
+
+  private get connection() {
+    return ClientFactory.createInstance();
+  }
+
+  async insertMany(events: UserEvent[]): Promise<null> {
+    if (!events.length) {
+      throw new InvalidArgumentException('EMPTY_PAYLOAD', [
+        `저장할 이벤트가 전달되지 않았습니다.`,
+      ]);
+    }
+
+    await this.connection.insert(userEvents).values(
+      events.map((event) => ({
+        albumId: event.albumId,
+        event: event.event,
+        createdAt: event.created.at,
+        createdById: event.created.by.id,
+      })),
+    );
+
+    return null;
+  }
+}

--- a/packages/domain-user-event/src/service/user-event.service.ts
+++ b/packages/domain-user-event/src/service/user-event.service.ts
@@ -1,0 +1,38 @@
+import { InvalidArgumentException } from '@joka/core/src/exception';
+import { Album } from '@joka/core/src/model/Album';
+import { User } from '@joka/core/src/model/User';
+
+import { Payload } from '../domain/type';
+import { UserEvent } from '../domain/UserEvent';
+import { UserEventRepository } from '../infrastructure/persistence/user-event.repository';
+
+interface Context {
+  album: Album;
+  user: User;
+}
+interface CreateRequest {
+  events: Payload[];
+}
+
+export class UserEventService {
+  constructor(private repository: UserEventRepository) {}
+
+  async create(context: Context, request: CreateRequest): Promise<null> {
+    const events = request.events.map((event) =>
+      UserEvent.from({
+        album: context.album,
+        user: context.user,
+        event,
+      }),
+    );
+    if (!events.length) {
+      throw new InvalidArgumentException('EMPTY_PAYLOAD', [
+        `저장할 이벤트가 전달되지 않았습니다.`,
+      ]);
+    }
+
+    await this.repository.insertMany(events);
+
+    return null;
+  }
+}

--- a/packages/domain-user-event/src/service/user-event.service.ts
+++ b/packages/domain-user-event/src/service/user-event.service.ts
@@ -3,7 +3,7 @@ import { Album } from '@joka/core/src/model/Album';
 import { User } from '@joka/core/src/model/User';
 
 import { Payload } from '../domain/type';
-import { UserEvent } from '../domain/UserEvent';
+import { MAX_EVENTS_LENGTH, UserEvent } from '../domain/UserEvent';
 import { UserEventRepository } from '../infrastructure/persistence/user-event.repository';
 
 interface Context {
@@ -28,6 +28,11 @@ export class UserEventService {
     if (!events.length) {
       throw new InvalidArgumentException('EMPTY_PAYLOAD', [
         `저장할 이벤트가 전달되지 않았습니다.`,
+      ]);
+    }
+    if (events.length > MAX_EVENTS_LENGTH) {
+      throw new InvalidArgumentException('TOO_MANY_EVENTS', [
+        `한 번에 저장할 수 있는 이벤트는 최대 ${MAX_EVENTS_LENGTH}개입니다.`,
       ]);
     }
 

--- a/packages/domain-user-event/test/domain/UserEvent.test.ts
+++ b/packages/domain-user-event/test/domain/UserEvent.test.ts
@@ -1,0 +1,116 @@
+import { UserEvent } from '../../src/domain/UserEvent';
+
+jest.mock('@joka/core/src/model/Actioned', () => {
+  const { z: zod } = jest.requireActual('zod');
+  return {
+    Actioned: {
+      from: jest.fn((params) => ({
+        at: params.at || new Date('2024-01-01'),
+        by: params.by,
+      })),
+      Schema: zod.object({
+        at: zod.date(),
+        by: zod.object({
+          id: zod.number(),
+          cid: zod.string(),
+          name: zod.string(),
+          email: zod.string(),
+        }),
+      }),
+    },
+  };
+});
+
+const createMockUser = (id: number = 1) => ({
+  id,
+  cid: `user-cid-${id}`,
+  name: `user-${id}`,
+  email: { value: `user${id}@example.com` },
+});
+
+const createMockAlbum = (id: number = 1) => ({
+  id,
+  cid: `album-cid-${id}`,
+  name: `album-${id}`,
+  description: '테스트 앨범',
+  isDeleted: false,
+});
+
+const createParams = (event: Record<string, unknown> = {}) => ({
+  album: createMockAlbum(),
+  user: createMockUser(),
+  event: {
+    name: 'list.view',
+    timestamp: 1700000000000,
+    userRole: 'EDITOR',
+    ...event,
+  },
+});
+
+describe('UserEvent', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('from', () => {
+    it('유효한 이벤트로 UserEvent를 생성한다', () => {
+      // given
+      const params = createParams();
+
+      // when
+      const userEvent = UserEvent.from(params as any);
+
+      // then
+      expect(userEvent).toBeInstanceOf(UserEvent);
+      expect(userEvent.albumId).toBe(1);
+      expect(userEvent.event.name).toBe('list.view');
+      expect(userEvent.event.timestamp).toBe(1700000000000);
+      expect(userEvent.event.userRole).toBe('EDITOR');
+      expect(userEvent.created.by.id).toBe(1);
+    });
+
+    it('name/timestamp/userRole 외의 추가 필드를 그대로 보존한다', () => {
+      // given
+      const params = createParams({
+        sessionId: 'session-123',
+        route: '/albums/1',
+        appVersion: '1.2.3',
+        props: { scrollDepth: 80 },
+      });
+
+      // when
+      const userEvent = UserEvent.from(params as any);
+
+      // then
+      expect(userEvent.event.sessionId).toBe('session-123');
+      expect(userEvent.event.route).toBe('/albums/1');
+      expect(userEvent.event.appVersion).toBe('1.2.3');
+      expect(userEvent.event.props).toEqual({ scrollDepth: 80 });
+      expect(userEvent.data.event.props).toEqual({ scrollDepth: 80 });
+    });
+
+    it('name이 비어 있으면 예외를 던진다', () => {
+      // given
+      const params = createParams({ name: '' });
+
+      // when & then
+      expect(() => UserEvent.from(params as any)).toThrow();
+    });
+
+    it('timestamp가 숫자가 아니면 예외를 던진다', () => {
+      // given
+      const params = createParams({ timestamp: 'not-a-number' });
+
+      // when & then
+      expect(() => UserEvent.from(params as any)).toThrow();
+    });
+
+    it('userRole이 허용되지 않은 값이면 예외를 던진다', () => {
+      // given
+      const params = createParams({ userRole: 'GUEST' });
+
+      // when & then
+      expect(() => UserEvent.from(params as any)).toThrow();
+    });
+  });
+});

--- a/packages/domain-user-event/test/service/user-event.service.test.ts
+++ b/packages/domain-user-event/test/service/user-event.service.test.ts
@@ -1,0 +1,89 @@
+import { InvalidArgumentException } from '@joka/core/src/exception';
+
+import { UserEventRepository } from '../../src/infrastructure/persistence/user-event.repository';
+import { UserEventService } from '../../src/service/user-event.service';
+
+const createMockUser = () => ({
+  id: 1,
+  cid: 'user-123',
+  name: 'tester',
+  email: { value: 'test@example.com' },
+});
+
+const createMockAlbum = () => ({
+  id: 1,
+  cid: 'album-123',
+  name: '테스트 앨범',
+  description: '테스트용 앨범',
+  isDeleted: false,
+});
+
+const createMockContext = () => ({
+  album: createMockAlbum(),
+  user: createMockUser(),
+});
+
+jest.mock('../../src/domain/UserEvent', () => ({
+  UserEvent: {
+    from: jest.fn((params) => ({
+      albumId: params.album.id,
+      event: params.event,
+      created: { at: new Date(), by: params.user },
+    })),
+  },
+}));
+
+describe('UserEventService', () => {
+  let service: UserEventService;
+  let mockRepository: jest.Mocked<UserEventRepository>;
+
+  beforeEach(() => {
+    mockRepository = {
+      insertMany: jest.fn(),
+    } as unknown as jest.Mocked<UserEventRepository>;
+
+    service = new UserEventService(mockRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('events를 UserEvent로 매핑하고 repository.insertMany를 호출한다', async () => {
+      // given
+      const context = createMockContext();
+      const request = {
+        events: [
+          { name: 'list.view', timestamp: 1, userRole: 'EDITOR' as const },
+          { name: 'detail.view', timestamp: 2, userRole: 'VIEWER' as const },
+        ],
+      };
+      // @ts-ignore
+      mockRepository.insertMany.mockResolvedValue(undefined);
+
+      // when
+      const result = await service.create(context as any, request);
+
+      // then
+      expect(result).toBeNull();
+      expect(mockRepository.insertMany).toHaveBeenCalledTimes(1);
+      const inserted = mockRepository.insertMany.mock.calls[0][0];
+      expect(inserted).toHaveLength(2);
+      expect(inserted[0].event.name).toBe('list.view');
+      expect(inserted[1].event.name).toBe('detail.view');
+    });
+
+    it('빈 events 배열이면 InvalidArgumentException을 던지고 insertMany를 호출하지 않는다', async () => {
+      // given
+      const context = createMockContext();
+      const request = { events: [] };
+
+      // when & then
+      await expect(service.create(context as any, request)).rejects.toThrow(
+        InvalidArgumentException,
+      );
+      expect(mockRepository.insertMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/domain-user-event/test/service/user-event.service.test.ts
+++ b/packages/domain-user-event/test/service/user-event.service.test.ts
@@ -24,6 +24,7 @@ const createMockContext = () => ({
 });
 
 jest.mock('../../src/domain/UserEvent', () => ({
+  MAX_EVENTS_LENGTH: 20,
   UserEvent: {
     from: jest.fn((params) => ({
       albumId: params.album.id,
@@ -78,6 +79,41 @@ describe('UserEventService', () => {
       // given
       const context = createMockContext();
       const request = { events: [] };
+
+      // when & then
+      await expect(service.create(context as any, request)).rejects.toThrow(
+        InvalidArgumentException,
+      );
+      expect(mockRepository.insertMany).not.toHaveBeenCalled();
+    });
+
+    const createEvents = (length: number) =>
+      Array.from({ length }, (_, index) => ({
+        name: `event.${index}`,
+        timestamp: index,
+        userRole: 'EDITOR' as const,
+      }));
+
+    it('events가 최대 길이(20)이면 정상적으로 insertMany를 호출한다', async () => {
+      // given
+      const context = createMockContext();
+      const request = { events: createEvents(20) };
+      // @ts-ignore
+      mockRepository.insertMany.mockResolvedValue(undefined);
+
+      // when
+      const result = await service.create(context as any, request);
+
+      // then
+      expect(result).toBeNull();
+      expect(mockRepository.insertMany).toHaveBeenCalledTimes(1);
+      expect(mockRepository.insertMany.mock.calls[0][0]).toHaveLength(20);
+    });
+
+    it('events가 최대 길이(20)를 초과하면 InvalidArgumentException을 던지고 insertMany를 호출하지 않는다', async () => {
+      // given
+      const context = createMockContext();
+      const request = { events: createEvents(21) };
 
       // when & then
       await expect(service.create(context as any, request)).rejects.toThrow(

--- a/packages/domain-user-event/tsconfig.json
+++ b/packages/domain-user-event/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "composite": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "test", "dist"]
+}

--- a/packages/lib-drizzle/.drizzle/0001_aspiring_ravenous.sql
+++ b/packages/lib-drizzle/.drizzle/0001_aspiring_ravenous.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "joka"."user_events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"cid" uuid NOT NULL,
+	"album_id" integer NOT NULL,
+	"event" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"created_by_id" integer NOT NULL,
+	CONSTRAINT "user_events_cid_unique" UNIQUE("cid")
+);
+--> statement-breakpoint
+ALTER TABLE "joka"."user_events" ADD CONSTRAINT "user_events_album_id_fk" FOREIGN KEY ("album_id") REFERENCES "joka"."albums"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "joka"."user_events" ADD CONSTRAINT "user_events_created_by_fk" FOREIGN KEY ("created_by_id") REFERENCES "joka"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/packages/lib-drizzle/.drizzle/meta/0001_snapshot.json
+++ b/packages/lib-drizzle/.drizzle/meta/0001_snapshot.json
@@ -1,0 +1,645 @@
+{
+  "id": "9c1d6c11-fc93-40ab-96a3-a8a2ebe695cb",
+  "prevId": "13ebb96c-7ea9-413f-a535-5048c8671cc7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "joka.albums": {
+      "name": "albums",
+      "schema": "joka",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "albums_cid_unique": {
+          "name": "albums_cid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "joka.contents": {
+      "name": "contents",
+      "schema": "joka",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eTag": {
+          "name": "eTag",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contents_media_id_fk": {
+          "name": "contents_media_id_fk",
+          "tableFrom": "contents",
+          "tableTo": "media",
+          "schemaTo": "joka",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contents_cid_unique": {
+          "name": "contents_cid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cid"
+          ]
+        },
+        "contents_media_id_unique": {
+          "name": "contents_media_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "joka.media": {
+      "name": "media",
+      "schema": "joka",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_album_id_fk": {
+          "name": "media_album_id_fk",
+          "tableFrom": "media",
+          "tableTo": "albums",
+          "schemaTo": "joka",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_created_by_fk": {
+          "name": "media_created_by_fk",
+          "tableFrom": "media",
+          "tableTo": "users",
+          "schemaTo": "joka",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_updated_by_fk": {
+          "name": "media_updated_by_fk",
+          "tableFrom": "media",
+          "tableTo": "users",
+          "schemaTo": "joka",
+          "columnsFrom": [
+            "updated_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_cid_unique": {
+          "name": "media_cid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "joka.thumbnails": {
+      "name": "thumbnails",
+      "schema": "joka",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eTag": {
+          "name": "eTag",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blurhash": {
+          "name": "blurhash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thumbnails_content_id_fk": {
+          "name": "thumbnails_content_id_fk",
+          "tableFrom": "thumbnails",
+          "tableTo": "contents",
+          "schemaTo": "joka",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "thumbnails_cid_unique": {
+          "name": "thumbnails_cid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cid"
+          ]
+        },
+        "thumbnails_content_id_unique": {
+          "name": "thumbnails_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "joka.user_events": {
+      "name": "user_events",
+      "schema": "joka",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_events_album_id_fk": {
+          "name": "user_events_album_id_fk",
+          "tableFrom": "user_events",
+          "tableTo": "albums",
+          "schemaTo": "joka",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_events_created_by_fk": {
+          "name": "user_events_created_by_fk",
+          "tableFrom": "user_events",
+          "tableTo": "users",
+          "schemaTo": "joka",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_events_cid_unique": {
+          "name": "user_events_cid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "joka.user_roles": {
+      "name": "user_roles",
+      "schema": "joka",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'VIEWER'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_fk_1": {
+          "name": "user_roles_fk_1",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "schemaTo": "joka",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_fk_2": {
+          "name": "user_roles_fk_2",
+          "tableFrom": "user_roles",
+          "tableTo": "albums",
+          "schemaTo": "joka",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_roles_uq_1": {
+          "name": "user_roles_uq_1",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "joka.user_whitelists": {
+      "name": "user_whitelists",
+      "schema": "joka",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "joka.users": {
+      "name": "users",
+      "schema": "joka",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_cid_unique": {
+          "name": "users_cid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "joka": "joka"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/lib-drizzle/.drizzle/meta/_journal.json
+++ b/packages/lib-drizzle/.drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777934341091,
       "tag": "0000_broken_shard",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1783863135451,
+      "tag": "0001_aspiring_ravenous",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/lib-drizzle/src/schema/index.ts
+++ b/packages/lib-drizzle/src/schema/index.ts
@@ -9,6 +9,7 @@ import {
   unique,
   foreignKey,
   uuid,
+  jsonb,
 } from 'drizzle-orm/pg-core';
 import { v7 as uuidv7 } from 'uuid';
 
@@ -149,6 +150,33 @@ export const thumbnails = jokaSchema.table(
       columns: [t.contentId],
       foreignColumns: [contents.id],
       name: 'thumbnails_content_id_fk',
+    }),
+  }),
+);
+
+export const userEvents = jokaSchema.table(
+  'user_events',
+  {
+    id: serial('id').primaryKey(),
+    cid: uuid('cid')
+      .$defaultFn(() => uuidv7())
+      .unique()
+      .notNull(),
+    albumId: integer('album_id').notNull(),
+    event: jsonb('event').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    createdById: integer('created_by_id').notNull(),
+  },
+  (t) => ({
+    userEventsAlbumFk: foreignKey({
+      columns: [t.albumId],
+      foreignColumns: [albums.id],
+      name: 'user_events_album_id_fk',
+    }),
+    userEventsCreatedByFk: foreignKey({
+      columns: [t.createdById],
+      foreignColumns: [users.id],
+      name: 'user_events_created_by_fk',
     }),
   }),
 );

--- a/packages/lib-openapi/docs/api-v1.yml
+++ b/packages/lib-openapi/docs/api-v1.yml
@@ -13,6 +13,29 @@ info:
 servers:
   - url: 'http://mindjuk.dev/api/v1'
 paths:
+  /user-events:
+    post:
+      tags:
+        - joka
+      summary: User Event 수집
+      description: 사용자 행동 이벤트를 수집합니다.
+      operationId: createUserEvents
+      parameters:
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/X-Album-Id'
+      requestBody:
+        $ref: '#/components/requestBodies/CreateUserEvents'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          $ref: '#/components/responses/Error'
+        '401':
+          $ref: '#/components/responses/Error'
+        '403':
+          $ref: '#/components/responses/Error'
+      servers:
+        - url: 'http://mindjuk.dev/api/v1'
   /media:
     post:
       tags:
@@ -383,6 +406,36 @@ components:
       schema:
         type: string
   requestBodies:
+    CreateUserEvents:
+      description: User Event 수집 요청
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            properties:
+              events:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+                  properties:
+                    name:
+                      type: string
+                      description: 이벤트 이름
+                      minLength: 1
+                    timestamp:
+                      type: integer
+                      description: 이벤트 발생 시각(epoch millis)
+                      format: int64
+                    userRole:
+                      $ref: '#/components/schemas/Role'
+                  required:
+                    - name
+                    - timestamp
+                    - userRole
+            required:
+              - events
     CreateMedia:
       description: Media 생성 요청
       content:

--- a/packages/lib-openapi/src/generated/api-v1.d.ts
+++ b/packages/lib-openapi/src/generated/api-v1.d.ts
@@ -4,872 +4,937 @@
  */
 
 export interface paths {
-  '/media': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/user-events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * User Event 수집
+         * @description 사용자 행동 이벤트를 수집합니다.
+         */
+        post: operations["createUserEvents"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Media 목록 조회
-     * @description Media의 목록을 조회합니다.
-     */
-    get: operations['listMedia'];
-    put?: never;
-    /**
-     * Media 생성
-     * @description Media를 생성합니다.
-     */
-    post: operations['createMedia'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/media/{cid}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/media": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Media 목록 조회
+         * @description Media의 목록을 조회합니다.
+         */
+        get: operations["listMedia"];
+        put?: never;
+        /**
+         * Media 생성
+         * @description Media를 생성합니다.
+         */
+        post: operations["createMedia"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Media 상세 조회
-     * @description Media를 상세 조회합니다.
-     */
-    get: operations['getMedia'];
-    put?: never;
-    post?: never;
-    /**
-     * Media 삭제
-     * @description Media를 삭제합니다.
-     */
-    delete: operations['deleteMedia'];
-    options?: never;
-    head?: never;
-    /**
-     * Media 수정
-     * @description Media를 수정합니다.
-     */
-    patch: operations['updateMedia'];
-    trace?: never;
-  };
-  '/media/{cid}/upload-urls': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/media/{cid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Media 상세 조회
+         * @description Media를 상세 조회합니다.
+         */
+        get: operations["getMedia"];
+        put?: never;
+        post?: never;
+        /**
+         * Media 삭제
+         * @description Media를 삭제합니다.
+         */
+        delete: operations["deleteMedia"];
+        options?: never;
+        head?: never;
+        /**
+         * Media 수정
+         * @description Media를 수정합니다.
+         */
+        patch: operations["updateMedia"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Media 업로드 URL 생성
-     * @description Media 전용 업로드 URL을 생성합니다.
-     */
-    post: operations['createUploadUrlForMedia'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/media/{cid}/confirm': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/media/{cid}/upload-urls": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Media 업로드 URL 생성
+         * @description Media 전용 업로드 URL을 생성합니다.
+         */
+        post: operations["createUploadUrlForMedia"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Media 확정
-     * @description Media의 상태를 확정합니다.
-     */
-    post: operations['confirmMedia'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/media/{cid}/contents': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/media/{cid}/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Media 확정
+         * @description Media의 상태를 확정합니다.
+         */
+        post: operations["confirmMedia"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Content 생성
-     * @description Media에 Content를 생성합니다.
-     */
-    post: operations['createContent'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/albums': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/media/{cid}/contents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Content 생성
+         * @description Media에 Content를 생성합니다.
+         */
+        post: operations["createContent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Album 목록 조회
-     * @description Album의 목록을 조회합니다.
-     */
-    get: operations['listAlbums'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/login': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/albums": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Album 목록 조회
+         * @description Album의 목록을 조회합니다.
+         */
+        get: operations["listAlbums"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 로그인
-     * @description JOKA 애플리케이션에 로그인합니다.
-     */
-    post: operations['login'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/logout': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 로그인
+         * @description JOKA 애플리케이션에 로그인합니다.
+         */
+        post: operations["login"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 로그아웃
-     * @description JOKA 애플리케이션으로부터 로그아웃합니다.
-     */
-    post: operations['logout'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/me': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 로그아웃
+         * @description JOKA 애플리케이션으로부터 로그아웃합니다.
+         */
+        post: operations["logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * '나' 상세 조회
-     * @description 로그인한 사용자의 상세 정보를 조회합니다.
-     */
-    get: operations['getMyInfo'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * '나' 상세 조회
+         * @description 로그인한 사용자의 상세 정보를 조회합니다.
+         */
+        get: operations["getMyInfo"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    /**
-     * Media
-     * @description Media와 관련된 정보
-     */
-    Media: {
-      /** @description 식별자 */
-      id: string;
-      /** @description 설명 */
-      description: string;
-      state: components['schemas']['MediaState'];
-      content?: components['schemas']['Content'];
-      /** @description 즐겨찾기 등록 여부 */
-      isFavorite: boolean;
-      created: components['schemas']['Actioned'];
-    };
-    /**
-     * MediaState
-     * @description Media 상태 정보
-     * @enum {string}
-     */
-    MediaState: 'DRAFT' | 'PREPARING' | 'COMPLETE';
-    /**
-     * Content
-     * @description Content와 관련된 정보
-     */
-    Content: {
-      location: components['schemas']['Location'];
-      /**
-       * Format: int64
-       * @description 용량
-       */
-      size: number;
-      /** @description 엔티티 태그 */
-      eTag: string;
-      /**
-       * @description 컨텐츠 타입
-       * @example image/png
-       */
-      mimeType: string;
-      thumbnail?: components['schemas']['Thumbnail'];
-    };
-    /**
-     * Location
-     * @description Location과 관련된 정보
-     */
-    Location: {
-      /**
-       * Format: uri
-       * @description URL 주소
-       */
-      url: string;
-      /**
-       * Format: uri
-       * @description 접근 가능한 URL 주소
-       */
-      accessUrl: string;
-    };
-    /**
-     * Thumbnail
-     * @description Thumbnail과 관련된 정보
-     */
-    Thumbnail: {
-      location: components['schemas']['Location'];
-      /**
-       * Format: int64
-       * @description 용량
-       */
-      size: number;
-      /** @description 엔티티 태그 */
-      eTag: string;
-      /**
-       * @description 컨텐츠 타입
-       * @example image/jpeg
-       */
-      mimeType: string;
-      /**
-       * @description blurhash 라이브러리용 해시값
-       * @example LEHV6nWB2yk8pyo0adR*.7kCMdnj
-       */
-      blurhash: string;
-    };
-    /**
-     * Actioned
-     * @description 행위와 관련된 정보
-     */
-    Actioned: {
-      /**
-       * Format: date-time
-       * @description 발생 일시
-       */
-      at: string;
-      by: components['schemas']['User'];
-    };
-    /**
-     * User
-     * @description User와 관련된 정보
-     */
-    User: {
-      /** @description 식별자 */
-      id: string;
-      /** @description 이름 */
-      name: string;
-      /**
-       * Format: email
-       * @description 이메일 주소
-       */
-      email: string;
-    };
-    /**
-     * Role
-     * @description Role 종류
-     * @enum {string}
-     */
-    Role: 'ADMIN' | 'EDITOR' | 'VIEWER';
-    /**
-     * Error
-     * @description Error와 관련된 정보
-     */
-    Error: {
-      /**
-       * Format: uuid
-       * @description 트레이스
-       */
-      traceId: string;
-      /**
-       * @description API 경로
-       * @example /api/v1/media/xxx
-       */
-      path: string;
-      /**
-       * Format: int32
-       * @description HTTP 상태 코드
-       * @example 404
-       */
-      status: number;
-      /**
-       * @description 비즈니스 에러 코드
-       * @example MEDIA_NOT_FOUND
-       */
-      code: string;
-      /** @description 설명 문구 */
-      messages: string[];
-      /** @description 발생 시각 */
-      timestamp: string;
-    };
-    /**
-     * Album
-     * @description Album과 관련된 정보
-     */
-    Album: {
-      /** @description 식별자 */
-      id: string;
-      /** @description 이름 */
-      name: string;
-      role: components['schemas']['Role'];
-    };
-  };
-  responses: {
-    /** @description Media 생성 응답 */
-    CreateMedia: {
-      headers: {
-        /** @description Media 위치 */
-        Location?: string;
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': components['schemas']['Media'];
-      };
-    };
-    /** @description Media 목록 조회 응답 */
-    ListMedia: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': {
-          items: components['schemas']['Media'][];
-          /** @description 이번 조회에 적용된 페이지네이션과 관련된 정보 */
-          pagination: {
+    schemas: {
+        /**
+         * Media
+         * @description Media와 관련된 정보
+         */
+        Media: {
+            /** @description 식별자 */
+            id: string;
+            /** @description 설명 */
+            description: string;
+            state: components["schemas"]["MediaState"];
+            content?: components["schemas"]["Content"];
+            /** @description 즐겨찾기 등록 여부 */
+            isFavorite: boolean;
+            created: components["schemas"]["Actioned"];
+        };
+        /**
+         * MediaState
+         * @description Media 상태 정보
+         * @enum {string}
+         */
+        MediaState: "DRAFT" | "PREPARING" | "COMPLETE";
+        /**
+         * Content
+         * @description Content와 관련된 정보
+         */
+        Content: {
+            location: components["schemas"]["Location"];
             /**
-             * Format: int32
-             * @description 목록에 포함될 요소 개수
+             * Format: int64
+             * @description 용량
              */
             size: number;
+            /** @description 엔티티 태그 */
+            eTag: string;
             /**
-             * @description 정렬 기준
-             * @enum {string}
+             * @description 컨텐츠 타입
+             * @example image/png
              */
-            sortBy: 'CREATED_AT';
+            mimeType: string;
+            thumbnail?: components["schemas"]["Thumbnail"];
+        };
+        /**
+         * Location
+         * @description Location과 관련된 정보
+         */
+        Location: {
             /**
-             * @description 정렬 순서
-             * @enum {string}
+             * Format: uri
+             * @description URL 주소
              */
-            order: 'ASC' | 'DESC';
-            /** @description 커서 */
-            nextCursor?: string;
-            /** @description 다음 페이지 존재 여부 */
-            hasNext: boolean;
-          };
-        };
-      };
-    };
-    /** @description Media 상세 조회 응답 */
-    GetMedia: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': components['schemas']['Media'];
-      };
-    };
-    /** @description Media 수정 응답 */
-    UpdateMedia: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': components['schemas']['Media'];
-      };
-    };
-    /** @description Media 전용 업로드 URL 생성 응답 */
-    CreateUploadUrlForMedia: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': {
-          /**
-           * Format: uri
-           * @description URL 주소
-           */
-          url: string;
-        };
-      };
-    };
-    /** @description Content 생성 응답 */
-    CreateContent: {
-      headers: {
-        /** @description Content 위치 */
-        Location?: string;
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': components['schemas']['Content'];
-      };
-    };
-    /** @description 로그인 응답 */
-    Login: {
-      headers: {
-        /** @description 리프레쉬 토큰 정보 */
-        'Set-Cookie'?: string;
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': {
-          /** @description 액세스 토큰 */
-          accessToken: string;
-        };
-      };
-    };
-    /** @description Media 확정 응답 */
-    ConfirmMedia: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': components['schemas']['Media'];
-      };
-    };
-    /** @description '나' 상세 조회 응답 */
-    GetMe: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': {
-          /** @description 식별자 */
-          id: string;
-          /** @description 이름 */
-          name: string;
-          /**
-           * Format: email
-           * @description 이메일 주소
-           */
-          email: string;
-        };
-      };
-    };
-    /** @description 요청 처리 실패 응답 */
-    Error: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': components['schemas']['Error'];
-      };
-    };
-    /** @description Album 목록 조회 응답 */
-    ListAlbums: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        'application/json': {
-          items: components['schemas']['Album'][];
-          /** @description 이번 조회에 적용된 페이지네이션과 관련된 정보 */
-          pagination: {
+            url: string;
             /**
-             * Format: int32
-             * @description 목록에 포함될 요소 개수
+             * Format: uri
+             * @description 접근 가능한 URL 주소
+             */
+            accessUrl: string;
+        };
+        /**
+         * Thumbnail
+         * @description Thumbnail과 관련된 정보
+         */
+        Thumbnail: {
+            location: components["schemas"]["Location"];
+            /**
+             * Format: int64
+             * @description 용량
              */
             size: number;
+            /** @description 엔티티 태그 */
+            eTag: string;
             /**
-             * @description 정렬 순서
-             * @enum {string}
+             * @description 컨텐츠 타입
+             * @example image/jpeg
              */
-            order: 'ASC' | 'DESC';
-            /** @description 커서 */
-            nextCursor?: string;
-            /** @description 다음 페이지 존재 여부 */
-            hasNext: boolean;
-          };
+            mimeType: string;
+            /**
+             * @description blurhash 라이브러리용 해시값
+             * @example LEHV6nWB2yk8pyo0adR*.7kCMdnj
+             */
+            blurhash: string;
         };
-      };
-    };
-  };
-  parameters: {
-    /** @description 인증 토큰 */
-    'Authorization': string;
-    /** @description 현재 속한 Album의 식별자 */
-    'X-Album-Id': string;
-  };
-  requestBodies: {
-    /** @description Media 생성 요청 */
-    CreateMedia: {
-      content: {
-        'application/json': {
-          /** @description 설명 */
-          description: string;
+        /**
+         * Actioned
+         * @description 행위와 관련된 정보
+         */
+        Actioned: {
+            /**
+             * Format: date-time
+             * @description 발생 일시
+             */
+            at: string;
+            by: components["schemas"]["User"];
         };
-      };
-    };
-    /** @description Media 수정 요청 */
-    UpdateMedia: {
-      content: {
-        'application/json': {
-          /** @description 설명 */
-          description?: string;
+        /**
+         * User
+         * @description User와 관련된 정보
+         */
+        User: {
+            /** @description 식별자 */
+            id: string;
+            /** @description 이름 */
+            name: string;
+            /**
+             * Format: email
+             * @description 이메일 주소
+             */
+            email: string;
         };
-      };
-    };
-    /** @description Media 전용 업로드 URL 생성 요청 */
-    CreateUploadUrlForMedia: {
-      content: {
-        'application/json': Record<string, never>;
-      };
-    };
-    /** @description Content 생성 요청 */
-    CreateContent: {
-      content: {
-        'application/json': {
-          /**
-           * Format: uri
-           * @description URL 주소
-           */
-          url: string;
+        /**
+         * Role
+         * @description Role 종류
+         * @enum {string}
+         */
+        Role: "ADMIN" | "EDITOR" | "VIEWER";
+        /**
+         * Error
+         * @description Error와 관련된 정보
+         */
+        Error: {
+            /**
+             * Format: uuid
+             * @description 트레이스
+             */
+            traceId: string;
+            /**
+             * @description API 경로
+             * @example /api/v1/media/xxx
+             */
+            path: string;
+            /**
+             * Format: int32
+             * @description HTTP 상태 코드
+             * @example 404
+             */
+            status: number;
+            /**
+             * @description 비즈니스 에러 코드
+             * @example MEDIA_NOT_FOUND
+             */
+            code: string;
+            /** @description 설명 문구 */
+            messages: string[];
+            /** @description 발생 시각 */
+            timestamp: string;
         };
-      };
+        /**
+         * Album
+         * @description Album과 관련된 정보
+         */
+        Album: {
+            /** @description 식별자 */
+            id: string;
+            /** @description 이름 */
+            name: string;
+            role: components["schemas"]["Role"];
+        };
     };
-    /** @description 로그인 */
-    Login: {
-      content: {
-        'application/json': Record<string, never>;
-      };
+    responses: {
+        /** @description Media 생성 응답 */
+        CreateMedia: {
+            headers: {
+                /** @description Media 위치 */
+                Location?: string;
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Media"];
+            };
+        };
+        /** @description Media 목록 조회 응답 */
+        ListMedia: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    items: components["schemas"]["Media"][];
+                    /** @description 이번 조회에 적용된 페이지네이션과 관련된 정보 */
+                    pagination: {
+                        /**
+                         * Format: int32
+                         * @description 목록에 포함될 요소 개수
+                         */
+                        size: number;
+                        /**
+                         * @description 정렬 기준
+                         * @enum {string}
+                         */
+                        sortBy: "CREATED_AT";
+                        /**
+                         * @description 정렬 순서
+                         * @enum {string}
+                         */
+                        order: "ASC" | "DESC";
+                        /** @description 커서 */
+                        nextCursor?: string;
+                        /** @description 다음 페이지 존재 여부 */
+                        hasNext: boolean;
+                    };
+                };
+            };
+        };
+        /** @description Media 상세 조회 응답 */
+        GetMedia: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Media"];
+            };
+        };
+        /** @description Media 수정 응답 */
+        UpdateMedia: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Media"];
+            };
+        };
+        /** @description Media 전용 업로드 URL 생성 응답 */
+        CreateUploadUrlForMedia: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uri
+                     * @description URL 주소
+                     */
+                    url: string;
+                };
+            };
+        };
+        /** @description Content 생성 응답 */
+        CreateContent: {
+            headers: {
+                /** @description Content 위치 */
+                Location?: string;
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Content"];
+            };
+        };
+        /** @description 로그인 응답 */
+        Login: {
+            headers: {
+                /** @description 리프레쉬 토큰 정보 */
+                "Set-Cookie"?: string;
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @description 액세스 토큰 */
+                    accessToken: string;
+                };
+            };
+        };
+        /** @description Media 확정 응답 */
+        ConfirmMedia: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Media"];
+            };
+        };
+        /** @description '나' 상세 조회 응답 */
+        GetMe: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @description 식별자 */
+                    id: string;
+                    /** @description 이름 */
+                    name: string;
+                    /**
+                     * Format: email
+                     * @description 이메일 주소
+                     */
+                    email: string;
+                };
+            };
+        };
+        /** @description 요청 처리 실패 응답 */
+        Error: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+        /** @description Album 목록 조회 응답 */
+        ListAlbums: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    items: components["schemas"]["Album"][];
+                    /** @description 이번 조회에 적용된 페이지네이션과 관련된 정보 */
+                    pagination: {
+                        /**
+                         * Format: int32
+                         * @description 목록에 포함될 요소 개수
+                         */
+                        size: number;
+                        /**
+                         * @description 정렬 순서
+                         * @enum {string}
+                         */
+                        order: "ASC" | "DESC";
+                        /** @description 커서 */
+                        nextCursor?: string;
+                        /** @description 다음 페이지 존재 여부 */
+                        hasNext: boolean;
+                    };
+                };
+            };
+        };
     };
-    /** @description 로그아웃 */
-    Logout: {
-      content: {
-        'application/json': Record<string, never>;
-      };
+    parameters: {
+        /** @description 인증 토큰 */
+        Authorization: string;
+        /** @description 현재 속한 Album의 식별자 */
+        "X-Album-Id": string;
     };
-    /** @description Media 확정 요청 */
-    ConfirmMedia: {
-      content: {
-        'application/json': Record<string, never>;
-      };
+    requestBodies: {
+        /** @description User Event 수집 요청 */
+        CreateUserEvents: {
+            content: {
+                "application/json": {
+                    events: ({
+                        /** @description 이벤트 이름 */
+                        name: string;
+                        /**
+                         * Format: int64
+                         * @description 이벤트 발생 시각(epoch millis)
+                         */
+                        timestamp: number;
+                        userRole: components["schemas"]["Role"];
+                    } & {
+                        [key: string]: unknown;
+                    })[];
+                };
+            };
+        };
+        /** @description Media 생성 요청 */
+        CreateMedia: {
+            content: {
+                "application/json": {
+                    /** @description 설명 */
+                    description: string;
+                };
+            };
+        };
+        /** @description Media 수정 요청 */
+        UpdateMedia: {
+            content: {
+                "application/json": {
+                    /** @description 설명 */
+                    description?: string;
+                };
+            };
+        };
+        /** @description Media 전용 업로드 URL 생성 요청 */
+        CreateUploadUrlForMedia: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        /** @description Content 생성 요청 */
+        CreateContent: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uri
+                     * @description URL 주소
+                     */
+                    url: string;
+                };
+            };
+        };
+        /** @description 로그인 */
+        Login: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        /** @description 로그아웃 */
+        Logout: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        /** @description Media 확정 요청 */
+        ConfirmMedia: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
     };
-  };
-  headers: never;
-  pathItems: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  listMedia: {
-    parameters: {
-      query?: {
-        /** @description 목록에 포함될 요소 개수 */
-        size?: string;
-        /** @description 정렬 기준 */
-        sortBy?: 'CREATED_AT';
-        /** @description 정렬 순서 */
-        order?: 'ASC' | 'DESC';
-        /** @description 커서 */
-        cursor?: string;
-        /**
-         * @description Media 상태 정보
-         * @example DRAFT,PREPARING,COMPLETE
-         */
-        states?: string;
-      };
-      header: {
-        /** @description 인증 토큰 */
-        'Authorization': components['parameters']['Authorization'];
-        /** @description 현재 속한 Album의 식별자 */
-        'X-Album-Id': components['parameters']['X-Album-Id'];
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components['responses']['ListMedia'];
-      400: components['responses']['Error'];
-      401: components['responses']['Error'];
-      403: components['responses']['Error'];
-    };
-  };
-  createMedia: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description 인증 토큰 */
-        'Authorization': components['parameters']['Authorization'];
-        /** @description 현재 속한 Album의 식별자 */
-        'X-Album-Id': components['parameters']['X-Album-Id'];
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: components['requestBodies']['CreateMedia'];
-    responses: {
-      201: components['responses']['CreateMedia'];
-      400: components['responses']['Error'];
-      401: components['responses']['Error'];
-      403: components['responses']['Error'];
-    };
-  };
-  getMedia: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description 인증 토큰 */
-        'Authorization': components['parameters']['Authorization'];
-        /** @description 현재 속한 Album의 식별자 */
-        'X-Album-Id': components['parameters']['X-Album-Id'];
-      };
-      path: {
-        /** @description Media 식별자 */
-        mediaId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components['responses']['GetMedia'];
-      401: components['responses']['Error'];
-      403: components['responses']['Error'];
-      404: components['responses']['Error'];
-    };
-  };
-  deleteMedia: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description 인증 토큰 */
-        'Authorization': components['parameters']['Authorization'];
-        /** @description 현재 속한 Album의 식별자 */
-        'X-Album-Id': components['parameters']['X-Album-Id'];
-      };
-      path: {
-        /** @description Media 식별자 */
-        mediaId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description No Content */
-      204: {
-        headers: {
-          [name: string]: unknown;
+    createUserEvents: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+                /** @description 현재 속한 Album의 식별자 */
+                "X-Album-Id": components["parameters"]["X-Album-Id"];
+            };
+            path?: never;
+            cookie?: never;
         };
-        content?: never;
-      };
-      401: components['responses']['Error'];
-      403: components['responses']['Error'];
-      404: components['responses']['Error'];
-    };
-  };
-  updateMedia: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description 인증 토큰 */
-        'Authorization': components['parameters']['Authorization'];
-        /** @description 현재 속한 Album의 식별자 */
-        'X-Album-Id': components['parameters']['X-Album-Id'];
-      };
-      path: {
-        /** @description Media 식별자 */
-        mediaId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: components['requestBodies']['UpdateMedia'];
-    responses: {
-      200: components['responses']['UpdateMedia'];
-      400: components['responses']['Error'];
-      401: components['responses']['Error'];
-      403: components['responses']['Error'];
-      404: components['responses']['Error'];
-    };
-  };
-  createUploadUrlForMedia: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description 인증 토큰 */
-        'Authorization': components['parameters']['Authorization'];
-        /** @description 현재 속한 Album의 식별자 */
-        'X-Album-Id': components['parameters']['X-Album-Id'];
-      };
-      path: {
-        /** @description Media 식별자 */
-        mediaId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: components['requestBodies']['CreateUploadUrlForMedia'];
-    responses: {
-      201: components['responses']['CreateUploadUrlForMedia'];
-      401: components['responses']['Error'];
-      403: components['responses']['Error'];
-      404: components['responses']['Error'];
-      409: components['responses']['Error'];
-    };
-  };
-  confirmMedia: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description 인증 토큰 */
-        'Authorization': components['parameters']['Authorization'];
-        /** @description 현재 속한 Album의 식별자 */
-        'X-Album-Id': components['parameters']['X-Album-Id'];
-      };
-      path: {
-        /** @description Media 식별자 */
-        mediaId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: components['requestBodies']['ConfirmMedia'];
-    responses: {
-      200: components['responses']['ConfirmMedia'];
-      401: components['responses']['Error'];
-      403: components['responses']['Error'];
-      404: components['responses']['Error'];
-      409: components['responses']['Error'];
-    };
-  };
-  createContent: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description 인증 토큰 */
-        'Authorization': components['parameters']['Authorization'];
-        /** @description 현재 속한 Album의 식별자 */
-        'X-Album-Id': components['parameters']['X-Album-Id'];
-      };
-      path: {
-        /** @description Media 식별자 */
-        mediaId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: components['requestBodies']['CreateContent'];
-    responses: {
-      201: components['responses']['CreateContent'];
-      400: components['responses']['Error'];
-      401: components['responses']['Error'];
-      403: components['responses']['Error'];
-      404: components['responses']['Error'];
-      409: components['responses']['Error'];
-    };
-  };
-  listAlbums: {
-    parameters: {
-      query?: {
-        /** @description 목록에 포함될 요소 개수 */
-        size?: string;
-        /** @description 정렬 순서 */
-        order?: 'ASC' | 'DESC';
-        /** @description 커서 */
-        cursor?: string;
-      };
-      header: {
-        /** @description 인증 토큰 */
-        Authorization: components['parameters']['Authorization'];
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components['responses']['ListAlbums'];
-      401: components['responses']['Error'];
-    };
-  };
-  login: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: components['requestBodies']['Login'];
-    responses: {
-      200: components['responses']['Login'];
-      400: components['responses']['Error'];
-      401: components['responses']['Error'];
-    };
-  };
-  logout: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description 인증 토큰 */
-        Authorization: components['parameters']['Authorization'];
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: components['requestBodies']['Logout'];
-    responses: {
-      /** @description No Content */
-      204: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: components["requestBodies"]["CreateUserEvents"];
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["Error"];
+            401: components["responses"]["Error"];
+            403: components["responses"]["Error"];
         };
-        content?: never;
-      };
-      400: components['responses']['Error'];
-      401: components['responses']['Error'];
     };
-  };
-  getMyInfo: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description 인증 토큰 */
-        Authorization: components['parameters']['Authorization'];
-      };
-      path?: never;
-      cookie?: never;
+    listMedia: {
+        parameters: {
+            query?: {
+                /** @description 목록에 포함될 요소 개수 */
+                size?: string;
+                /** @description 정렬 기준 */
+                sortBy?: "CREATED_AT";
+                /** @description 정렬 순서 */
+                order?: "ASC" | "DESC";
+                /** @description 커서 */
+                cursor?: string;
+                /**
+                 * @description Media 상태 정보
+                 * @example DRAFT,PREPARING,COMPLETE
+                 */
+                states?: string;
+            };
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+                /** @description 현재 속한 Album의 식별자 */
+                "X-Album-Id": components["parameters"]["X-Album-Id"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["ListMedia"];
+            400: components["responses"]["Error"];
+            401: components["responses"]["Error"];
+            403: components["responses"]["Error"];
+        };
     };
-    requestBody?: never;
-    responses: {
-      200: components['responses']['GetMe'];
-      401: components['responses']['Error'];
+    createMedia: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+                /** @description 현재 속한 Album의 식별자 */
+                "X-Album-Id": components["parameters"]["X-Album-Id"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["CreateMedia"];
+        responses: {
+            201: components["responses"]["CreateMedia"];
+            400: components["responses"]["Error"];
+            401: components["responses"]["Error"];
+            403: components["responses"]["Error"];
+        };
     };
-  };
+    getMedia: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+                /** @description 현재 속한 Album의 식별자 */
+                "X-Album-Id": components["parameters"]["X-Album-Id"];
+            };
+            path: {
+                /** @description Media 식별자 */
+                mediaId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["GetMedia"];
+            401: components["responses"]["Error"];
+            403: components["responses"]["Error"];
+            404: components["responses"]["Error"];
+        };
+    };
+    deleteMedia: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+                /** @description 현재 속한 Album의 식별자 */
+                "X-Album-Id": components["parameters"]["X-Album-Id"];
+            };
+            path: {
+                /** @description Media 식별자 */
+                mediaId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Error"];
+            403: components["responses"]["Error"];
+            404: components["responses"]["Error"];
+        };
+    };
+    updateMedia: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+                /** @description 현재 속한 Album의 식별자 */
+                "X-Album-Id": components["parameters"]["X-Album-Id"];
+            };
+            path: {
+                /** @description Media 식별자 */
+                mediaId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["UpdateMedia"];
+        responses: {
+            200: components["responses"]["UpdateMedia"];
+            400: components["responses"]["Error"];
+            401: components["responses"]["Error"];
+            403: components["responses"]["Error"];
+            404: components["responses"]["Error"];
+        };
+    };
+    createUploadUrlForMedia: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+                /** @description 현재 속한 Album의 식별자 */
+                "X-Album-Id": components["parameters"]["X-Album-Id"];
+            };
+            path: {
+                /** @description Media 식별자 */
+                mediaId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["CreateUploadUrlForMedia"];
+        responses: {
+            201: components["responses"]["CreateUploadUrlForMedia"];
+            401: components["responses"]["Error"];
+            403: components["responses"]["Error"];
+            404: components["responses"]["Error"];
+            409: components["responses"]["Error"];
+        };
+    };
+    confirmMedia: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+                /** @description 현재 속한 Album의 식별자 */
+                "X-Album-Id": components["parameters"]["X-Album-Id"];
+            };
+            path: {
+                /** @description Media 식별자 */
+                mediaId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["ConfirmMedia"];
+        responses: {
+            200: components["responses"]["ConfirmMedia"];
+            401: components["responses"]["Error"];
+            403: components["responses"]["Error"];
+            404: components["responses"]["Error"];
+            409: components["responses"]["Error"];
+        };
+    };
+    createContent: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+                /** @description 현재 속한 Album의 식별자 */
+                "X-Album-Id": components["parameters"]["X-Album-Id"];
+            };
+            path: {
+                /** @description Media 식별자 */
+                mediaId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["CreateContent"];
+        responses: {
+            201: components["responses"]["CreateContent"];
+            400: components["responses"]["Error"];
+            401: components["responses"]["Error"];
+            403: components["responses"]["Error"];
+            404: components["responses"]["Error"];
+            409: components["responses"]["Error"];
+        };
+    };
+    listAlbums: {
+        parameters: {
+            query?: {
+                /** @description 목록에 포함될 요소 개수 */
+                size?: string;
+                /** @description 정렬 순서 */
+                order?: "ASC" | "DESC";
+                /** @description 커서 */
+                cursor?: string;
+            };
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["ListAlbums"];
+            401: components["responses"]["Error"];
+        };
+    };
+    login: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["Login"];
+        responses: {
+            200: components["responses"]["Login"];
+            400: components["responses"]["Error"];
+            401: components["responses"]["Error"];
+        };
+    };
+    logout: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["Logout"];
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["Error"];
+            401: components["responses"]["Error"];
+        };
+    };
+    getMyInfo: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description 인증 토큰 */
+                Authorization: components["parameters"]["Authorization"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["GetMe"];
+            401: components["responses"]["Error"];
+        };
+    };
 }

--- a/packages/lib-openapi/src/generated/type/types.gen.ts
+++ b/packages/lib-openapi/src/generated/type/types.gen.ts
@@ -211,6 +211,24 @@ export type Authorization = string;
 export type XAlbumId = string;
 
 /**
+ * User Event 수집 요청
+ */
+export type CreateUserEvents = {
+  events: Array<{
+    /**
+     * 이벤트 이름
+     */
+    name: string;
+    /**
+     * 이벤트 발생 시각(epoch millis)
+     */
+    timestamp: number;
+    userRole: Role;
+    [key: string]: unknown | string | number | Role;
+  }>;
+};
+
+/**
  * Media 생성 요청
  */
 export type CreateMedia = {
@@ -267,6 +285,54 @@ export type Logout = {
 export type ConfirmMedia = {
   [key: string]: never;
 };
+
+export type CreateUserEventsData = {
+  /**
+   * User Event 수집 요청
+   */
+  body?: CreateUserEvents;
+  headers: {
+    /**
+     * 인증 토큰
+     */
+    'Authorization': string;
+    /**
+     * 현재 속한 Album의 식별자
+     */
+    'X-Album-Id': string;
+  };
+  path?: never;
+  query?: never;
+  url: '/user-events';
+};
+
+export type CreateUserEventsErrors = {
+  /**
+   * 요청 처리 실패 응답
+   */
+  400: _Error;
+  /**
+   * 요청 처리 실패 응답
+   */
+  401: _Error;
+  /**
+   * 요청 처리 실패 응답
+   */
+  403: _Error;
+};
+
+export type CreateUserEventsError =
+  CreateUserEventsErrors[keyof CreateUserEventsErrors];
+
+export type CreateUserEventsResponses = {
+  /**
+   * No Content
+   */
+  204: void;
+};
+
+export type CreateUserEventsResponse =
+  CreateUserEventsResponses[keyof CreateUserEventsResponses];
 
 export type ListMediaData = {
   body?: never;

--- a/packages/lib-openapi/src/generated/type/zod.gen.ts
+++ b/packages/lib-openapi/src/generated/type/zod.gen.ts
@@ -7,7 +7,11 @@ import { z } from 'zod';
  *
  * Media 상태 정보
  */
-export const zMediaState = z.enum(['DRAFT', 'PREPARING', 'COMPLETE']);
+export const zMediaState = z.enum([
+    'DRAFT',
+    'PREPARING',
+    'COMPLETE'
+]);
 
 /**
  * Location
@@ -15,8 +19,8 @@ export const zMediaState = z.enum(['DRAFT', 'PREPARING', 'COMPLETE']);
  * Location과 관련된 정보
  */
 export const zLocation = z.object({
-  url: z.url().min(1),
-  accessUrl: z.url().min(1),
+    url: z.url().min(1),
+    accessUrl: z.url().min(1)
 });
 
 /**
@@ -25,11 +29,11 @@ export const zLocation = z.object({
  * Thumbnail과 관련된 정보
  */
 export const zThumbnail = z.object({
-  location: zLocation,
-  size: z.coerce.bigint().gte(BigInt(1)),
-  eTag: z.string(),
-  mimeType: z.string(),
-  blurhash: z.string(),
+    location: zLocation,
+    size: z.coerce.bigint().gte(BigInt(1)),
+    eTag: z.string(),
+    mimeType: z.string(),
+    blurhash: z.string()
 });
 
 /**
@@ -38,11 +42,11 @@ export const zThumbnail = z.object({
  * Content와 관련된 정보
  */
 export const zContent = z.object({
-  location: zLocation,
-  size: z.coerce.bigint().gte(BigInt(1)),
-  eTag: z.string(),
-  mimeType: z.string(),
-  thumbnail: z.optional(zThumbnail),
+    location: zLocation,
+    size: z.coerce.bigint().gte(BigInt(1)),
+    eTag: z.string(),
+    mimeType: z.string(),
+    thumbnail: z.optional(zThumbnail)
 });
 
 /**
@@ -51,9 +55,9 @@ export const zContent = z.object({
  * User와 관련된 정보
  */
 export const zUser = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.email(),
+    id: z.string(),
+    name: z.string(),
+    email: z.email()
 });
 
 /**
@@ -62,8 +66,8 @@ export const zUser = z.object({
  * 행위와 관련된 정보
  */
 export const zActioned = z.object({
-  at: z.iso.datetime(),
-  by: zUser,
+    at: z.iso.datetime(),
+    by: zUser
 });
 
 /**
@@ -72,12 +76,12 @@ export const zActioned = z.object({
  * Media와 관련된 정보
  */
 export const zMedia = z.object({
-  id: z.string(),
-  description: z.string(),
-  state: zMediaState,
-  content: z.optional(zContent),
-  isFavorite: z.boolean(),
-  created: zActioned,
+    id: z.string(),
+    description: z.string(),
+    state: zMediaState,
+    content: z.optional(zContent),
+    isFavorite: z.boolean(),
+    created: zActioned
 });
 
 /**
@@ -85,7 +89,11 @@ export const zMedia = z.object({
  *
  * Role 종류
  */
-export const zRole = z.enum(['ADMIN', 'EDITOR', 'VIEWER']);
+export const zRole = z.enum([
+    'ADMIN',
+    'EDITOR',
+    'VIEWER'
+]);
 
 /**
  * Error
@@ -93,12 +101,12 @@ export const zRole = z.enum(['ADMIN', 'EDITOR', 'VIEWER']);
  * Error와 관련된 정보
  */
 export const zError = z.object({
-  traceId: z.uuid(),
-  path: z.string(),
-  status: z.int().gte(400).lte(599),
-  code: z.string(),
-  messages: z.array(z.string()),
-  timestamp: z.string(),
+    traceId: z.uuid(),
+    path: z.string(),
+    status: z.int().gte(400).lte(599),
+    code: z.string(),
+    messages: z.array(z.string()),
+    timestamp: z.string()
 });
 
 /**
@@ -107,9 +115,9 @@ export const zError = z.object({
  * Album과 관련된 정보
  */
 export const zAlbum = z.object({
-  id: z.string(),
-  name: z.string(),
-  role: zRole,
+    id: z.string(),
+    name: z.string(),
+    role: zRole
 });
 
 /**
@@ -123,17 +131,28 @@ export const zAuthorization = z.string();
 export const zXAlbumId = z.string();
 
 /**
+ * User Event 수집 요청
+ */
+export const zCreateUserEvents = z.object({
+    events: z.array(z.object({
+        name: z.string().min(1),
+        timestamp: z.coerce.bigint(),
+        userRole: zRole
+    }))
+});
+
+/**
  * Media 생성 요청
  */
 export const zCreateMedia = z.object({
-  description: z.string().min(1),
+    description: z.string().min(1)
 });
 
 /**
  * Media 수정 요청
  */
 export const zUpdateMedia = z.object({
-  description: z.optional(z.string().min(1)),
+    description: z.optional(z.string().min(1))
 });
 
 /**
@@ -145,7 +164,7 @@ export const zCreateUploadUrlForMedia = z.record(z.string(), z.never());
  * Content 생성 요청
  */
 export const zCreateContent = z.object({
-  url: z.url().min(1),
+    url: z.url().min(1)
 });
 
 /**
@@ -163,46 +182,69 @@ export const zLogout = z.record(z.string(), z.never());
  */
 export const zConfirmMedia = z.record(z.string(), z.never());
 
+export const zCreateUserEventsData = z.object({
+    body: z.optional(zCreateUserEvents),
+    path: z.optional(z.never()),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string(),
+        'X-Album-Id': z.string()
+    })
+});
+
+/**
+ * No Content
+ */
+export const zCreateUserEventsResponse = z.void();
+
 export const zListMediaData = z.object({
-  body: z.optional(z.never()),
-  path: z.optional(z.never()),
-  query: z.optional(
-    z.object({
-      size: z.optional(z.string().min(1)).default('20'),
-      sortBy: z.optional(z.enum(['CREATED_AT'])),
-      order: z.optional(z.enum(['ASC', 'DESC'])),
-      cursor: z.optional(z.string().min(1)),
-      states: z.optional(z.string().min(1)),
-    }),
-  ),
-  headers: z.object({
-    'Authorization': z.string(),
-    'X-Album-Id': z.string(),
-  }),
+    body: z.optional(z.never()),
+    path: z.optional(z.never()),
+    query: z.optional(z.object({
+        size: z.optional(z.string().min(1)).default('20'),
+        sortBy: z.optional(z.enum([
+            'CREATED_AT'
+        ])),
+        order: z.optional(z.enum([
+            'ASC',
+            'DESC'
+        ])),
+        cursor: z.optional(z.string().min(1)),
+        states: z.optional(z.string().min(1))
+    })),
+    headers: z.object({
+        Authorization: z.string(),
+        'X-Album-Id': z.string()
+    })
 });
 
 /**
  * Media 목록 조회 응답
  */
 export const zListMediaResponse = z.object({
-  items: z.array(zMedia),
-  pagination: z.object({
-    size: z.int().gte(1).lte(50),
-    sortBy: z.enum(['CREATED_AT']),
-    order: z.enum(['ASC', 'DESC']),
-    nextCursor: z.optional(z.string().min(1)),
-    hasNext: z.boolean(),
-  }),
+    items: z.array(zMedia),
+    pagination: z.object({
+        size: z.int().gte(1).lte(50),
+        sortBy: z.enum([
+            'CREATED_AT'
+        ]),
+        order: z.enum([
+            'ASC',
+            'DESC'
+        ]),
+        nextCursor: z.optional(z.string().min(1)),
+        hasNext: z.boolean()
+    })
 });
 
 export const zCreateMediaData = z.object({
-  body: z.optional(zCreateMedia),
-  path: z.optional(z.never()),
-  query: z.optional(z.never()),
-  headers: z.object({
-    'Authorization': z.string(),
-    'X-Album-Id': z.string(),
-  }),
+    body: z.optional(zCreateMedia),
+    path: z.optional(z.never()),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string(),
+        'X-Album-Id': z.string()
+    })
 });
 
 /**
@@ -211,15 +253,15 @@ export const zCreateMediaData = z.object({
 export const zCreateMediaResponse = zMedia;
 
 export const zDeleteMediaData = z.object({
-  body: z.optional(z.never()),
-  path: z.object({
-    mediaId: z.string(),
-  }),
-  query: z.optional(z.never()),
-  headers: z.object({
-    'Authorization': z.string(),
-    'X-Album-Id': z.string(),
-  }),
+    body: z.optional(z.never()),
+    path: z.object({
+        mediaId: z.string()
+    }),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string(),
+        'X-Album-Id': z.string()
+    })
 });
 
 /**
@@ -228,15 +270,15 @@ export const zDeleteMediaData = z.object({
 export const zDeleteMediaResponse = z.void();
 
 export const zGetMediaData = z.object({
-  body: z.optional(z.never()),
-  path: z.object({
-    mediaId: z.string(),
-  }),
-  query: z.optional(z.never()),
-  headers: z.object({
-    'Authorization': z.string(),
-    'X-Album-Id': z.string(),
-  }),
+    body: z.optional(z.never()),
+    path: z.object({
+        mediaId: z.string()
+    }),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string(),
+        'X-Album-Id': z.string()
+    })
 });
 
 /**
@@ -245,15 +287,15 @@ export const zGetMediaData = z.object({
 export const zGetMediaResponse = zMedia;
 
 export const zUpdateMediaData = z.object({
-  body: z.optional(zUpdateMedia),
-  path: z.object({
-    mediaId: z.string(),
-  }),
-  query: z.optional(z.never()),
-  headers: z.object({
-    'Authorization': z.string(),
-    'X-Album-Id': z.string(),
-  }),
+    body: z.optional(zUpdateMedia),
+    path: z.object({
+        mediaId: z.string()
+    }),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string(),
+        'X-Album-Id': z.string()
+    })
 });
 
 /**
@@ -262,34 +304,34 @@ export const zUpdateMediaData = z.object({
 export const zUpdateMediaResponse = zMedia;
 
 export const zCreateUploadUrlForMediaData = z.object({
-  body: z.optional(zCreateUploadUrlForMedia),
-  path: z.object({
-    mediaId: z.string(),
-  }),
-  query: z.optional(z.never()),
-  headers: z.object({
-    'Authorization': z.string(),
-    'X-Album-Id': z.string(),
-  }),
+    body: z.optional(zCreateUploadUrlForMedia),
+    path: z.object({
+        mediaId: z.string()
+    }),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string(),
+        'X-Album-Id': z.string()
+    })
 });
 
 /**
  * Media 전용 업로드 URL 생성 응답
  */
 export const zCreateUploadUrlForMediaResponse = z.object({
-  url: z.url().min(1),
+    url: z.url().min(1)
 });
 
 export const zConfirmMediaData = z.object({
-  body: z.optional(zConfirmMedia),
-  path: z.object({
-    mediaId: z.string(),
-  }),
-  query: z.optional(z.never()),
-  headers: z.object({
-    'Authorization': z.string(),
-    'X-Album-Id': z.string(),
-  }),
+    body: z.optional(zConfirmMedia),
+    path: z.object({
+        mediaId: z.string()
+    }),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string(),
+        'X-Album-Id': z.string()
+    })
 });
 
 /**
@@ -298,15 +340,15 @@ export const zConfirmMediaData = z.object({
 export const zConfirmMediaResponse = zMedia;
 
 export const zCreateContentData = z.object({
-  body: z.optional(zCreateContent),
-  path: z.object({
-    mediaId: z.string(),
-  }),
-  query: z.optional(z.never()),
-  headers: z.object({
-    'Authorization': z.string(),
-    'X-Album-Id': z.string(),
-  }),
+    body: z.optional(zCreateContent),
+    path: z.object({
+        mediaId: z.string()
+    }),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string(),
+        'X-Album-Id': z.string()
+    })
 });
 
 /**
@@ -315,53 +357,57 @@ export const zCreateContentData = z.object({
 export const zCreateContentResponse = zContent;
 
 export const zListAlbumsData = z.object({
-  body: z.optional(z.never()),
-  path: z.optional(z.never()),
-  query: z.optional(
-    z.object({
-      size: z.optional(z.string().min(1)).default('20'),
-      order: z.optional(z.enum(['ASC', 'DESC'])),
-      cursor: z.optional(z.string().min(1)),
-    }),
-  ),
-  headers: z.object({
-    Authorization: z.string(),
-  }),
+    body: z.optional(z.never()),
+    path: z.optional(z.never()),
+    query: z.optional(z.object({
+        size: z.optional(z.string().min(1)).default('20'),
+        order: z.optional(z.enum([
+            'ASC',
+            'DESC'
+        ])),
+        cursor: z.optional(z.string().min(1))
+    })),
+    headers: z.object({
+        Authorization: z.string()
+    })
 });
 
 /**
  * Album 목록 조회 응답
  */
 export const zListAlbumsResponse = z.object({
-  items: z.array(zAlbum),
-  pagination: z.object({
-    size: z.int(),
-    order: z.enum(['ASC', 'DESC']),
-    nextCursor: z.optional(z.string()),
-    hasNext: z.boolean(),
-  }),
+    items: z.array(zAlbum),
+    pagination: z.object({
+        size: z.int(),
+        order: z.enum([
+            'ASC',
+            'DESC'
+        ]),
+        nextCursor: z.optional(z.string()),
+        hasNext: z.boolean()
+    })
 });
 
 export const zLoginData = z.object({
-  body: z.optional(zLogin),
-  path: z.optional(z.never()),
-  query: z.optional(z.never()),
+    body: z.optional(zLogin),
+    path: z.optional(z.never()),
+    query: z.optional(z.never())
 });
 
 /**
  * 로그인 응답
  */
 export const zLoginResponse = z.object({
-  accessToken: z.string().min(1),
+    accessToken: z.string().min(1)
 });
 
 export const zLogoutData = z.object({
-  body: z.optional(zLogout),
-  path: z.optional(z.never()),
-  query: z.optional(z.never()),
-  headers: z.object({
-    Authorization: z.string(),
-  }),
+    body: z.optional(zLogout),
+    path: z.optional(z.never()),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string()
+    })
 });
 
 /**
@@ -370,19 +416,19 @@ export const zLogoutData = z.object({
 export const zLogoutResponse = z.void();
 
 export const zGetMyInfoData = z.object({
-  body: z.optional(z.never()),
-  path: z.optional(z.never()),
-  query: z.optional(z.never()),
-  headers: z.object({
-    Authorization: z.string(),
-  }),
+    body: z.optional(z.never()),
+    path: z.optional(z.never()),
+    query: z.optional(z.never()),
+    headers: z.object({
+        Authorization: z.string()
+    })
 });
 
 /**
  * '나' 상세 조회 응답
  */
 export const zGetMyInfoResponse = z.object({
-  id: z.string().min(1),
-  name: z.string().min(1),
-  email: z.email().min(1),
+    id: z.string().min(1),
+    name: z.string().min(1),
+    email: z.email().min(1)
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,24 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0
 
+  packages/domain-user-event:
+    dependencies:
+      '@joka/core':
+        specifier: workspace:*
+        version: link:../core
+      '@joka/lib-drizzle':
+        specifier: workspace:*
+        version: link:../lib-drizzle
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@cloudflare/workers-types@4.20260203.0)(postgres@3.4.8)
+      postgres:
+        specifier: ^3.4.8
+        version: 3.4.8
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
+
   packages/infra-object-storage:
     dependencies:
       '@joka/core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@joka/domain-media':
         specifier: workspace:*
         version: link:../../packages/domain-media
+      '@joka/domain-user-event':
+        specifier: workspace:*
+        version: link:../../packages/domain-user-event
       '@joka/infra-object-storage':
         specifier: workspace:*
         version: link:../../packages/infra-object-storage


### PR DESCRIPTION
## 📌 관련 이슈

* #108 

---

## 🧹 작업 내용

* user-events 도메인 정의
* user-events 저장 API 구현
---

## 🛠️ 테스트 (선택)

* [x] 단위 테스트 통과
* [x] 수동 테스트 완료
* [x] 기존 기능 영향 없음 확인

---

## 🔍 고민 / 결정 사항

* 이 도메인은 FE에 종속되는거라, BE에서 어느 정도의 정보를 알고 있어야되나 고민을 많이 했네요. 결론적으로 `name`, `timestamp`, `userRole`과 같은 정보를 제외하고는 BE에서 알 필요가 없도록 구현했습니다.
* user-events 생성 요청 1회당 최대 `event` 개수는 20개로 제한했어요! 피드백 주시면 바로 반영하겠습니다~

---

## 💬 참고 사항

* 현재로서는 저장만하고, FE 측에서 이를 조회할 방법을 제공하지 않습니다. 오프라인에서 합의했던대로 필요시마다 JSON 문서를 전달하는 방식으로 가되, 이런 일이 빈번해진다면 그 때가서 자동화된 방법을 도입하는 식으로 확장 여지를 남겨두었어요!
