### PR TITLE
[Fix] 썸네일 로드 실패 시 재시도·실패 노출·로깅 추가

### DIFF
--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -182,24 +182,24 @@ export function usePhotoDetail(id: string, options?: { enabled?: boolean }) {
 }
 
 /**
- * 썸네일 로드에 실패한 사진 하나만 새 presigned URL로 다시 받아온다.
+ * 이미지 로드에 실패한 사진 하나만 새 presigned URL(썸네일·원본)로 다시 받아온다.
+ *
+ * presigned 서명은 180초 만에 만료되므로, 목록을 오래 열어두고 스크롤하거나 상세를 재진입하면
+ * 이미 죽은 URL로 요청이 나갈 수 있다. 그때 이 훅으로 그 사진만 재서명해 다시 그린다.
  *
  * - 목록 쿼리 무효화 대신 상세 조회로 그 사진만 재서명 (전체 재다운로드 방지)
  * - 부수 효과로 상세 캐시도 채워져, 그 사진 상세 진입이 빨라짐
  */
-export function useRefreshThumbnail() {
+export function useRefreshPhotoUrls() {
   const queryClient = useQueryClient();
 
   return useCallback(
-    async (id: string): Promise<string | undefined> => {
-      const photo = await queryClient.fetchQuery({
+    (id: string): Promise<Photo> =>
+      queryClient.fetchQuery({
         queryKey: photoKeys.detail(id),
         queryFn: () => fetchPhotoDetail(id),
         staleTime: 0, // 캐시를 건너뛰고 새 서명 URL을 받아야 한다
-      });
-
-      return photo.thumbnailUrl;
-    },
+      }),
     [queryClient],
   );
 }

--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -4,6 +4,7 @@ import {
   useQueryClient,
   type QueryClient,
 } from '@tanstack/react-query';
+import { useCallback } from 'react';
 
 import { photoKeys, type PhotoListFilters } from './keys';
 import { toPhoto } from '../lib/mapper';
@@ -178,6 +179,29 @@ export function usePhotoDetail(id: string, options?: { enabled?: boolean }) {
     throwOnError: true,
     meta: { operationId: 'getMedia' },
   });
+}
+
+/**
+ * 썸네일 로드에 실패한 사진 하나만 새 presigned URL로 다시 받아온다.
+ *
+ * - 목록 쿼리 무효화 대신 상세 조회로 그 사진만 재서명 (전체 재다운로드 방지)
+ * - 부수 효과로 상세 캐시도 채워져, 그 사진 상세 진입이 빨라짐
+ */
+export function useRefreshThumbnail() {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (id: string): Promise<string | undefined> => {
+      const photo = await queryClient.fetchQuery({
+        queryKey: photoKeys.detail(id),
+        queryFn: () => fetchPhotoDetail(id),
+        staleTime: 0, // 캐시를 건너뛰고 새 서명 URL을 받아야 한다
+      });
+
+      return photo.thumbnailUrl;
+    },
+    [queryClient],
+  );
 }
 
 export function usePhotosInfinite(

--- a/apps/web/src/entities/photo/index.ts
+++ b/apps/web/src/entities/photo/index.ts
@@ -2,7 +2,7 @@ export { photoKeys, type PhotoListFilters } from './api/keys';
 export {
   usePhotosInfinite,
   usePhotoDetail,
-  useRefreshThumbnail,
+  useRefreshPhotoUrls,
   findPhotoInListCache,
   prependMediaToLists,
   removeMediaFromLists,
@@ -24,12 +24,10 @@ export type {
   PhotoState,
   MediaDto,
   MediaListResponse,
+  ImageErrorHandler,
 } from './model/types';
 
 export { PhotoCard } from './ui/photo-card';
-export {
-  PhotoThumbnail,
-  type ThumbnailErrorHandler,
-} from './ui/photo-thumbnail';
+export { PhotoThumbnail } from './ui/photo-thumbnail';
 export { PhotoProgressiveImage } from './ui/photo-progressive-image';
 export { PhotoMeta } from './ui/photo-meta';

--- a/apps/web/src/entities/photo/index.ts
+++ b/apps/web/src/entities/photo/index.ts
@@ -2,6 +2,7 @@ export { photoKeys, type PhotoListFilters } from './api/keys';
 export {
   usePhotosInfinite,
   usePhotoDetail,
+  useRefreshThumbnail,
   findPhotoInListCache,
   prependMediaToLists,
   removeMediaFromLists,
@@ -26,6 +27,9 @@ export type {
 } from './model/types';
 
 export { PhotoCard } from './ui/photo-card';
-export { PhotoThumbnail } from './ui/photo-thumbnail';
+export {
+  PhotoThumbnail,
+  type ThumbnailErrorHandler,
+} from './ui/photo-thumbnail';
 export { PhotoProgressiveImage } from './ui/photo-progressive-image';
 export { PhotoMeta } from './ui/photo-meta';

--- a/apps/web/src/entities/photo/lib/use-image-retry.ts
+++ b/apps/web/src/entities/photo/lib/use-image-retry.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { ImageErrorHandler } from '../model/types';
+
+interface ImageRetry {
+  /** 실제로 그릴 URL(재시도로 받은 새 URL이 있으면 그것) */
+  activeSrc: string | undefined;
+  /** 재시도까지 실패해 더 볼 게 없는 상태 */
+  failed: boolean;
+  /** 새 URL을 받아오는 중 */
+  retrying: boolean;
+  /** <img>의 onError에 그대로 연결한다 */
+  handleError: () => Promise<void>;
+  /** 수동 재시도(버튼 등). 새 URL을 받아내면 실패 상태를 푼다 */
+  retry: () => Promise<void>;
+}
+
+/**
+ * 이미지 로드 실패를 감지해 새 URL로 1회 다시 시도하는 상태 머신.
+ *
+ * - presigned URL은 180초 만에 만료되는데, 브라우저는 이미지 로드를 스스로 재시도하지 않는다.
+ * - 이 실패를 잡아 호출자에게 새 URL을 요청하고(onLoadError), 받으면 그걸로 다시 그린다.
+ * - 목록(PhotoThumbnail)과 상세(PhotoProgressiveImage)가 이 규칙을 공유한다.
+ *
+ * @param src - 서버가 준 원래 URL.
+ * @param onLoadError - 실패 시 호출. attempt 1에서 새 URL을 반환하면 그걸로 재시도한다.
+ */
+export function useImageRetry(
+  src: string | undefined,
+  onLoadError: ImageErrorHandler | undefined,
+): ImageRetry {
+  const [failed, setFailed] = useState(false);
+  const [retrying, setRetrying] = useState(false);
+  // 실패 후 받아온 새 presigned URL
+  const [retrySrc, setRetrySrc] = useState<string | undefined>(undefined);
+  const attempts = useRef(0);
+
+  const activeSrc = retrySrc ?? src;
+
+  // src가 갈리면(다른 사진으로 이동, 목록 리페치로 서명 재발급 등) 처음부터 다시 시작한다.
+  useEffect(() => {
+    setFailed(false);
+    setRetrying(false);
+    setRetrySrc(undefined);
+    attempts.current = 0;
+  }, [src]);
+
+  const handleError = async () => {
+    attempts.current += 1;
+    const attempt = attempts.current;
+
+    setRetrying(true);
+    const nextSrc = await onLoadError?.(attempt);
+    setRetrying(false);
+
+    // 자동 재시도는 1회 (새 URL을 못 받으면 실패로 굳힘)
+    if (attempt === 1 && nextSrc && nextSrc !== activeSrc) {
+      setRetrySrc(nextSrc);
+      return;
+    }
+
+    setFailed(true);
+  };
+
+  // 새 URL을 받아낸 뒤에 실패 상태를 푼다.
+  // 먼저 풀면 죽은 src로 이미지가 다시 렌더되고, 그 error가 이 재시도와 경합한다.
+  const retry = async () => {
+    setRetrying(true);
+    const nextSrc = await onLoadError?.(1);
+    setRetrying(false);
+
+    if (!nextSrc || nextSrc === activeSrc) return;
+
+    attempts.current = 0;
+    setRetrySrc(nextSrc);
+    setFailed(false);
+  };
+
+  return { activeSrc, failed, retrying, handleError, retry };
+}

--- a/apps/web/src/entities/photo/model/types.ts
+++ b/apps/web/src/entities/photo/model/types.ts
@@ -1,5 +1,14 @@
 export type PhotoState = 'DRAFT' | 'PREPARING' | 'COMPLETE';
 
+/**
+ * 이미지 로드 실패 핸들러.
+ * - attempt 1: 첫 실패 → 새 src(재서명 URL)를 반환하면 그걸로 한 번 더 시도한다
+ * - attempt 2: 재시도까지 실패 → 반환값은 무시하고 실패로 확정한다
+ */
+export type ImageErrorHandler = (
+  attempt: number,
+) => Promise<string | undefined> | void;
+
 export interface UserSummary {
   id: string;
   name: string;

--- a/apps/web/src/entities/photo/ui/photo-card.tsx
+++ b/apps/web/src/entities/photo/ui/photo-card.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
-import { PhotoThumbnail, type ThumbnailErrorHandler } from './photo-thumbnail';
-import type { Photo } from '../model/types';
+import { PhotoThumbnail } from './photo-thumbnail';
+import type { ImageErrorHandler, Photo } from '../model/types';
 
 interface PhotoCardProps {
   photo: Photo;
@@ -9,7 +9,7 @@ interface PhotoCardProps {
   actionSlot?: ReactNode | undefined;
   selected?: boolean | undefined;
   onOpen?: ((id: string) => void) | undefined;
-  onThumbnailError?: ThumbnailErrorHandler | undefined;
+  onThumbnailError?: ImageErrorHandler | undefined;
 }
 
 export function PhotoCard({

--- a/apps/web/src/entities/photo/ui/photo-card.tsx
+++ b/apps/web/src/entities/photo/ui/photo-card.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { PhotoThumbnail } from './photo-thumbnail';
+import { PhotoThumbnail, type ThumbnailErrorHandler } from './photo-thumbnail';
 import type { Photo } from '../model/types';
 
 interface PhotoCardProps {
@@ -9,6 +9,7 @@ interface PhotoCardProps {
   actionSlot?: ReactNode | undefined;
   selected?: boolean | undefined;
   onOpen?: ((id: string) => void) | undefined;
+  onThumbnailError?: ThumbnailErrorHandler | undefined;
 }
 
 export function PhotoCard({
@@ -17,6 +18,7 @@ export function PhotoCard({
   actionSlot,
   selected,
   onOpen,
+  onThumbnailError,
 }: PhotoCardProps) {
   return (
     // content-visibility로 화면 밖 카드 렌더링 스킵함
@@ -32,6 +34,7 @@ export function PhotoCard({
           src={photo.thumbnailUrl ?? photo.imageUrl}
           alt={photo.description}
           blurhash={photo.blurhash}
+          onLoadError={onThumbnailError}
         />
         {selected && (
           <span

--- a/apps/web/src/entities/photo/ui/photo-progressive-image.stories.tsx
+++ b/apps/web/src/entities/photo/ui/photo-progressive-image.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, waitFor } from 'storybook/test';
 
 import { PhotoProgressiveImage } from './photo-progressive-image';
+
+// 네트워크 없이도 반드시 로드되는 이미지(재시도 성공을 결정적으로 재현하기 위함)
+const OK_SRC =
+  "data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='800'%3E%3Crect width='800' height='800' fill='%231d4ed8'/%3E%3C/svg%3E";
+const BROKEN_SRC = 'https://placehold.co/broken-original-does-not-exist';
 
 const meta = {
   title: 'entities/photo/PhotoProgressiveImage',
@@ -36,4 +42,67 @@ export const PreviewOverBlur: Story = {
 /** 썸네일도 없을 때(blurhash placeholder만) */
 export const BlurhashOnly: Story = {
   args: { src: undefined, previewSrc: undefined },
+};
+
+/**
+ * 원본 로드 실패 + 재시도 성공
+ * - 만료된 presigned URL로 요청이 나간 경우, 새 서명 URL을 받아 자동으로 살아난다.
+ */
+export const RetrySucceeds: Story = {
+  args: {
+    src: BROKEN_SRC,
+    onLoadError: fn(async () => OK_SRC),
+  },
+  play: async ({ args, canvas }) => {
+    await waitFor(() => expect(args.onLoadError).toHaveBeenCalledWith(1));
+    await waitFor(() =>
+      expect(
+        canvas.queryByText('사진을 불러오지 못했어요'),
+      ).not.toBeInTheDocument(),
+    );
+  },
+};
+
+/** 원본 로드 실패 + 재시도도 실패 → 실패 문구와 수동 재시도 버튼을 노출한다 */
+export const Failed: Story = {
+  args: {
+    src: BROKEN_SRC,
+    onLoadError: fn(async () => undefined),
+  },
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByText('사진을 불러오지 못했어요')).toBeInTheDocument(),
+    );
+    await expect(
+      canvas.getByRole('button', { name: '다시 불러오기' }),
+    ).toBeInTheDocument();
+  },
+};
+
+/** 실패 후 버튼을 누르면 다시 URL을 요청하고, 살아나면 실패 표시가 사라진다 */
+let manualRetryCalls = 0;
+
+export const ManualRetry: Story = {
+  beforeEach: () => {
+    manualRetryCalls = 0;
+  },
+  args: {
+    src: BROKEN_SRC,
+    // 첫 시도(자동)는 새 URL을 못 받고, 버튼으로 누른 재시도에서 받아온다
+    onLoadError: fn(async () =>
+      ++manualRetryCalls === 1 ? undefined : OK_SRC,
+    ),
+  },
+  play: async ({ canvas }) => {
+    const button = await waitFor(() =>
+      canvas.getByRole('button', { name: '다시 불러오기' }),
+    );
+    await userEvent.click(button);
+
+    await waitFor(() =>
+      expect(
+        canvas.queryByText('사진을 불러오지 못했어요'),
+      ).not.toBeInTheDocument(),
+    );
+  },
 };

--- a/apps/web/src/entities/photo/ui/photo-progressive-image.tsx
+++ b/apps/web/src/entities/photo/ui/photo-progressive-image.tsx
@@ -1,7 +1,8 @@
 import { RefreshCw } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { blurhashToDataUrl } from '../lib/blurhash';
+import { useImageRetry } from '../lib/use-image-retry';
 import type { ImageErrorHandler } from '../model/types';
 
 import { cn } from '@/shared/lib/utils/cn';
@@ -39,58 +40,15 @@ export function PhotoProgressiveImage({
   const [fullLoaded, setFullLoaded] = useState(false);
   const [blurGone, setBlurGone] = useState(false);
   const [previewGone, setPreviewGone] = useState(false);
-  const [failed, setFailed] = useState(false);
-  const [retrying, setRetrying] = useState(false);
-  // 실패 후 받아온 새 presigned URL
-  const [retrySrc, setRetrySrc] = useState<string | undefined>(undefined);
-  const attempts = useRef(0);
-
-  const activeSrc = retrySrc ?? src;
-
-  // src가 갈리면(다른 사진으로 이동 등) 처음부터 다시 시작한다.
-  useEffect(() => {
-    setFailed(false);
-    setRetrying(false);
-    setRetrySrc(undefined);
-    attempts.current = 0;
-  }, [src]);
+  const { activeSrc, failed, retrying, handleError, retry } = useImageRetry(
+    src,
+    onLoadError,
+  );
 
   const blurUrl = useMemo(
     () => (blurhash ? blurhashToDataUrl(blurhash) : undefined),
     [blurhash],
   );
-
-  // presigned 만료 등으로 원본 로드가 실패하면 새 URL을 받아 1회 다시 시도한다.
-  // 브라우저는 이미지 로드를 재시도해주지 않으므로 직접 걸어야 한다.
-  const handleError = async () => {
-    attempts.current += 1;
-    const attempt = attempts.current;
-
-    setRetrying(true);
-    const nextSrc = await onLoadError?.(attempt);
-    setRetrying(false);
-
-    if (attempt === 1 && nextSrc && nextSrc !== activeSrc) {
-      setRetrySrc(nextSrc);
-      return;
-    }
-
-    setFailed(true);
-  };
-
-  // 수동 재시도 (새 URL을 받아낸 뒤에 실패 상태를 푼다)
-  // 먼저 풀면 죽은 src로 이미지가 다시 렌더되고, 그 error가 재시도와 경합한다.
-  const handleRetryClick = async () => {
-    setRetrying(true);
-    const nextSrc = await onLoadError?.(1);
-    setRetrying(false);
-
-    if (!nextSrc || nextSrc === activeSrc) return;
-
-    attempts.current = 0;
-    setRetrySrc(nextSrc);
-    setFailed(false);
-  };
 
   return (
     <>
@@ -156,7 +114,7 @@ export function PhotoProgressiveImage({
             variant="secondary"
             size="sm"
             className="rounded-full"
-            onClick={handleRetryClick}
+            onClick={retry}
             disabled={retrying}
           >
             <RefreshCw className={cn('size-4', retrying && 'animate-spin')} />

--- a/apps/web/src/entities/photo/ui/photo-progressive-image.tsx
+++ b/apps/web/src/entities/photo/ui/photo-progressive-image.tsx
@@ -1,8 +1,11 @@
-import { useMemo, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { blurhashToDataUrl } from '../lib/blurhash';
+import type { ImageErrorHandler } from '../model/types';
 
 import { cn } from '@/shared/lib/utils/cn';
+import { Button } from '@/shared/ui/button';
 
 interface PhotoProgressiveImageProps {
   /** 원본(최종 표시 픽셀) */
@@ -12,6 +15,8 @@ interface PhotoProgressiveImageProps {
   /** blurhash(초기 placeholder) */
   blurhash?: string | undefined;
   alt: string;
+  /** 원본 로드 실패 시 호출. 새 src(재서명 URL)를 반환하면 그걸로 다시 시도한다 */
+  onLoadError?: ImageErrorHandler | undefined;
 }
 
 /**
@@ -28,16 +33,64 @@ export function PhotoProgressiveImage({
   previewSrc,
   blurhash,
   alt,
+  onLoadError,
 }: PhotoProgressiveImageProps) {
   const [previewLoaded, setPreviewLoaded] = useState(false);
   const [fullLoaded, setFullLoaded] = useState(false);
   const [blurGone, setBlurGone] = useState(false);
   const [previewGone, setPreviewGone] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [retrying, setRetrying] = useState(false);
+  // 실패 후 받아온 새 presigned URL
+  const [retrySrc, setRetrySrc] = useState<string | undefined>(undefined);
+  const attempts = useRef(0);
+
+  const activeSrc = retrySrc ?? src;
+
+  // src가 갈리면(다른 사진으로 이동 등) 처음부터 다시 시작한다.
+  useEffect(() => {
+    setFailed(false);
+    setRetrying(false);
+    setRetrySrc(undefined);
+    attempts.current = 0;
+  }, [src]);
 
   const blurUrl = useMemo(
     () => (blurhash ? blurhashToDataUrl(blurhash) : undefined),
     [blurhash],
   );
+
+  // presigned 만료 등으로 원본 로드가 실패하면 새 URL을 받아 1회 다시 시도한다.
+  // 브라우저는 이미지 로드를 재시도해주지 않으므로 직접 걸어야 한다.
+  const handleError = async () => {
+    attempts.current += 1;
+    const attempt = attempts.current;
+
+    setRetrying(true);
+    const nextSrc = await onLoadError?.(attempt);
+    setRetrying(false);
+
+    if (attempt === 1 && nextSrc && nextSrc !== activeSrc) {
+      setRetrySrc(nextSrc);
+      return;
+    }
+
+    setFailed(true);
+  };
+
+  // 수동 재시도 (새 URL을 받아낸 뒤에 실패 상태를 푼다)
+  // 먼저 풀면 죽은 src로 이미지가 다시 렌더되고, 그 error가 재시도와 경합한다.
+  const handleRetryClick = async () => {
+    setRetrying(true);
+    const nextSrc = await onLoadError?.(1);
+    setRetrying(false);
+
+    if (!nextSrc || nextSrc === activeSrc) return;
+
+    attempts.current = 0;
+    setRetrySrc(nextSrc);
+    setFailed(false);
+  };
 
   return (
     <>
@@ -72,13 +125,16 @@ export function PhotoProgressiveImage({
       )}
 
       {/* 3단계: 원본 (로드되면 위로 페이드인하며 아래를 정리) */}
-      {src && (
+      {activeSrc && !failed && (
+        // key: 재시도 시 새 엘리먼트로 교체해 이전 로드 상태가 남지 않게 한다
         <img
-          src={src}
+          key={activeSrc}
+          src={activeSrc}
           alt={alt}
           decoding="async"
           data-clarity-mask="True"
           onLoad={() => setFullLoaded(true)}
+          onError={handleError}
           onTransitionEnd={(e) => {
             if (e.propertyName === 'opacity' && fullLoaded) {
               setBlurGone(true);
@@ -90,6 +146,23 @@ export function PhotoProgressiveImage({
             fullLoaded ? 'opacity-100' : 'opacity-0',
           )}
         />
+      )}
+
+      {/* 원본을 끝내 못 받으면 blurhash·썸네일 위에 실패를 드러내고 다시 시도할 길을 준다 */}
+      {failed && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-black/50">
+          <p className="text-[14px] text-white">사진을 불러오지 못했어요</p>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="rounded-full"
+            onClick={handleRetryClick}
+            disabled={retrying}
+          >
+            <RefreshCw className={cn('size-4', retrying && 'animate-spin')} />
+            {retrying ? '불러오는 중…' : '다시 불러오기'}
+          </Button>
+        </div>
       )}
     </>
   );

--- a/apps/web/src/entities/photo/ui/photo-thumbnail.stories.tsx
+++ b/apps/web/src/entities/photo/ui/photo-thumbnail.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, waitFor } from 'storybook/test';
+
+import { PhotoThumbnail } from './photo-thumbnail';
+
+const BLURHASH = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+const OK_SRC = 'https://placehold.co/300x300/png';
+const BROKEN_SRC = 'https://placehold.co/broken-thumbnail-does-not-exist';
+
+const meta = {
+  title: 'entities/photo/PhotoThumbnail',
+  component: PhotoThumbnail,
+  parameters: { layout: 'centered' },
+  args: { alt: '바닷가 사진', blurhash: BLURHASH },
+  decorators: [
+    (Story) => (
+      // 목록 카드와 같은 폭(2열 메이슨리)에서 확인한다
+      <div className="w-44">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PhotoThumbnail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 정상: 썸네일이 로드되면 blurhash 위로 페이드인한다 */
+export const Loaded: Story = {
+  args: { src: OK_SRC },
+};
+
+/** 썸네일 URL이 아직 없는 상태(추출 전) — blurhash만 보인다 */
+export const BlurhashOnly: Story = {
+  args: { src: undefined },
+};
+
+/**
+ * 로드 실패 + 재시도 성공
+ * 실패하면 새 서명 URL을 받아 한 번 더 시도한다(만료된 presigned URL 등)
+ */
+export const RetrySucceeds: Story = {
+  args: {
+    src: BROKEN_SRC,
+    onLoadError: fn(async () => OK_SRC),
+  },
+  play: async ({ args, canvas }) => {
+    await waitFor(() => expect(args.onLoadError).toHaveBeenCalledWith(1));
+    // 재시도로 받은 URL이 로드되면 실패 표시는 뜨지 않는다
+    await waitFor(() =>
+      expect(
+        canvas.queryByLabelText('썸네일을 불러오지 못했어요'),
+      ).not.toBeInTheDocument(),
+    );
+  },
+};
+
+/**
+ * 로드 실패 + 재시도도 실패 (지금 프로덕션의 iOS 디코딩 불가 썸네일이 이 경우)
+ * blurhash 위에 실패 아이콘을 얹어, 로딩 중으로 오해하지 않게 한다.
+ */
+export const Failed: Story = {
+  args: {
+    src: BROKEN_SRC,
+    onLoadError: fn(async () => undefined),
+  },
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(
+        canvas.getByLabelText('썸네일을 불러오지 못했어요'),
+      ).toBeInTheDocument(),
+    );
+  },
+};
+
+/** 핸들러가 없으면 재시도 없이 곧바로 실패로 확정한다 */
+export const FailedWithoutHandler: Story = {
+  args: { src: BROKEN_SRC },
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(
+        canvas.getByLabelText('썸네일을 불러오지 못했어요'),
+      ).toBeInTheDocument(),
+    );
+  },
+};

--- a/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
+++ b/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
@@ -1,14 +1,25 @@
-import { useMemo, useState } from 'react';
+import { ImageOff } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { blurhashToDataUrl } from '../lib/blurhash';
 
 import { cn } from '@/shared/lib/utils/cn';
+
+/**
+ * 썸네일 로드 실패 핸들러.
+ * - attempt 1: 첫 실패 → 새 src(재서명 URL)를 반환하면 그걸로 한 번 더 시도한다
+ * - attempt 2: 재시도까지 실패 → 반환값은 무시하고 실패로 확정한다
+ */
+export type ThumbnailErrorHandler = (
+  attempt: number,
+) => Promise<string | undefined> | void;
 
 interface PhotoThumbnailProps {
   src?: string | undefined;
   alt: string;
   blurhash?: string | undefined;
   className?: string | undefined;
+  onLoadError?: ThumbnailErrorHandler | undefined;
 }
 
 export function PhotoThumbnail({
@@ -16,9 +27,25 @@ export function PhotoThumbnail({
   alt,
   blurhash,
   className,
+  onLoadError,
 }: PhotoThumbnailProps) {
   const [loaded, setLoaded] = useState(false);
   const [blurGone, setBlurGone] = useState(false);
+  const [failed, setFailed] = useState(false);
+  // 첫 실패 후 받아온 새 presigned URL(사진당 1회)
+  const [retrySrc, setRetrySrc] = useState<string | undefined>(undefined);
+  const attempts = useRef(0);
+
+  const activeSrc = retrySrc ?? src;
+
+  // src가 갈리면(목록 리페치로 서명이 새로 발급 등) 처음부터 다시 시작한다.
+  useEffect(() => {
+    setLoaded(false);
+    setBlurGone(false);
+    setFailed(false);
+    setRetrySrc(undefined);
+    attempts.current = 0;
+  }, [src]);
 
   // blurhash → data URL 디코딩은 비용이 있으므로 hash가 바뀔 때만 계산한다.
   const blurUrl = useMemo(
@@ -26,12 +53,28 @@ export function PhotoThumbnail({
     [blurhash],
   );
 
+  // 이미지 로드 실패는 브라우저가 재시도해주지 않는다.
+  // 만료된 서명 같은 일시적 실패는 1회만 다시 시도하고, 그래도 실패하면 실패 상태로 굳힌다.
+  const handleError = async () => {
+    attempts.current += 1;
+    const attempt = attempts.current;
+
+    const nextSrc = await onLoadError?.(attempt);
+
+    if (attempt === 1 && nextSrc && nextSrc !== activeSrc) {
+      setRetrySrc(nextSrc);
+      return;
+    }
+
+    setFailed(true);
+  };
+
   return (
     <div
       className={cn(
         'relative overflow-hidden rounded-2xl bg-black/5 dark:bg-white/5',
         // 비율 알기 전 정사각형으로 자리 확보 → 로드 시 실제 비율로 (레이아웃 출렁임 방지, 메이슨리)
-        !loaded && 'aspect-square',
+        (!loaded || failed) && 'aspect-square',
         className,
       )}
     >
@@ -43,14 +86,17 @@ export function PhotoThumbnail({
           className="absolute inset-0 h-full w-full scale-105 object-cover blur-md"
         />
       )}
-      {src && (
+      {activeSrc && !failed && (
+        // key: 재시도 시 새 엘리먼트로 교체해 이전 로드 상태가 남지 않게 한다
         <img
-          src={src}
+          key={activeSrc}
+          src={activeSrc}
           alt={alt}
           loading="lazy"
           decoding="async"
           data-clarity-mask="True"
           onLoad={() => setLoaded(true)}
+          onError={handleError}
           // 페이드(opacity) 종료 시점에 뒤의 블러를 제거 → 회색 깜빡임 없이 정리
           onTransitionEnd={(e) => {
             if (e.propertyName === 'opacity' && loaded) setBlurGone(true);
@@ -60,6 +106,20 @@ export function PhotoThumbnail({
             loaded ? 'opacity-100' : 'opacity-0',
           )}
         />
+      )}
+      {/* 실패는 블러해시 위에 드러낸다. 계속 블러만 보이면 사용자는 로딩 중으로 오해한다 */}
+      {failed && (
+        <span
+          role="img"
+          aria-label="썸네일을 불러오지 못했어요"
+          className="absolute inset-0 flex items-center justify-center"
+        >
+          <ImageOff
+            className="size-5 text-white opacity-70 drop-shadow"
+            strokeWidth={1.5}
+            aria-hidden
+          />
+        </span>
       )}
     </div>
   );

--- a/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
+++ b/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
@@ -2,24 +2,16 @@ import { ImageOff } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { blurhashToDataUrl } from '../lib/blurhash';
+import type { ImageErrorHandler } from '../model/types';
 
 import { cn } from '@/shared/lib/utils/cn';
-
-/**
- * 썸네일 로드 실패 핸들러.
- * - attempt 1: 첫 실패 → 새 src(재서명 URL)를 반환하면 그걸로 한 번 더 시도한다
- * - attempt 2: 재시도까지 실패 → 반환값은 무시하고 실패로 확정한다
- */
-export type ThumbnailErrorHandler = (
-  attempt: number,
-) => Promise<string | undefined> | void;
 
 interface PhotoThumbnailProps {
   src?: string | undefined;
   alt: string;
   blurhash?: string | undefined;
   className?: string | undefined;
-  onLoadError?: ThumbnailErrorHandler | undefined;
+  onLoadError?: ImageErrorHandler | undefined;
 }
 
 export function PhotoThumbnail({

--- a/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
+++ b/apps/web/src/entities/photo/ui/photo-thumbnail.tsx
@@ -1,7 +1,8 @@
 import { ImageOff } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { blurhashToDataUrl } from '../lib/blurhash';
+import { useImageRetry } from '../lib/use-image-retry';
 import type { ImageErrorHandler } from '../model/types';
 
 import { cn } from '@/shared/lib/utils/cn';
@@ -23,20 +24,12 @@ export function PhotoThumbnail({
 }: PhotoThumbnailProps) {
   const [loaded, setLoaded] = useState(false);
   const [blurGone, setBlurGone] = useState(false);
-  const [failed, setFailed] = useState(false);
-  // 첫 실패 후 받아온 새 presigned URL(사진당 1회)
-  const [retrySrc, setRetrySrc] = useState<string | undefined>(undefined);
-  const attempts = useRef(0);
+  const { activeSrc, failed, handleError } = useImageRetry(src, onLoadError);
 
-  const activeSrc = retrySrc ?? src;
-
-  // src가 갈리면(목록 리페치로 서명이 새로 발급 등) 처음부터 다시 시작한다.
+  // src가 갈리면(목록 리페치로 서명이 새로 발급 등) 페이드도 처음부터 다시 시작한다.
   useEffect(() => {
     setLoaded(false);
     setBlurGone(false);
-    setFailed(false);
-    setRetrySrc(undefined);
-    attempts.current = 0;
   }, [src]);
 
   // blurhash → data URL 디코딩은 비용이 있으므로 hash가 바뀔 때만 계산한다.
@@ -44,22 +37,6 @@ export function PhotoThumbnail({
     () => (blurhash ? blurhashToDataUrl(blurhash) : undefined),
     [blurhash],
   );
-
-  // 이미지 로드 실패는 브라우저가 재시도해주지 않는다.
-  // 만료된 서명 같은 일시적 실패는 1회만 다시 시도하고, 그래도 실패하면 실패 상태로 굳힌다.
-  const handleError = async () => {
-    attempts.current += 1;
-    const attempt = attempts.current;
-
-    const nextSrc = await onLoadError?.(attempt);
-
-    if (attempt === 1 && nextSrc && nextSrc !== activeSrc) {
-      setRetrySrc(nextSrc);
-      return;
-    }
-
-    setFailed(true);
-  };
 
   return (
     <div

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -12,6 +12,7 @@ import {
   useDeletePhotoMutation,
   usePhotoDetail,
   usePhotosInfinite,
+  useRefreshPhotoUrls,
   type Photo,
 } from '@/entities/photo';
 import {
@@ -26,6 +27,7 @@ import { ApiError } from '@/shared/api/error';
 import { track } from '@/shared/lib/analytics';
 import { recordForbidden } from '@/shared/lib/business-ux-logging';
 import { errorFallbackMessage } from '@/shared/lib/error-fallback';
+import { log } from '@/shared/lib/logger';
 import { cn } from '@/shared/lib/utils/cn';
 import { Button } from '@/shared/ui/button';
 import {
@@ -93,10 +95,28 @@ export function PhotoDetailPage() {
   const query = usePhotoDetail(id, { enabled: !!albumId && !!id });
   const photo = query.data;
   const { prevId, nextId } = usePrevNext(id);
+  const refreshPhotoUrls = useRefreshPhotoUrls();
 
   useEffect(() => {
     track('detail.view', { source });
   }, [id, source]);
+
+  const handleImageError = async (attempt: number) => {
+    log.bug(new Error('photo image load failed'), {
+      operationId: 'photoImageLoad',
+      photoId: id,
+      attempt,
+    });
+
+    if (attempt > 1) return undefined; // 자동 재시도는 1회 (수동 버튼은 카운트를 되돌린다)
+
+    try {
+      const refreshed = await refreshPhotoUrls(id);
+      return refreshed.imageUrl;
+    } catch {
+      return undefined; // 새 URL도 못 받으면 실패로 확정
+    }
+  };
 
   if (query.isLoading || !photo) {
     return <DetailSkeleton />;
@@ -117,6 +137,7 @@ export function PhotoDetailPage() {
             previewSrc={photo.thumbnailUrl}
             blurhash={photo.blurhash}
             alt={photo.description}
+            onLoadError={handleImageError}
           />
         )}
 

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -11,6 +11,7 @@ import {
   PhotoCard,
   selectPhotos,
   usePhotosInfinite,
+  useRefreshThumbnail,
   type Photo,
 } from '@/entities/photo';
 import { canUpload, useAuthErrorRedirect } from '@/features/auth';
@@ -32,6 +33,7 @@ import { ApiError } from '@/shared/api/error';
 import { track } from '@/shared/lib/analytics';
 import { recordForbidden } from '@/shared/lib/business-ux-logging';
 import { errorFallbackMessage } from '@/shared/lib/error-fallback';
+import { log } from '@/shared/lib/logger';
 import { cn } from '@/shared/lib/utils/cn';
 import { ErrorState } from '@/shared/ui/error-state';
 import { toast } from '@/shared/ui/toast';
@@ -261,6 +263,23 @@ function GridCard({
   const enabled = useSelectEnabled();
   const selected = useIsSelected(photo.id);
   const toggle = usePhotoSelectStore((s) => s.toggle);
+  const refreshThumbnail = useRefreshThumbnail();
+
+  const handleThumbnailError = async (attempt: number) => {
+    log.bug(new Error('thumbnail load failed'), {
+      operationId: 'thumbnailLoad',
+      photoId: photo.id,
+      attempt,
+    });
+
+    if (attempt > 1) return undefined;
+
+    try {
+      return await refreshThumbnail(photo.id);
+    } catch {
+      return undefined; // 새 URL도 못 받으면 실패로 확정
+    }
+  };
 
   return (
     <PhotoCard
@@ -269,6 +288,7 @@ function GridCard({
       selectionSlot={enabled ? <SelectCheckbox id={photo.id} /> : undefined}
       actionSlot={!enabled ? <DownloadButton photo={photo} /> : undefined}
       onOpen={(id) => (enabled ? toggle(id) : onOpen(id))}
+      onThumbnailError={handleThumbnailError}
     />
   );
 }

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -11,7 +11,7 @@ import {
   PhotoCard,
   selectPhotos,
   usePhotosInfinite,
-  useRefreshThumbnail,
+  useRefreshPhotoUrls,
   type Photo,
 } from '@/entities/photo';
 import { canUpload, useAuthErrorRedirect } from '@/features/auth';
@@ -263,7 +263,7 @@ function GridCard({
   const enabled = useSelectEnabled();
   const selected = useIsSelected(photo.id);
   const toggle = usePhotoSelectStore((s) => s.toggle);
-  const refreshThumbnail = useRefreshThumbnail();
+  const refreshPhotoUrls = useRefreshPhotoUrls();
 
   const handleThumbnailError = async (attempt: number) => {
     log.bug(new Error('thumbnail load failed'), {
@@ -275,7 +275,8 @@ function GridCard({
     if (attempt > 1) return undefined;
 
     try {
-      return await refreshThumbnail(photo.id);
+      const refreshed = await refreshPhotoUrls(photo.id);
+      return refreshed.thumbnailUrl;
     } catch {
       return undefined; // 새 URL도 못 받으면 실패로 확정
     }


### PR DESCRIPTION
## 📌 관련 이슈

* Issue: #136 
> 썸네일 JPEG 크로마 서브샘플링 → iOS 디코딩 불가

---

## 🧹 작업 내용

목록에서 썸네일이 안 뜨면 **로그 한 줄 없이 blurhash로 영영 굳어버리는** 문제의 복원력을 일부 상승시킵니다.

- `PhotoThumbnail`에 `onError`가 아예 없어서, 
- 어떤 이유로 실패하든 사용자는 로딩 중인 줄 알고 기다리고, 
- 우리는 실패했다는 사실조차 알 수 없었습니다.

> [!NOTE]
> * `PhotoThumbnail`에 `onError` 추가 — 실패 시 재시도 1회 → 그래도 실패하면 실패 상태로 확정
> * `useRefreshThumbnail()` 추가 — 상세 조회로 **그 사진 하나만** 재서명해 새 URL을 받음
> * 재시도까지 실패하면 blurhash 위에 실패 아이콘 노출 (로딩 중 오해 방지)
> * 실패한 `photoId`·`attempt`를 Sentry로 전송

다만 #136 이슈 **해결**과는 무관합니다.
해당 이슈는 iOS에서 디코딩되지 않는 부분이 원인이기에, 프론트에서 해결할 수 없습니다.

다만 이 PR은 그 실패를 **드러내고 기록**하는데 초점을 뒀습니다.

---

## 🛠️ 테스트

* [x] 단위 테스트 통과 (57개)
* [x] 수동 테스트 완료 (Storybook)
* [x] 기존 기능 영향 없음 확인 (타입체크·린트 통과)

---

## 📸 스크린샷


https://github.com/user-attachments/assets/4f52968d-4bf9-4f89-9191-8b472bdff096



---

## 🔍 고민 / 결정 사항

**재시도를 목록 무효화가 아니라 상세 조회로 했습니다.**
목록을 무효화하면 모든 사진의 presigned 서명이 새로 발급돼 **화면의 썸네일 100여 장이 전부 재다운로드**됩니다. 한 장 살리자고 목록 전체를 다시 받을 이유가 없어서, 상세 조회(`GET /v1/media/{id}`)로 그 사진만 재서명합니다. 부수적으로 상세 캐시가 채워지는 이점도 있습니다.

**재시도는 1회입니다.** 만료된 서명이면 1회로 살아나고, 파일 자체가 문제면 몇 번을 해도 실패합니다. 2회 이상은 낭비입니다.

**재시도 버튼은 넣지 않았습니다.** 지금 실패하는 케이스는 눌러도 절대 안 뜨는 상태라, 버튼은 사용자를 낚는 셈입니다. 로그에 일시적 실패가 실제로 찍히면 그때 재검토하겠습니다.

**presigned URL은 로그에 넣지 않았습니다.** 서명이 그대로 담겨 있어 Sentry로 유효한 접근 자격증명이 새어나갑니다. `photoId`만 남깁니다.