### PR TITLE
[Feat] 사진 목록 새로고침 (헤더 버튼 + 당겨서 새로고침)

### DIFF
--- a/apps/web/src/app/index.tsx
+++ b/apps/web/src/app/index.tsx
@@ -6,13 +6,13 @@ import { ErrorBoundary } from '@/app/providers/error-boundary';
 import { queryClient } from '@/app/providers/query-client';
 import { AppRouter } from '@/app/providers/router';
 import { initSentry } from '@/app/providers/sentry';
+import { AppToaster } from '@/app/providers/toaster';
 import { hideSplash, hideSplashWithFloor } from '@/app/splash';
 import { useAlbumStore } from '@/entities/album';
 import { useAuthStore } from '@/features/auth';
 import { initTheme } from '@/features/theme';
 import { initAnalytics, setRoleResolver } from '@/shared/lib/analytics';
 import { hasConsent } from '@/shared/lib/consent';
-import { Toaster } from '@/shared/ui/toast';
 import './styles/globals.css';
 
 initSentry();
@@ -29,7 +29,7 @@ if (root) {
     <QueryClientProvider client={queryClient}>
       <ErrorBoundary>
         <AppRouter />
-        <Toaster />
+        <AppToaster />
       </ErrorBoundary>
     </QueryClientProvider>,
   );

--- a/apps/web/src/app/providers/toaster.tsx
+++ b/apps/web/src/app/providers/toaster.tsx
@@ -1,0 +1,9 @@
+import { useTheme } from '@/features/theme';
+import { Toaster } from '@/shared/ui/toast';
+
+/** 앱의 테마 토글 값을 토스트에 전달한다(shared는 features를 모르므로 app에서 주입) */
+export function AppToaster() {
+  const theme = useTheme();
+
+  return <Toaster theme={theme} />;
+}

--- a/apps/web/src/app/styles/globals.css
+++ b/apps/web/src/app/styles/globals.css
@@ -97,6 +97,8 @@
   }
   body {
     @apply bg-background text-foreground;
+    /* 브라우저 기본 당겨서 새로고침(안드로이드 크롬)을 끄고, 앱이 그린 것만 남긴다. */
+    overscroll-behavior-y: contain;
   }
 }
 

--- a/apps/web/src/entities/photo/api/mutations.test.ts
+++ b/apps/web/src/entities/photo/api/mutations.test.ts
@@ -1,12 +1,16 @@
 import { MutationObserver, QueryClient } from '@tanstack/react-query';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { photoKeys } from './keys';
 import {
   buildDeletePhotoOptions,
   buildUpdatePhotoMetaOptions,
+  isAlreadyDeleted,
 } from './mutations';
-import { photoKeys } from './keys';
-import type { MediaDto, Photo } from '../model/types';
+import { selectPhotos } from './queries';
+import type { MediaDto, MediaPagination, Photo } from '../model/types';
+
+import { ApiError } from '@/shared/api/error';
 
 const mocks = vi.hoisted(() => ({
   patch: vi.fn(),
@@ -44,6 +48,23 @@ function mediaDto(description: string): MediaDto {
     },
     created: { at: '2026-01-01T00:00:00.000Z', by: photo().createdBy },
   };
+}
+
+function otherDto(id: string): MediaDto {
+  return { ...mediaDto('다른 사진'), id };
+}
+
+const pagination: MediaPagination = {
+  size: 20,
+  sortBy: 'CREATED_AT',
+  order: 'DESC',
+  hasNext: false,
+};
+
+function listIds(qc: QueryClient): string[] {
+  return selectPhotos(qc.getQueryData(photoKeys.list({ order: 'desc' }))).map(
+    (p) => p.id,
+  );
 }
 
 function runUpdate(qc: QueryClient, vars: { id: string; description: string }) {
@@ -142,12 +163,20 @@ describe('buildUpdatePhotoMetaOptions', () => {
 });
 
 describe('buildDeletePhotoOptions', () => {
-  beforeEach(() => mocks.del.mockReset());
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    mocks.del.mockReset();
+    qc = new QueryClient();
+    qc.setQueryData(photoKeys.detail('p1'), photo());
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [{ items: [mediaDto('설명'), otherDto('p2')], pagination }],
+      pageParams: [undefined],
+    });
+  });
 
   test('성공 시 상세 캐시를 제거하고 목록을 무효화한다', async () => {
     mocks.del.mockResolvedValueOnce(undefined);
-    const qc = new QueryClient();
-    qc.setQueryData(photoKeys.detail('p1'), photo());
 
     const remove = vi.spyOn(qc, 'removeQueries');
     const invalidate = vi.spyOn(qc, 'invalidateQueries');
@@ -157,5 +186,40 @@ describe('buildDeletePhotoOptions', () => {
     expect(mocks.del).toHaveBeenCalledWith('/v1/media/p1');
     expect(remove).toHaveBeenCalledWith({ queryKey: photoKeys.detail('p1') });
     expect(invalidate).toHaveBeenCalledWith({ queryKey: photoKeys.lists() });
+  });
+
+  // invalidate만으로는 enabled:false 옵저버뿐인 목록이 리페치되지 않아 유령 카드가 남는다.
+  test('성공 시 목록 캐시에서도 즉시 제거한다', async () => {
+    mocks.del.mockResolvedValueOnce(undefined);
+
+    await runDelete(qc, 'p1');
+
+    expect(listIds(qc)).toEqual(['p2']);
+  });
+
+  test('404(이미 삭제됨)면 실패로 두지 않고 캐시를 동일하게 정리한다', async () => {
+    mocks.del.mockRejectedValueOnce(new ApiError({ status: 404 }));
+
+    await expect(runDelete(qc, 'p1')).rejects.toBeInstanceOf(ApiError);
+
+    expect(listIds(qc)).toEqual(['p2']);
+    expect(qc.getQueryData(photoKeys.detail('p1'))).toBeUndefined();
+  });
+
+  test('403 같은 다른 실패는 캐시를 건드리지 않는다', async () => {
+    mocks.del.mockRejectedValueOnce(new ApiError({ status: 403 }));
+
+    await expect(runDelete(qc, 'p1')).rejects.toBeInstanceOf(ApiError);
+
+    expect(listIds(qc)).toEqual(['p1', 'p2']);
+    expect(qc.getQueryData(photoKeys.detail('p1'))).toBeDefined();
+  });
+});
+
+describe('isAlreadyDeleted', () => {
+  test('404 ApiError만 이미 삭제됨으로 본다', () => {
+    expect(isAlreadyDeleted(new ApiError({ status: 404 }))).toBe(true);
+    expect(isAlreadyDeleted(new ApiError({ status: 403 }))).toBe(false);
+    expect(isAlreadyDeleted(new Error('boom'))).toBe(false);
   });
 });

--- a/apps/web/src/entities/photo/api/mutations.ts
+++ b/apps/web/src/entities/photo/api/mutations.ts
@@ -5,11 +5,13 @@ import {
   type UseMutationOptions,
 } from '@tanstack/react-query';
 
-import { http } from '@/shared/api';
-
+import { photoKeys } from './keys';
+import { removeMediaFromLists } from './queries';
 import { toPhoto } from '../lib/mapper';
 import type { MediaDto, Photo } from '../model/types';
-import { photoKeys } from './keys';
+
+import { http } from '@/shared/api';
+import { ApiError } from '@/shared/api/error';
 
 export interface UpdatePhotoMetaVars {
   id: string;
@@ -64,6 +66,20 @@ export function useUpdatePhotoMetaMutation() {
   return useMutation(buildUpdatePhotoMetaOptions(queryClient));
 }
 
+/** 404는 "이미 삭제됨"이다. 실패가 아니라 목표 상태에 도달한 것으로 본다(멱등). */
+export function isAlreadyDeleted(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 404;
+}
+
+/**
+ * 삭제된 사진의 상세/목록 캐시를 즉시 정리하고, 최종 정합은 invalidate로 위임한다.
+ */
+function purgeDeletedPhoto(queryClient: QueryClient, id: string): void {
+  queryClient.removeQueries({ queryKey: photoKeys.detail(id) });
+  removeMediaFromLists(queryClient, id);
+  queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
+}
+
 export function buildDeletePhotoOptions(
   queryClient: QueryClient,
 ): UseMutationOptions<void, Error, string> {
@@ -71,9 +87,12 @@ export function buildDeletePhotoOptions(
     mutationFn: (id) => http.delete(`/v1/media/${id}`),
     meta: { operationId: 'deleteMedia' },
 
-    onSuccess: (_data, id) => {
-      queryClient.removeQueries({ queryKey: photoKeys.detail(id) });
-      queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
+    onSuccess: (_data, id) => purgeDeletedPhoto(queryClient, id),
+
+    onError: (error, id) => {
+      if (isAlreadyDeleted(error)) {
+        purgeDeletedPhoto(queryClient, id);
+      }
     },
   };
 }

--- a/apps/web/src/entities/photo/api/queries.test.ts
+++ b/apps/web/src/entities/photo/api/queries.test.ts
@@ -1,9 +1,14 @@
 import { QueryClient } from '@tanstack/react-query';
 import { describe, expect, test } from 'vitest';
 
-import type { MediaDto, MediaListResponse } from '../model/types';
 import { photoKeys } from './keys';
-import { findPhotoInListCache, nextCursorOf, selectPhotos } from './queries';
+import {
+  findPhotoInListCache,
+  nextCursorOf,
+  removeMediaFromLists,
+  selectPhotos,
+} from './queries';
+import type { MediaDto, MediaListResponse } from '../model/types';
 
 function page(
   items: MediaDto[],
@@ -95,7 +100,7 @@ describe('findPhotoInListCache', () => {
       pages: [page([dto('a'), dto('b')])],
     });
 
-    expect(findPhotoInListCache(qc, 'b')?.id).toBe('b');
+    expect(findPhotoInListCache(qc, 'b')?.photo.id).toBe('b');
   });
 
   test('정렬이 다른 여러 list 캐시를 순회해 찾는다', () => {
@@ -107,7 +112,7 @@ describe('findPhotoInListCache', () => {
       pages: [page([dto('b')])],
     });
 
-    expect(findPhotoInListCache(qc, 'b')?.id).toBe('b');
+    expect(findPhotoInListCache(qc, 'b')?.photo.id).toBe('b');
   });
 
   test('data가 비어있는 캐시 항목이 섞여 있어도 안전하게 넘어간다', () => {
@@ -117,7 +122,7 @@ describe('findPhotoInListCache', () => {
       pages: [page([dto('b')])],
     });
 
-    expect(findPhotoInListCache(qc, 'b')?.id).toBe('b');
+    expect(findPhotoInListCache(qc, 'b')?.photo.id).toBe('b');
   });
 
   test('캐시에 id가 없으면 undefined(직접 진입 → normal fetch)', () => {
@@ -133,5 +138,107 @@ describe('findPhotoInListCache', () => {
     const qc = new QueryClient();
 
     expect(findPhotoInListCache(qc, 'a')).toBeUndefined();
+  });
+
+  // 상세 쿼리가 initialDataUpdatedAt으로 쓴다.
+  // staleTime 동안 리페치를 건너뛰기 위함
+  test('사진을 담고 있던 목록 캐시의 dataUpdatedAt을 함께 반환한다', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a')])],
+    });
+
+    const updatedAt = qc.getQueryState(
+      photoKeys.list({ order: 'desc' }),
+    )?.dataUpdatedAt;
+
+    expect(findPhotoInListCache(qc, 'a')?.dataUpdatedAt).toBe(updatedAt);
+  });
+});
+
+describe('removeMediaFromLists', () => {
+  test('모든 페이지에서 해당 id를 걷어낸다', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a'), dto('b')]), page([dto('c')])],
+      pageParams: [undefined, 'c2'],
+    });
+
+    removeMediaFromLists(qc, 'b');
+
+    expect(
+      selectPhotos(qc.getQueryData(photoKeys.list({ order: 'desc' }))).map(
+        (p) => p.id,
+      ),
+    ).toEqual(['a', 'c']);
+  });
+
+  test('정렬이 다른 여러 list 캐시에서 모두 제거한다', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a'), dto('b')])],
+      pageParams: [undefined],
+    });
+    qc.setQueryData(photoKeys.list({ order: 'asc' }), {
+      pages: [page([dto('b'), dto('a')])],
+      pageParams: [undefined],
+    });
+
+    removeMediaFromLists(qc, 'b');
+
+    expect(findPhotoInListCache(qc, 'b')).toBeUndefined();
+    expect(findPhotoInListCache(qc, 'a')?.photo.id).toBe('a');
+  });
+
+  test('pageParams는 보존한다(다음 페이지 요청이 깨지지 않게)', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [page([dto('a')]), page([dto('b')])],
+      pageParams: [undefined, 'c2'],
+    });
+
+    removeMediaFromLists(qc, 'b');
+
+    const data = qc.getQueryData<{ pages: unknown[]; pageParams: unknown[] }>(
+      photoKeys.list({ order: 'desc' }),
+    );
+    expect(data?.pageParams).toEqual([undefined, 'c2']);
+    expect(data?.pages).toHaveLength(2);
+  });
+
+  test('해당 사진이 없는 페이지는 참조를 그대로 둔다(불필요한 리렌더 방지)', () => {
+    const qc = new QueryClient();
+    const untouched = page([dto('a')]);
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), {
+      pages: [untouched, page([dto('b')])],
+      pageParams: [undefined, 'c2'],
+    });
+
+    removeMediaFromLists(qc, 'b');
+
+    const data = qc.getQueryData<{ pages: MediaListResponse[] }>(
+      photoKeys.list({ order: 'desc' }),
+    );
+    expect(data?.pages[0]).toBe(untouched);
+    expect(data?.pages[1].items).toEqual([]);
+  });
+
+  test('없는 id면 캐시 참조를 그대로 둔다(불필요한 리렌더 방지)', () => {
+    const qc = new QueryClient();
+    const before = {
+      pages: [page([dto('a')])],
+      pageParams: [undefined],
+    };
+    qc.setQueryData(photoKeys.list({ order: 'desc' }), before);
+
+    removeMediaFromLists(qc, 'zzz');
+
+    expect(qc.getQueryData(photoKeys.list({ order: 'desc' }))).toBe(before);
+  });
+
+  test('list 캐시가 없어도 안전하다', () => {
+    const qc = new QueryClient();
+
+    expect(() => removeMediaFromLists(qc, 'a')).not.toThrow();
   });
 });

--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -52,23 +52,48 @@ async function fetchPhotoPage(
   return response;
 }
 
+/** 목록 캐시에서 찾은 Photo와, 그 데이터를 받아온 시각. */
+export interface PhotoCacheHit {
+  photo: Photo;
+  dataUpdatedAt: number;
+}
+
+function isMediaListPage(value: unknown): value is MediaListResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'items' in value &&
+    Array.isArray(value.items)
+  );
+}
+
+function isPagedMedia(value: unknown): value is { pages: MediaListResponse[] } {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('pages' in value)) return false;
+
+  return Array.isArray(value.pages) && value.pages.every(isMediaListPage);
+}
+
 /**
- * 이미 로드된 목록 캐시(모든 list 쿼리)에서 id에 해당하는 Photo를 찾는다.
- * - 목록 → 상세 진입 시 단건 요청을 기다리지 않고 즉시 표시한다.
- * - 직접 진입(새로고침)처럼 캐시가 없으면 undefined를 반환해 정상 fetch로 넘어간다.
+ * 이미 로드된 목록 캐시에서 id에 해당하는 Photo를 찾는다.
+ * - 캐시가 없으면 undefined를 반환함
+ * - dataUpdatedAt을 함께 반환해 호출자가 캐시 신선도를 판단할 수 있음
  */
 export function findPhotoInListCache(
   queryClient: QueryClient,
   id: string,
-): Photo | undefined {
-  const entries = queryClient.getQueriesData<{ pages: MediaListResponse[] }>({
-    queryKey: photoKeys.lists(),
-  });
+): PhotoCacheHit | undefined {
+  const queries = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: photoKeys.lists() });
 
-  for (const [, data] of entries) {
+  for (const query of queries) {
+    const { data, dataUpdatedAt } = query.state;
+    if (!isPagedMedia(data)) continue;
+
     const found = selectPhotos(data).find((photo) => photo.id === id);
     if (found) {
-      return found;
+      return { photo: found, dataUpdatedAt };
     }
   }
 
@@ -104,6 +129,36 @@ export function prependMediaToLists(
   );
 }
 
+/**
+ * 삭제된 사진을 목록 캐시 전 페이지에서 즉시 걷어낸다.
+ * - 삭제 후 목록으로 돌아왔을 때 백그라운드 리페치를 기다리며 유령 카드가 보이는 걸 막음
+ * - 서버가 이미 404를 주는 상태(다른 기기에서 삭제됨)에서도 정리
+ */
+export function removeMediaFromLists(
+  queryClient: QueryClient,
+  id: string,
+): void {
+  queryClient.setQueriesData<InfiniteMedia>(
+    { queryKey: photoKeys.lists() },
+    (data) => {
+      if (!data) return data;
+
+      const exists = data.pages.some((page) =>
+        page.items.some((it) => it.id === id),
+      );
+      if (!exists) return data;
+
+      // 해당 사진이 없는 페이지는 참조를 유지해 불필요한 리렌더를 막는다.
+      const pages = data.pages.map((page) =>
+        page.items.some((it) => it.id === id)
+          ? { ...page, items: page.items.filter((it) => it.id !== id) }
+          : page,
+      );
+      return { ...data, pages };
+    },
+  );
+}
+
 async function fetchPhotoDetail(id: string): Promise<Photo> {
   const dto = await http.get<MediaDto>(`/v1/media/${id}`);
   return toPhoto(dto);
@@ -116,7 +171,9 @@ export function usePhotoDetail(id: string, options?: { enabled?: boolean }) {
     queryKey: photoKeys.detail(id),
     queryFn: () => fetchPhotoDetail(id),
     enabled: (options?.enabled ?? true) && !!id,
-    initialData: () => findPhotoInListCache(queryClient, id),
+    initialData: () => findPhotoInListCache(queryClient, id)?.photo,
+    initialDataUpdatedAt: () =>
+      findPhotoInListCache(queryClient, id)?.dataUpdatedAt,
     staleTime: 60_000,
     throwOnError: true,
     meta: { operationId: 'getMedia' },

--- a/apps/web/src/entities/photo/index.ts
+++ b/apps/web/src/entities/photo/index.ts
@@ -4,12 +4,15 @@ export {
   usePhotoDetail,
   findPhotoInListCache,
   prependMediaToLists,
+  removeMediaFromLists,
   selectPhotos,
   nextCursorOf,
+  type PhotoCacheHit,
 } from './api/queries';
 export {
   useUpdatePhotoMetaMutation,
   useDeletePhotoMutation,
+  isAlreadyDeleted,
   type UpdatePhotoMetaVars,
 } from './api/mutations';
 

--- a/apps/web/src/entities/photo/ui/photo-card.tsx
+++ b/apps/web/src/entities/photo/ui/photo-card.tsx
@@ -19,7 +19,9 @@ export function PhotoCard({
   onOpen,
 }: PhotoCardProps) {
   return (
-    <div className="group relative">
+    // content-visibility로 화면 밖 카드 렌더링 스킵함
+    // 200px은 미렌더 카드의 임시 높이 추정치(auto가 실측치로 자동 대체)
+    <div className="group relative [contain-intrinsic-size:auto_200px] [content-visibility:auto]">
       <button
         type="button"
         onClick={() => onOpen?.(photo.id)}

--- a/apps/web/src/features/photo-refresh/index.ts
+++ b/apps/web/src/features/photo-refresh/index.ts
@@ -1,0 +1,7 @@
+export { usePhotoRefreshStore } from './model/store';
+export {
+  useRefreshPhotos,
+  type RefreshSource,
+} from './model/use-refresh-photos';
+export { PullToRefresh } from './ui/pull-to-refresh';
+export { RefreshButton } from './ui/refresh-button';

--- a/apps/web/src/features/photo-refresh/model/store.test.ts
+++ b/apps/web/src/features/photo-refresh/model/store.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { usePhotoRefreshStore } from './store';
+
+function run(task: () => Promise<unknown>) {
+  return usePhotoRefreshStore.getState().run(task);
+}
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe('usePhotoRefreshStore.run', () => {
+  beforeEach(() => usePhotoRefreshStore.setState({ isRefreshing: false }));
+
+  test('작업이 끝날 때까지 isRefreshing이 유지된다', async () => {
+    const task = deferred();
+
+    const running = run(() => task.promise);
+    expect(usePhotoRefreshStore.getState().isRefreshing).toBe(true);
+
+    task.resolve();
+    await running;
+    expect(usePhotoRefreshStore.getState().isRefreshing).toBe(false);
+  });
+
+  // 헤더 버튼을 연타하거나, 버튼 새로고침 중에 목록을 당기는 상황.
+  test('진행 중에 다시 호출하면 작업이 한 번만 실행된다', async () => {
+    const task = deferred();
+    const spy = vi.fn(() => task.promise);
+
+    const running = run(spy);
+    await run(spy);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    task.resolve();
+    await running;
+  });
+
+  test('작업이 실패해도 잠금이 풀려 다시 시도할 수 있다', async () => {
+    await expect(run(() => Promise.reject(new Error('boom')))).rejects.toThrow(
+      'boom',
+    );
+
+    expect(usePhotoRefreshStore.getState().isRefreshing).toBe(false);
+
+    const retry = vi.fn(() => Promise.resolve());
+    await run(retry);
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/photo-refresh/model/store.ts
+++ b/apps/web/src/features/photo-refresh/model/store.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+interface PhotoRefreshState {
+  isRefreshing: boolean;
+  /** 진행 중이면 새 작업을 무시한다. 헤더 버튼과 당겨서 새로고침이 겹쳐도 요청은 한 번만 나간다. */
+  run: (task: () => Promise<unknown>) => Promise<void>;
+}
+
+/**
+ * 새로고침 진행 상태를 헤더(top-bar)와 목록(photo-list)이 함께 본다.
+ * - 어느 쪽에서 시작하든 버튼은 회전하고, 다른 쪽 트리거는 잠긴다.
+ */
+export const usePhotoRefreshStore = create<PhotoRefreshState>((set, get) => ({
+  isRefreshing: false,
+
+  run: async (task) => {
+    if (get().isRefreshing) return;
+
+    set({ isRefreshing: true });
+
+    try {
+      await task();
+    } finally {
+      // 실패해도 잠금은 반드시 풀어야 다시 시도할 수 있다.
+      set({ isRefreshing: false });
+    }
+  },
+}));

--- a/apps/web/src/features/photo-refresh/model/use-refresh-photos.ts
+++ b/apps/web/src/features/photo-refresh/model/use-refresh-photos.ts
@@ -1,0 +1,43 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { usePhotoRefreshStore } from './store';
+
+import { photoKeys } from '@/entities/photo';
+import { track } from '@/shared/lib/analytics';
+
+/** list.refresh 이벤트에 남길 시작 지점. 타입으로 강제해 track() 호출을 누락 못 하게 한다. */
+export type RefreshSource = 'button' | 'pull';
+
+interface RefreshPhotos {
+  isRefreshing: boolean;
+  refresh: (source: RefreshSource) => Promise<void>;
+}
+
+/**
+ * 목록을 서버 기준으로 다시 맞춘다.
+ *
+ * - type: 'active'만 리페치해 화면에 붙은 쿼리만 갱신
+ * - 삭제된 사진은 사라지고, 낙관적으로 끼워둔 로컬 카드는 서버 썸네일로 교체
+ * - 실패 시 에러 처리는 안 함 (목록 쿼리의 throwOnError가 ErrorBoundary로 전달)
+ */
+export function useRefreshPhotos(): RefreshPhotos {
+  const queryClient = useQueryClient();
+  const isRefreshing = usePhotoRefreshStore((s) => s.isRefreshing);
+
+  const refresh = useCallback(
+    (source: RefreshSource) =>
+      // 구독한 isRefreshing이 아니라 스토어의 최신 값으로 잠금을 판단한다.
+      usePhotoRefreshStore.getState().run(async () => {
+        track('list.refresh', { source });
+
+        await queryClient.refetchQueries({
+          queryKey: photoKeys.lists(),
+          type: 'active',
+        });
+      }),
+    [queryClient],
+  );
+
+  return { isRefreshing, refresh };
+}

--- a/apps/web/src/features/photo-refresh/ui/pull-to-refresh.tsx
+++ b/apps/web/src/features/photo-refresh/ui/pull-to-refresh.tsx
@@ -1,0 +1,58 @@
+import { RefreshCw } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { useRefreshPhotos } from '../model/use-refresh-photos';
+
+import { PULL_TRIGGER_DISTANCE } from '@/shared/lib/gesture/pull';
+import { usePullToRefresh } from '@/shared/lib/hooks/use-pull-to-refresh';
+import { cn } from '@/shared/lib/utils/cn';
+
+/** 인디케이터가 화면 밖(위)에 대기하는 높이. 당긴 만큼 내려온다. */
+const INDICATOR_PARKED_OFFSET = 40;
+
+/**
+ * 목록을 감싸 당겨서 새로고침을 붙인다.
+ *
+ * - iOS standalone엔 당겨서 새로고침이 없어 제스처·인디케이터를 직접 구현
+ * - 헤더 버튼과 진행 상태를 공유하므로, 어느 쪽으로 시작해도 둘 다 진행 중으로 표시
+ */
+export function PullToRefresh({ children }: { children: ReactNode }) {
+  const { isRefreshing, refresh } = useRefreshPhotos();
+  const { distance, isDragging } = usePullToRefresh({
+    onRefresh: () => void refresh('pull'),
+    enabled: !isRefreshing,
+  });
+
+  const offset = isRefreshing ? PULL_TRIGGER_DISTANCE : distance;
+  const progress = Math.min(offset / PULL_TRIGGER_DISTANCE, 1);
+  const settle = isDragging ? undefined : 'transition-transform duration-200';
+
+  return (
+    <div className="relative">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 flex justify-center"
+        style={{
+          transform: `translateY(${offset - INDICATOR_PARKED_OFFSET}px)`,
+          opacity: progress,
+        }}
+      >
+        <span className="rounded-full border border-border bg-background p-2 shadow-sm">
+          <RefreshCw
+            className={cn('size-4', isRefreshing && 'animate-spin')}
+            style={
+              // 당긴 진행도만큼 회전, 반 바퀴(180°) 돌면 손을 떼도 된다는 신호.
+              isRefreshing
+                ? undefined
+                : { transform: `rotate(${progress * 180}deg)` }
+            }
+          />
+        </span>
+      </div>
+
+      <div className={settle} style={{ transform: `translateY(${offset}px)` }}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/photo-refresh/ui/refresh-button.stories.tsx
+++ b/apps/web/src/features/photo-refresh/ui/refresh-button.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { RefreshButton } from './refresh-button';
+import { usePhotoRefreshStore } from '../model/store';
+
+const meta = {
+  title: 'features/photo-refresh/RefreshButton',
+  component: RefreshButton,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={new QueryClient()}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+  async beforeEach() {
+    usePhotoRefreshStore.setState({ isRefreshing: false });
+    return () => usePhotoRefreshStore.setState({ isRefreshing: false });
+  },
+} satisfies Meta<typeof RefreshButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** 진행 중에는 아이콘이 회전하고 버튼이 잠겨 중복 요청을 막는다. */
+export const Refreshing: Story = {
+  async beforeEach() {
+    usePhotoRefreshStore.setState({ isRefreshing: true });
+    return () => usePhotoRefreshStore.setState({ isRefreshing: false });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole('button', { name: '사진 목록 새로고침' }),
+    ).toBeDisabled();
+    await expect(canvas.getByRole('status')).toHaveTextContent(
+      '사진 목록을 새로고침하는 중이에요',
+    );
+  },
+};
+
+/** 붙어 있는 목록 쿼리가 없어도 클릭은 즉시 끝나고, 완료가 스크린리더에 안내된다. */
+export const AnnouncesCompletion: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: '사진 목록 새로고침' }),
+    );
+
+    await expect(canvas.getByRole('status')).toHaveTextContent(
+      '사진 목록을 새로고침했어요',
+    );
+  },
+};

--- a/apps/web/src/features/photo-refresh/ui/refresh-button.stories.tsx
+++ b/apps/web/src/features/photo-refresh/ui/refresh-button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { RefreshButton } from './refresh-button';
 import { usePhotoRefreshStore } from '../model/store';
@@ -39,8 +39,13 @@ export const Refreshing: Story = {
     await expect(
       canvas.getByRole('button', { name: '사진 목록 새로고침' }),
     ).toBeDisabled();
-    await expect(canvas.getByRole('status')).toHaveTextContent(
-      '사진 목록을 새로고침하는 중이에요',
+
+    // 안내 문구는 effect로 비동기 채워짐
+    // act() 없는 Chromatic 빌드에선 play가 먼저 돌 수 있어 waitFor로 대기 필요
+    await waitFor(() =>
+      expect(canvas.getByRole('status')).toHaveTextContent(
+        '사진 목록을 새로고침하는 중이에요',
+      ),
     );
   },
 };
@@ -54,8 +59,10 @@ export const AnnouncesCompletion: Story = {
       canvas.getByRole('button', { name: '사진 목록 새로고침' }),
     );
 
-    await expect(canvas.getByRole('status')).toHaveTextContent(
-      '사진 목록을 새로고침했어요',
+    await waitFor(() =>
+      expect(canvas.getByRole('status')).toHaveTextContent(
+        '사진 목록을 새로고침했어요',
+      ),
     );
   },
 };

--- a/apps/web/src/features/photo-refresh/ui/refresh-button.tsx
+++ b/apps/web/src/features/photo-refresh/ui/refresh-button.tsx
@@ -1,0 +1,56 @@
+import { RefreshCw } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { useRefreshPhotos } from '../model/use-refresh-photos';
+
+import { cn } from '@/shared/lib/utils/cn';
+import { Button } from '@/shared/ui/button';
+
+const ANNOUNCEMENT = {
+  refreshing: '사진 목록을 새로고침하는 중이에요',
+  done: '사진 목록을 새로고침했어요',
+} as const;
+
+/**
+ * 홈 화면 PWA에는 브라우저 새로고침 버튼이 사라지므로 그 자리를 대신하는 새로고침 버튼
+ *
+ * - 진행 중에는 disabled로 중복 요청을 막음(스토어 잠금과 이중 방어)
+ * - 아이콘 회전을 볼 수 없는 스크린리더에는 aria-live로 시작·완료를 알림
+ */
+export function RefreshButton() {
+  const { isRefreshing, refresh } = useRefreshPhotos();
+  const announcement = useRefreshAnnouncement(isRefreshing);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="사진 목록 새로고침"
+        disabled={isRefreshing}
+        onClick={() => void refresh('button')}
+      >
+        <RefreshCw className={cn(isRefreshing && 'animate-spin')} aria-hidden />
+      </Button>
+
+      <span role="status" aria-live="polite" className="sr-only">
+        {announcement}
+      </span>
+    </>
+  );
+}
+
+/** 마운트 직후엔 알릴 것이 없다. 첫 새로고침부터 시작 → 완료 순서로 알린다. */
+function useRefreshAnnouncement(isRefreshing: boolean): string {
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    setAnnouncement((prev) => {
+      if (isRefreshing) return ANNOUNCEMENT.refreshing;
+      return prev ? ANNOUNCEMENT.done : '';
+    });
+  }, [isRefreshing]);
+
+  return announcement;
+}

--- a/apps/web/src/features/photo-upload/ui/upload-dropzone.tsx
+++ b/apps/web/src/features/photo-upload/ui/upload-dropzone.tsx
@@ -1,12 +1,12 @@
-import { useRef, useState, type ChangeEvent, type DragEvent } from 'react';
 import { ImagePlus } from 'lucide-react';
-import { toast } from 'sonner';
-
-import { Button } from '@/shared/ui/button';
-import { cn } from '@/shared/lib/utils/cn';
+import { useRef, useState, type ChangeEvent, type DragEvent } from 'react';
 
 import { validateFile } from '../lib/validate';
 import { useUploadQueueStore } from '../model/store';
+
+import { cn } from '@/shared/lib/utils/cn';
+import { Button } from '@/shared/ui/button';
+import { toast } from '@/shared/ui/toast';
 
 export function UploadDropzone() {
   const inputRef = useRef<HTMLInputElement>(null);

--- a/apps/web/src/pages/auth/ui/page.tsx
+++ b/apps/web/src/pages/auth/ui/page.tsx
@@ -9,7 +9,7 @@ import { toast } from '@/shared/ui/toast';
 
 function InviteButton() {
   const handleClick = () => {
-    toast('초대 코드 기능은 아직 준비 중이에요.');
+    toast.info('초대 코드 기능은 아직 준비 중이에요.');
   };
 
   return (

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ErrorBoundary } from '@/app/providers/error-boundary';
 import { useAlbumStore, useCurrentAlbumRole } from '@/entities/album';
 import {
+  isAlreadyDeleted,
   PhotoMeta,
   PhotoProgressiveImage,
   selectPhotos,
@@ -221,15 +222,22 @@ function DeletePhotoButton({ photo }: { photo: Photo }) {
       },
 
       onError: (err) => {
+        if (isAlreadyDeleted(err)) {
+          toast.info('이미 삭제된 사진이에요.');
+          navigate('/photos');
+          return;
+        }
+
         if (err instanceof ApiError && err.status === 403) {
           recordForbidden({
             userRole: role ?? 'unknown',
             operationId: 'deleteMedia',
           });
           toast.error('삭제 권한이 없어요.');
-        } else {
-          toast.error('삭제에 실패했어요.');
+          return;
         }
+
+        toast.error('삭제에 실패했어요.');
       },
     });
   };

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -200,12 +200,11 @@ export function PhotoListPage() {
 }
 
 const TABS = [
-  { key: 'all', label: '전체', enabled: true },
-  { key: 'recent', label: '최근', enabled: false },
-  { key: 'favorite', label: '즐겨찾기', enabled: false },
+  { key: 'all', label: '전체', ready: true },
+  { key: 'favorite', label: '즐겨찾기', ready: false },
 ] as const;
 
-// TODO: 최근/즐겨찾기 필터 API 연결 (연결되면 active를 상태로 변경)
+// TODO: 즐겨찾기 필터 API 연결 (연결되면 ready: true + active를 상태로 변경, 안내 토스트 제거)
 function FilterTabs() {
   const active = 'all';
 
@@ -217,12 +216,14 @@ function FilterTabs() {
           <button
             key={tab.key}
             type="button"
-            disabled={!tab.enabled}
             aria-current={isActive ? 'page' : undefined}
+            onClick={() => {
+              if (!tab.ready) toast.info('즐겨찾기는 준비 중이에요.');
+            }}
             className={cn(
               'text-[22px] tracking-tight',
               isActive ? 'text-primary' : 'text-foreground',
-              !tab.enabled && 'opacity-25',
+              !tab.ready && 'opacity-25',
             )}
           >
             {tab.label}

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -19,6 +19,7 @@ import {
   downloadFilename,
   downloadMany,
 } from '@/features/photo-download';
+import { PullToRefresh } from '@/features/photo-refresh';
 import {
   SelectCheckbox,
   useIsSelected,
@@ -163,32 +164,34 @@ export function PhotoListPage() {
       </div>
 
       <ErrorBoundary fallback={(error) => <GridErrorFallback error={error} />}>
-        <PhotoGrid
-          photos={photos}
-          isLoading={!albumsSettled || query.isLoading}
-          isFetchingNextPage={query.isFetchingNextPage}
-          hasNextPage={!!query.hasNextPage}
-          onLoadMore={() => query.fetchNextPage()}
-          emptyAction={
-            canUpload(role) ? (
-              <Link
-                to="/upload"
-                className="text-[14px] text-foreground opacity-30 transition-opacity hover:opacity-100"
-              >
-                사진 올리기
-              </Link>
-            ) : undefined
-          }
-          renderCard={(photo) => (
-            <GridCard
-              key={photo.id}
-              photo={photo}
-              onOpen={(id) =>
-                navigate(`/photos/${id}`, { state: { source: 'grid' } })
-              }
-            />
-          )}
-        />
+        <PullToRefresh>
+          <PhotoGrid
+            photos={photos}
+            isLoading={!albumsSettled || query.isLoading}
+            isFetchingNextPage={query.isFetchingNextPage}
+            hasNextPage={!!query.hasNextPage}
+            onLoadMore={() => query.fetchNextPage()}
+            emptyAction={
+              canUpload(role) ? (
+                <Link
+                  to="/upload"
+                  className="text-[14px] text-foreground opacity-30 transition-opacity hover:opacity-100"
+                >
+                  사진 올리기
+                </Link>
+              ) : undefined
+            }
+            renderCard={(photo) => (
+              <GridCard
+                key={photo.id}
+                photo={photo}
+                onOpen={(id) =>
+                  navigate(`/photos/${id}`, { state: { source: 'grid' } })
+                }
+              />
+            )}
+          />
+        </PullToRefresh>
       </ErrorBoundary>
 
       <SelectionBar

--- a/apps/web/src/shared/lib/analytics/types.ts
+++ b/apps/web/src/shared/lib/analytics/types.ts
@@ -7,6 +7,7 @@ export type AnalyticsEvent =
   | 'album.select'
   | 'list.view'
   | 'list.scroll_depth'
+  | 'list.refresh'
   | 'detail.view'
   | 'api.timing'
   | 'upload.session_complete'

--- a/apps/web/src/shared/lib/gesture/pull.test.ts
+++ b/apps/web/src/shared/lib/gesture/pull.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  isPullTriggered,
+  isVerticalPull,
+  PULL_MAX_DISTANCE,
+  PULL_TRIGGER_DISTANCE,
+  pullDistance,
+} from './pull';
+
+describe('isVerticalPull', () => {
+  test('아래로 향하고 세로 이동이 더 크면 당김이다', () => {
+    expect(isVerticalPull(10, 40)).toBe(true);
+  });
+
+  test('위로 향하면 당김이 아니다(일반 스크롤)', () => {
+    expect(isVerticalPull(0, -40)).toBe(false);
+  });
+
+  test('가로 이동이 더 크면 당김이 아니다(가로 스와이프)', () => {
+    expect(isVerticalPull(-50, 20)).toBe(false);
+  });
+});
+
+describe('pullDistance', () => {
+  test('저항이 적용돼 손가락 이동보다 적게 따라온다', () => {
+    expect(pullDistance(100)).toBe(50);
+  });
+
+  test('아무리 당겨도 상한을 넘지 않는다', () => {
+    expect(pullDistance(10_000)).toBe(PULL_MAX_DISTANCE);
+  });
+
+  test('위로 올리면 0이다', () => {
+    expect(pullDistance(-30)).toBe(0);
+  });
+});
+
+describe('isPullTriggered', () => {
+  test('임계값에 정확히 닿으면 발동한다', () => {
+    expect(isPullTriggered(PULL_TRIGGER_DISTANCE)).toBe(true);
+  });
+
+  test('임계값에 못 미치면 발동하지 않는다', () => {
+    expect(isPullTriggered(PULL_TRIGGER_DISTANCE - 1)).toBe(false);
+  });
+});

--- a/apps/web/src/shared/lib/gesture/pull.ts
+++ b/apps/web/src/shared/lib/gesture/pull.ts
@@ -1,0 +1,28 @@
+/** 이 거리(px) 이상 당겼다 놓으면 새로고침이 발동한다. */
+export const PULL_TRIGGER_DISTANCE = 72;
+
+export function isPullTriggered(distance: number): boolean {
+  return distance >= PULL_TRIGGER_DISTANCE;
+}
+
+/** 아무리 당겨도 인디케이터가 내려오는 최대 거리(px). */
+export const PULL_MAX_DISTANCE = 96;
+
+/** 손가락 이동 대비 화면이 따라오는 비율. 1이면 손끝에 딱 붙어 너무 쉽게 발동한다. */
+const PULL_RESISTANCE = 0.5;
+
+/** 가로 스와이프를 세로 당김으로 오인하지 않게 한다. */
+export function isVerticalPull(deltaX: number, deltaY: number): boolean {
+  return deltaY > 0 && deltaY > Math.abs(deltaX);
+}
+
+/**
+ * 손가락이 움직인 거리를 화면에 보여줄 당김 거리로 줄여준다.
+ * - 손가락 절반만큼만 화면이 따라오고(저항)
+ * - 아무리 당겨도 96px을 넘지 않는다(상한)
+ * @example 손가락을 144px 당기면 화면은 72px만 내려간다.
+ */
+export function pullDistance(deltaY: number): number {
+  if (deltaY <= 0) return 0;
+  return Math.min(deltaY * PULL_RESISTANCE, PULL_MAX_DISTANCE);
+}

--- a/apps/web/src/shared/lib/hooks/use-pull-to-refresh.ts
+++ b/apps/web/src/shared/lib/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  isPullTriggered,
+  isVerticalPull,
+  pullDistance,
+} from '@/shared/lib/gesture/pull';
+
+interface UsePullToRefreshOptions {
+  onRefresh: () => void;
+  /** 이미 새로고침 중이면 꺼서 제스처를 받지 않는다. */
+  enabled?: boolean;
+}
+
+interface PullState {
+  distance: number;
+  isDragging: boolean;
+}
+
+/** 문서가 최상단일 때만 당김을 시작한다. */
+function isAtTop(): boolean {
+  return window.scrollY <= 0;
+}
+
+/**
+ * 문서 스크롤 기준 당겨서 새로고침.
+ *
+ * - window에 직접 리스너를 등록한다 (React onTouchMove는 passive 지정 불가)
+ * - touchmove는 passive: false로 등록해 preventDefault로 브라우저 바운스를 막는다
+ * - 그 위에 우리가 그린 인디케이터만 움직인다
+ */
+export function usePullToRefresh({
+  onRefresh,
+  enabled = true,
+}: UsePullToRefreshOptions): PullState {
+  const [distance, setDistance] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const originRef = useRef<{ x: number; y: number } | null>(null);
+  const distanceRef = useRef(0);
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const reset = () => {
+      originRef.current = null;
+      distanceRef.current = 0;
+      setDistance(0);
+      setIsDragging(false);
+    };
+
+    const handleStart = (event: TouchEvent) => {
+      // 핀치 줌 등 멀티터치는 당김이 아니다.
+      if (event.touches.length !== 1 || !isAtTop()) {
+        originRef.current = null;
+        return;
+      }
+
+      const touch = event.touches[0]!;
+      originRef.current = { x: touch.clientX, y: touch.clientY };
+    };
+
+    const handleMove = (event: TouchEvent) => {
+      const origin = originRef.current;
+      const touch = event.touches[0];
+      if (!origin || !touch) return;
+
+      // 당기는 도중 손가락이 늘면(핀치 줌) touches[0]이 추적하던 손가락이 아닐 수 있다.
+      if (event.touches.length !== 1) {
+        reset();
+        return;
+      }
+
+      // 당기는 도중 최상단을 벗어났다면 일반 스크롤로 돌려준다.
+      if (!isAtTop()) {
+        reset();
+        return;
+      }
+
+      const deltaX = touch.clientX - origin.x;
+      const deltaY = touch.clientY - origin.y;
+
+      // 되돌리거나 가로로 긋는 중이면 인디케이터만 접고 추적은 유지한다.
+      // isDragging도 함께 꺼야 접히는 동안 transition이 살아나 툭 끊기지 않는다.
+      if (!isVerticalPull(deltaX, deltaY)) {
+        distanceRef.current = 0;
+        setDistance(0);
+        setIsDragging(false);
+        return;
+      }
+
+      event.preventDefault();
+
+      distanceRef.current = pullDistance(deltaY);
+      setDistance(distanceRef.current);
+      setIsDragging(true);
+    };
+
+    const handleEnd = () => {
+      const triggered = isPullTriggered(distanceRef.current);
+      reset();
+
+      if (triggered) onRefreshRef.current();
+    };
+
+    window.addEventListener('touchstart', handleStart, { passive: true });
+    window.addEventListener('touchmove', handleMove, { passive: false });
+    window.addEventListener('touchend', handleEnd);
+    window.addEventListener('touchcancel', handleEnd);
+
+    return () => {
+      window.removeEventListener('touchstart', handleStart);
+      window.removeEventListener('touchmove', handleMove);
+      window.removeEventListener('touchend', handleEnd);
+      window.removeEventListener('touchcancel', handleEnd);
+      reset();
+    };
+  }, [enabled]);
+
+  return { distance, isDragging };
+}

--- a/apps/web/src/shared/ui/toast/index.ts
+++ b/apps/web/src/shared/ui/toast/index.ts
@@ -1,2 +1,2 @@
 export { Toaster } from './toaster';
-export { toast } from 'sonner';
+export { toast, TOAST_DURATION } from './toast';

--- a/apps/web/src/shared/ui/toast/toast.stories.tsx
+++ b/apps/web/src/shared/ui/toast/toast.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TOAST_DURATION, toast } from './toast';
+import { Toaster } from './toaster';
+
+import { Button } from '@/shared/ui/button';
+
+const meta: Meta<typeof Toaster> = {
+  title: 'shared/ui/Toast',
+  component: Toaster,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story, ctx) => (
+      <>
+        <Toaster theme={ctx.globals.theme === 'dark' ? 'dark' : 'light'} />
+        <Story />
+      </>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 유형별 색·아이콘과 노출 시간을 한 화면에서 비교한다. 툴바 Theme으로 라이트/다크를 확인한다. */
+export const AllTypes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant="outline"
+          onClick={() => toast.success('사진을 삭제했어요.')}
+        >
+          성공 {TOAST_DURATION.success / 1000}초
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => toast.info('이미 삭제된 사진이에요.')}
+        >
+          안내 {TOAST_DURATION.info / 1000}초
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => toast.warning('3장 완료 · 1장 실패')}
+        >
+          경고 {TOAST_DURATION.warning / 1000}초
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => toast.error('삭제에 실패했어요.')}
+        >
+          실패 {TOAST_DURATION.error / 1000}초
+        </Button>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        실패 토스트만 닫기 버튼이 있고, 가장 오래 노출된다.
+      </p>
+    </div>
+  ),
+};
+
+/** 실패 토스트: 6초 노출 + 사용자가 직접 닫을 수 있다. */
+export const Error: Story = {
+  render: () => (
+    <Button
+      variant="destructive"
+      onClick={() => toast.error('삭제에 실패했어요.')}
+    >
+      실패 토스트 띄우기
+    </Button>
+  ),
+};
+
+/** 성공 토스트: 3초 후 자동으로 사라진다. */
+export const Success: Story = {
+  render: () => (
+    <Button onClick={() => toast.success('사진을 삭제했어요.')}>
+      성공 토스트 띄우기
+    </Button>
+  ),
+};
+
+/** 여러 개가 쌓였을 때의 정렬·간격을 본다. */
+export const Stacked: Story = {
+  render: () => (
+    <Button
+      variant="outline"
+      onClick={() => {
+        toast.success('사진을 삭제했어요.');
+        toast.warning('3장 완료 · 1장 실패');
+        toast.error('삭제에 실패했어요.');
+      }}
+    >
+      한꺼번에 띄우기
+    </Button>
+  ),
+};

--- a/apps/web/src/shared/ui/toast/toast.ts
+++ b/apps/web/src/shared/ui/toast/toast.ts
@@ -1,0 +1,37 @@
+import { toast as sonner, type ExternalToast } from 'sonner';
+
+/**
+ * 토스트 노출 시간 정책
+ * - 성공/안내는 짧게: 읽지 못해도 흐름에 지장이 없다.
+ * - 실패는 길게: 원인을 읽고 다음 행동을 정할 시간이 필요하다.
+ */
+export const TOAST_DURATION = {
+  success: 3000,
+  info: 3000,
+  warning: 4000,
+  error: 6000,
+} as const;
+
+type Message = Parameters<typeof sonner.success>[0];
+
+/** sonner의 toast에 노출 시간·닫기 버튼 기본값만 입힌 래퍼 */
+export const toast = {
+  success: (message: Message, options?: ExternalToast) =>
+    sonner.success(message, { duration: TOAST_DURATION.success, ...options }),
+
+  info: (message: Message, options?: ExternalToast) =>
+    sonner.info(message, { duration: TOAST_DURATION.info, ...options }),
+
+  warning: (message: Message, options?: ExternalToast) =>
+    sonner.warning(message, { duration: TOAST_DURATION.warning, ...options }),
+
+  // 오래 떠 있는 만큼 사용자가 직접 닫을 수 있어야 한다.
+  error: (message: Message, options?: ExternalToast) =>
+    sonner.error(message, {
+      duration: TOAST_DURATION.error,
+      closeButton: true,
+      ...options,
+    }),
+
+  dismiss: sonner.dismiss,
+};

--- a/apps/web/src/shared/ui/toast/toaster.tsx
+++ b/apps/web/src/shared/ui/toast/toaster.tsx
@@ -1,16 +1,22 @@
 import { Toaster as Sonner, type ToasterProps } from 'sonner';
 
+import { TOAST_DURATION } from './toast';
+
+/**
+ * - toast 배경·글자색은 richColors 팔레트를 덮어쓰므로 지정하지 않는다.
+ * - theme은 앱의 수동 토글 값을 주입한다('system'은 OS 설정만 봄).
+ */
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       className="toaster group"
       position="top-center"
+      richColors
       toastOptions={{
-        duration: 2000,
+        duration: TOAST_DURATION.info,
+        closeButtonAriaLabel: '닫기',
         classNames: {
-          toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-          description: 'group-[.toast]:text-muted-foreground',
+          toast: 'group toast group-[.toaster]:shadow-lg',
           actionButton:
             'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
           cancelButton:

--- a/apps/web/src/widgets/top-bar/ui/top-bar.tsx
+++ b/apps/web/src/widgets/top-bar/ui/top-bar.tsx
@@ -1,6 +1,5 @@
 import { LogOut, Plus } from 'lucide-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { useCurrentAlbumRole } from '@/entities/album';
 import type { UserRole } from '@/entities/user';
@@ -14,6 +13,7 @@ import { SelectToggle } from '@/features/photo-select';
 import { ThemeToggle } from '@/features/theme';
 import { cn } from '@/shared/lib/utils/cn';
 import { Button } from '@/shared/ui/button';
+import { toast } from '@/shared/ui/toast';
 
 /**
  * 모든 라우트에 상시 노출되는 상단 바

--- a/apps/web/src/widgets/top-bar/ui/top-bar.tsx
+++ b/apps/web/src/widgets/top-bar/ui/top-bar.tsx
@@ -9,6 +9,7 @@ import {
   useIsAuthenticated,
   useLogoutMutation,
 } from '@/features/auth';
+import { RefreshButton } from '@/features/photo-refresh';
 import { SelectToggle } from '@/features/photo-select';
 import { ThemeToggle } from '@/features/theme';
 import { cn } from '@/shared/lib/utils/cn';
@@ -65,6 +66,8 @@ function AuthActions() {
   return (
     <nav className="flex items-center gap-1.5">
       {isListRoute ? <SelectToggle /> : null}
+      {/* 목록에서만 새로고침 버튼을 노출한다. */}
+      {isListRoute ? <RefreshButton /> : null}
       <ThemeToggle />
       <UploadFab role={role} />
       <LogoutButton />


### PR DESCRIPTION
## 📌 관련 이슈

* Closed #132

---

## 🧹 작업 내용

* **헤더 새로고침 버튼** 
    * 목록 화면에서만 노출. 진행 중에는 아이콘이 회전하고 버튼이 잠깁니다.
* **당겨서 새로고침**
    * 목록을 감싸는 `PullToRefresh`. 
    * 72px 이상 당겼다 놓으면 발동하고, 당김 진행도에 따라 인디케이터가 회전합니다.

* 새로고침은 화면에 붙어 있는 목록 쿼리만(`type: 'active'`) refetch합니다. 
    * 로드된 모든 페이지를 다시 받으므로 삭제된 사진은 사라지고, 
    * 업로드 직후 낙관적으로 끼워넣은 로컬 카드는 서버 썸네일로 교체됩니다.
* `list.refresh` 이벤트로 시작 지점(`button` / `pull`)을 트래킹해 어느 수단이 실제로 쓰이는지 봅니다.

---

## 🛠️  테스트 (선택)

* [x] 단위 테스트 통과 — 당김 계산 경계값(`gesture/pull`), 스토어 잠금 규약(`photo-refresh/store`)
* [x] 수동 테스트 완료 — Storybook에서 `RefreshButton` 기본/진행 중/완료 안내 상태 확인
* [ ] 기존 기능 영향 없음 확인 — 실기기(iOS standalone / Android Chrome) 제스처 확인 필요


---

## 🔍 고민 / 결정 사항

* 제스처 계산은 merge 이후 실기기에서 사용해보며 조정할 예정입니다.

---

## 💬 참고 사항

> [!NOTE]
> * `touchmove`마다 `setState`가 돌아 리렌더가 잦습니다. 
> * 지금은 인디케이터 transform만 바뀌어 체감 문제가 없지만, 저사양 기기에서 버벅임이 보이면 `requestAnimationFrame`으로 프레임당 한 번만 반영하도록 바꾸겠습니다.
> * 현재는 이거 하나로 rAF를 도입할 필요있나 싶어서 가만뒀습니다.

* `usePullToRefresh`는 문서 스크롤(`window.scrollY`) 기준입니다. 목록을 가상 스크롤 컨테이너로 바꾸게 되면 이 기준도 함께 바꿔야 합니다.