### PR TITLE
[Fix] 이벤트 수집을 백엔드 user-events 계약에 맞춤

### DIFF
--- a/apps/web/src/features/auth/api/mutations.ts
+++ b/apps/web/src/features/auth/api/mutations.ts
@@ -2,17 +2,20 @@ import { useMutation } from '@tanstack/react-query';
 
 import { useAlbumStore } from '@/entities/album';
 import { http } from '@/shared/api';
-import { setAnalyticsUser, track } from '@/shared/lib/analytics';
+import { flush, setAnalyticsUser, track } from '@/shared/lib/analytics';
 
 export function useLogoutMutation() {
   const clearAlbum = useAlbumStore((s) => s.clear);
 
   return useMutation({
+    onMutate: () => {
+      track('auth.logout');
+      flush();
+    },
     mutationFn: () => http.post<void>('/v1/auth/logout'),
     meta: { operationId: 'auth_logout' },
     onSuccess: () => {
       clearAlbum();
-      track('auth.logout');
       void setAnalyticsUser(null);
     },
   });

--- a/apps/web/src/pages/album-select/ui/page.tsx
+++ b/apps/web/src/pages/album-select/ui/page.tsx
@@ -12,8 +12,6 @@ import {
   useMainAlbumStore,
   type Album,
 } from '@/entities/album';
-import { canUpload } from '@/features/auth';
-import { track } from '@/shared/lib/analytics';
 
 // 탭 후 배너를 잠깐 보여준 뒤 진입
 const NAV_DELAY_MS = 450;
@@ -45,8 +43,6 @@ export function AlbumSelectPage() {
       if (enteredRef.current) return;
       enteredRef.current = true;
 
-      track('album.select', { editable: canUpload(album.role) });
-
       setCurrent(album);
       navigate('/photos', { replace: true });
     },
@@ -58,14 +54,6 @@ export function AlbumSelectPage() {
 
   const isSingle = albumsQuery.isSuccess && albums.length === 1;
   const singleAlbum = isSingle ? albums[0] : null;
-
-  const listViewTracked = useRef(false);
-  useEffect(() => {
-    if (albumsQuery.isSuccess && !listViewTracked.current) {
-      listViewTracked.current = true;
-      track('album.list_view', { count: albumsQuery.data.length });
-    }
-  }, [albumsQuery.isSuccess, albumsQuery.data]);
 
   // 앨범이 하나뿐이면 안내 배너를 최소 1.5초 보여준 뒤 자동 진입
   useEffect(() => {

--- a/apps/web/src/shared/lib/analytics/track.test.ts
+++ b/apps/web/src/shared/lib/analytics/track.test.ts
@@ -4,9 +4,15 @@ vi.mock('@/shared/config/env', () => ({
   env: { VITE_API_BASE_URL: 'http://test.local', VITE_APP_VERSION: 'test' },
 }));
 
+import { setRoleResolver } from './identity';
 import { flush, initAnalytics, resetForTests, track } from './track';
 
-const ENDPOINT = 'http://test.local/v1/events';
+import { albumIdStore } from '@/shared/api/album-id';
+import { authTokenStore } from '@/shared/api/auth-token';
+
+const ENDPOINT = 'http://test.local/v1/user-events';
+const TOKEN = 'access-token';
+const ALBUM_ID = 'album-1';
 
 function mockFetch() {
   return vi
@@ -14,20 +20,33 @@ function mockFetch() {
     .mockResolvedValue(new Response(null, { status: 204 }));
 }
 
-function lastFetchBody(spy: ReturnType<typeof mockFetch>) {
+function lastCall(spy: ReturnType<typeof mockFetch>) {
   const calls = spy.mock.calls;
-  const init = calls[calls.length - 1]?.[1];
-  return JSON.parse(init?.body as string);
+  return calls[calls.length - 1];
+}
+
+function bodyOf(spy: ReturnType<typeof mockFetch>) {
+  return JSON.parse(lastCall(spy)?.[1]?.body as string);
+}
+
+function headersOf(spy: ReturnType<typeof mockFetch>) {
+  return lastCall(spy)?.[1]?.headers as Record<string, string>;
 }
 
 beforeEach(() => {
   sessionStorage.clear();
   resetForTests();
+  authTokenStore.set(TOKEN);
+  albumIdStore.set(ALBUM_ID);
+  setRoleResolver(() => 'EDITOR');
 });
 
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  authTokenStore.clear();
+  albumIdStore.clear();
+  setRoleResolver(() => null);
 });
 
 describe('track / flush', () => {
@@ -41,23 +60,50 @@ describe('track / flush', () => {
 
     expect(fetchSpy).toHaveBeenCalledOnce();
     expect(fetchSpy.mock.calls[0][0]).toBe(ENDPOINT);
-    const payload = lastFetchBody(fetchSpy);
+    const payload = bodyOf(fetchSpy);
     expect(payload.events).toHaveLength(1);
-    expect(payload.events[0].event).toBe('list.view');
+    expect(payload.events[0].name).toBe('list.view');
   });
 
-  test('봉투에 공통 필드 포함', () => {
+  // 서버는 필수 필드가 하나라도 어긋나면 배치 전체를 400으로 버린다
+  test('봉투에 서버 필수 필드(name·timestamp·userRole)와 공통 필드 포함', () => {
     const fetchSpy = mockFetch();
 
     track('detail.view', { source: 'grid' });
     flush();
 
-    const e = lastFetchBody(fetchSpy).events[0];
+    const e = bodyOf(fetchSpy).events[0];
+    expect(e.name).toBe('detail.view');
+    expect(typeof e.timestamp).toBe('number');
+    expect(e.userRole).toBe('EDITOR');
     expect(e.sessionId).toBeTruthy();
     expect(e.route).toBeTruthy();
     expect(e.appVersion).toBe('test');
     expect(e.props).toEqual({ source: 'grid' });
-    expect(typeof e.timestamp).toBe('number');
+  });
+
+  // 서버가 인증·앨범을 헤더로만 받으므로, 빠지면 401/400으로 전량 유실된다
+  test('인증 토큰과 앨범 헤더를 실어 전송', () => {
+    const fetchSpy = mockFetch();
+
+    track('list.view');
+    flush();
+
+    expect(headersOf(fetchSpy)).toMatchObject({
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${TOKEN}`,
+      'X-Album-Id': ALBUM_ID,
+    });
+  });
+
+  // sendBeacon은 헤더를 실을 수 없어 인증을 못해 헤더를 지원하는 keepalive로 대체
+  test('탭이 닫혀도 배달되도록 keepalive로 전송', () => {
+    const fetchSpy = mockFetch();
+
+    track('list.view');
+    flush();
+
+    expect(fetchSpy.mock.calls[0][1]?.keepalive).toBe(true);
   });
 
   test('버퍼 임계치(20) 도달 시 자동 전송', () => {
@@ -67,7 +113,7 @@ describe('track / flush', () => {
     for (let i = 0; i < 20; i += 1) track('list.view', { i });
 
     expect(fetchSpy).toHaveBeenCalledOnce();
-    expect(lastFetchBody(fetchSpy).events).toHaveLength(20);
+    expect(bodyOf(fetchSpy).events).toHaveLength(20);
   });
 
   // 정상 유저의 우발적 중복과 코드 버그로 인한 폭주를 걸러, DB·서버리스 호출이 불필요하게 쌓이지 않게 한다
@@ -79,7 +125,7 @@ describe('track / flush', () => {
     track('list.view');
     flush();
 
-    expect(lastFetchBody(fetchSpy).events).toHaveLength(1);
+    expect(bodyOf(fetchSpy).events).toHaveLength(1);
   });
 
   test('dedup 창(500ms)이 지나면 같은 이벤트도 다시 집계', () => {
@@ -91,7 +137,7 @@ describe('track / flush', () => {
     track('list.view');
     flush();
 
-    expect(lastFetchBody(fetchSpy).events).toHaveLength(2);
+    expect(bodyOf(fetchSpy).events).toHaveLength(2);
   });
 
   test('분당 상한(120)을 넘는 폭주는 조용히 드롭', () => {
@@ -131,8 +177,8 @@ describe('track / flush', () => {
     track('list.view'); // 직전 list.view와 동일 → 여전히 dedup에 걸려야
     flush();
 
-    const events = lastFetchBody(fetchSpy).events as { event: string }[];
-    const listViews = events.filter((e) => e.event === 'list.view');
+    const events = bodyOf(fetchSpy).events as { name: string }[];
+    const listViews = events.filter((e) => e.name === 'list.view');
     expect(listViews).toHaveLength(1);
   });
 
@@ -162,18 +208,78 @@ describe('track / flush', () => {
 
     expect(fetchSpy).toHaveBeenCalledOnce();
   });
+});
 
-  test('useBeacon=true면 fetch 대신 sendBeacon 사용', () => {
+// 서버는 이벤트를 앨범 스코프로 저장하고 앨범을 헤더 하나로만 받는다.
+// 앨범이 다른 이벤트를 한 요청에 섞으면 통계가 엉뚱한 앨범으로 귀속된다.
+describe('앨범 귀속', () => {
+  test('앨범이 다른 이벤트는 요청을 나눠 각자의 앨범으로 전송', () => {
     const fetchSpy = mockFetch();
-    const beacon = vi.fn((_url: string, _body?: BodyInit) => true);
-    vi.stubGlobal('navigator', { sendBeacon: beacon });
 
-    track('auth.logout');
-    flush(true);
+    track('list.view');
+    albumIdStore.set('album-2');
+    track('detail.view');
+    flush();
 
-    expect(beacon).toHaveBeenCalledOnce();
-    expect(beacon.mock.calls[0][0]).toBe(ENDPOINT);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const sent = fetchSpy.mock.calls.map((c) => ({
+      albumId: (c[1]?.headers as Record<string, string>)['X-Album-Id'],
+      names: JSON.parse(c[1]?.body as string).events.map(
+        (e: { name: string }) => e.name,
+      ),
+    }));
+    expect(sent).toEqual(
+      expect.arrayContaining([
+        { albumId: ALBUM_ID, names: ['list.view'] },
+        { albumId: 'album-2', names: ['detail.view'] },
+      ]),
+    );
+  });
+
+  test('앨범 확정 전 이벤트는 버리지 않고 보류했다가 첫 앨범에 귀속', () => {
+    const fetchSpy = mockFetch();
+    albumIdStore.clear();
+
+    track('auth.login_success');
+    flush();
+    expect(fetchSpy).not.toHaveBeenCalled(); // 보낼 앨범이 없으니 아직 보류
+
+    albumIdStore.set(ALBUM_ID);
+    track('list.view');
+    flush();
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(headersOf(fetchSpy)['X-Album-Id']).toBe(ALBUM_ID);
+    expect(
+      bodyOf(fetchSpy).events.map((e: { name: string }) => e.name),
+    ).toEqual(['auth.login_success', 'list.view']);
+  });
+
+  // 서버가 userRole을 필수 enum으로 요구하므로 null이 섞이면 배치 전체가 400으로 버려짐
+  test('권한이 끝내 확정되지 않은 이벤트는 배치를 오염시키지 않도록 드롭', () => {
+    const fetchSpy = mockFetch();
+    setRoleResolver(() => null);
+
+    track('list.view');
+    flush();
+
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('토큰이 없으면 전송하지 않고 로그인 이후로 보류', () => {
+    const fetchSpy = mockFetch();
+    authTokenStore.clear();
+
+    track('api.timing', { ms: 1 }, { raw: true });
+    flush();
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    authTokenStore.set(TOKEN);
+    flush();
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(bodyOf(fetchSpy).events).toHaveLength(1);
   });
 });
 
@@ -191,16 +297,15 @@ describe('initAnalytics', () => {
     );
   });
 
-  test('pagehide 발생 시 beacon으로 flush', () => {
-    const beacon = vi.fn((_url: string, _body?: BodyInit) => true);
-    vi.stubGlobal('navigator', { sendBeacon: beacon });
+  test('pagehide 발생 시 flush', () => {
+    const fetchSpy = mockFetch();
 
     initAnalytics();
     track('list.view');
 
     window.dispatchEvent(new Event('pagehide'));
 
-    expect(beacon).toHaveBeenCalledOnce();
-    expect(beacon.mock.calls[0][0]).toBe(ENDPOINT);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy.mock.calls[0][0]).toBe(ENDPOINT);
   });
 });

--- a/apps/web/src/shared/lib/analytics/track.ts
+++ b/apps/web/src/shared/lib/analytics/track.ts
@@ -6,14 +6,19 @@ import {
 } from './identity';
 import type { AnalyticsEvent, AnalyticsProps, EventEnvelope } from './types';
 
+import type { UserRole } from '@/entities/user';
+import { albumIdStore } from '@/shared/api/album-id';
+import { authTokenStore } from '@/shared/api/auth-token';
 import { env } from '@/shared/config/env';
 
 export interface TrackOptions {
   raw?: boolean;
 }
 
-const EVENTS_PATH = '/v1/events';
+const EVENTS_PATH = '/v1/user-events';
 const MAX_BUFFER = 20;
+// 서버가 한 요청당 허용하는 이벤트 수(초과 시 배치 전체가 TOO_MANY_EVENTS로 400)
+const MAX_EVENTS_PER_REQUEST = 20;
 const FLUSH_INTERVAL_MS = 10_000;
 
 // 우발적 중복 접기 (StrictMode 이중 마운트, 빠른 재렌더 등)
@@ -22,7 +27,15 @@ const DEDUP_WINDOW_MS = 500;
 const RATE_WINDOW_MS = 60_000;
 const MAX_EVENTS_PER_MINUTE = 120;
 
-const buffer: EventEnvelope[] = [];
+/** 전송 대기 이벤트
+ * - 이벤트가 쌓인 시점의 앨범을 기억해뒀다가 앨범별로 나눠 보냄
+ * - albumId가 null이면 첫 앨범 확정 시 귀속됨 */
+interface PendingEvent {
+  albumId: string | null;
+  envelope: Omit<EventEnvelope, 'userRole'> & { userRole: UserRole | null };
+}
+
+const buffer: PendingEvent[] = [];
 let timer: ReturnType<typeof setTimeout> | null = null;
 
 let lastKey: string | null = null;
@@ -32,10 +45,10 @@ let windowStart = 0;
 let windowCount = 0;
 
 export function initAnalytics(): void {
-  window.addEventListener('pagehide', () => flush(true));
+  window.addEventListener('pagehide', () => flush());
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {
-      flush(true);
+      flush();
     }
   });
 }
@@ -62,10 +75,17 @@ export function track(
     return;
   }
 
-  buffer.push(buildEnvelope(event, props));
+  buffer.push({
+    albumId: albumIdStore.get(),
+    envelope: buildEnvelope(event, props),
+  });
 
   if (buffer.length >= MAX_BUFFER) {
     flush();
+    // 아직 전송할 수 없는(앨범·토큰 미확정) 이벤트는 flush 후에도 남는다.
+    if (buffer.length > MAX_BUFFER) {
+      buffer.splice(0, buffer.length - MAX_BUFFER);
+    }
     return;
   }
   scheduleFlush();
@@ -86,28 +106,63 @@ function consumeRateLimit(now: number): boolean {
 function buildEnvelope(
   event: AnalyticsEvent,
   props?: AnalyticsProps,
-): EventEnvelope {
+): PendingEvent['envelope'] {
   return {
-    event,
+    name: event,
     timestamp: Date.now(),
+    userRole: getUserRole(),
     sessionId: getSessionId(),
     anonUserId: getAnonUserId(),
-    userRole: getUserRole(),
     route: routePattern(),
     appVersion: env.VITE_APP_VERSION,
     ...(props && { props }),
   };
 }
 
-export function flush(useBeacon = false): void {
+/**
+ * 전송 가능한 이벤트만 앨범별로 묶어 보내고, 아직 보낼 수 없는 이벤트는 버퍼에 남긴다.
+ *
+ * 전송 조건은 인증 토큰과 앨범이 모두 확정되는 것이다. 서버가 두 값을 헤더로 요구하기 때문이다.
+ */
+export function flush(): void {
   if (timer) {
     clearTimeout(timer);
     timer = null;
   }
   if (buffer.length === 0) return;
 
-  const events = buffer.splice(0, buffer.length);
-  send(events, useBeacon);
+  const token = authTokenStore.get();
+  // 로그인 완료 후 함께 보내도록 버퍼에 남긴다
+  if (!token) return;
+
+  const currentAlbumId = albumIdStore.get();
+  const byAlbum = new Map<string, EventEnvelope[]>();
+  const pending: PendingEvent[] = [];
+
+  for (const event of buffer) {
+    // 앨범 확정 전에 쌓인 이벤트는 첫 앨범에 귀속시킨다
+    const albumId = event.albumId ?? currentAlbumId;
+    if (!albumId) {
+      pending.push(event);
+      continue;
+    }
+
+    const userRole = event.envelope.userRole ?? getUserRole();
+    if (!userRole) continue;
+
+    const events = byAlbum.get(albumId) ?? [];
+    events.push({ ...event.envelope, userRole });
+    byAlbum.set(albumId, events);
+  }
+
+  buffer.length = 0;
+  buffer.push(...pending);
+
+  for (const [albumId, events] of byAlbum) {
+    for (let i = 0; i < events.length; i += MAX_EVENTS_PER_REQUEST) {
+      send(albumId, token, events.slice(i, i + MAX_EVENTS_PER_REQUEST));
+    }
+  }
 }
 
 function scheduleFlush(): void {
@@ -115,21 +170,16 @@ function scheduleFlush(): void {
   timer = setTimeout(() => flush(), FLUSH_INTERVAL_MS);
 }
 
-function send(events: EventEnvelope[], useBeacon: boolean): void {
-  const url = `${env.VITE_API_BASE_URL}${EVENTS_PATH}`;
-  const body = JSON.stringify({ events });
-
-  if (useBeacon && typeof navigator.sendBeacon === 'function') {
-    // sendBeacon은 헤더 설정이 불가능하므로, Content-Type 지정을 위해 데이터 타입 정보가 내장된 Blob으로 감싸 전송
-    navigator.sendBeacon(url, new Blob([body], { type: 'application/json' }));
-    return;
-  }
-
-  // 탭이 닫혀도 백그라운드 배달을 보장하는 keepalive 활성화
-  void fetch(url, {
+function send(albumId: string, token: string, events: EventEnvelope[]): void {
+  // keepalive는 헤더를 지원하면서 탭이 닫혀도 백그라운드 배달을 보장
+  void fetch(`${env.VITE_API_BASE_URL}${EVENTS_PATH}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body,
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+      'X-Album-Id': albumId,
+    },
+    body: JSON.stringify({ events }),
     keepalive: true,
   }).catch(() => {});
 }

--- a/apps/web/src/shared/lib/analytics/types.ts
+++ b/apps/web/src/shared/lib/analytics/types.ts
@@ -3,8 +3,6 @@ import type { UserRole } from '@/entities/user';
 export type AnalyticsEvent =
   | 'auth.login_success'
   | 'auth.logout'
-  | 'album.list_view'
-  | 'album.select'
   | 'list.view'
   | 'list.scroll_depth'
   | 'list.refresh'
@@ -27,18 +25,19 @@ export type AnalyticsEvent =
 export type AnalyticsProps = Record<string, string | number | boolean | null>;
 
 /**
- * 자체 수집 서버(POST /v1/events)로 전송할 공통 이벤트 포맷
+ * 수집 서버(POST /v1/user-events)로 전송할 공통 이벤트 포맷
  *
+ * - name·timestamp·userRole은 서버 필수 필드다.
+ * - 그 밖의 필드는 서버가 추가 속성으로 함께 저장한다.
  * - anonUserId: 프라이버시 보호를 위해 user.id를 SHA-256(16hex)으로 해싱한 값 (원본 ID/이메일 포함 금지)
- * - userRole: 앨범별로 권한이 다르므로, Album Store의 Resolver를 통해 동적으로 주입
  * - route: 통계 그룹화를 위해 실제 URL이 아닌 라우트 패턴(예: /photos/:id) 형태로 정규화하여 기록
  */
 export interface EventEnvelope {
-  event: AnalyticsEvent;
+  name: AnalyticsEvent;
   timestamp: number;
+  userRole: UserRole;
   sessionId: string;
   anonUserId: string | null;
-  userRole: UserRole | null;
   route: string;
   appVersion: string;
   props?: AnalyticsProps;


### PR DESCRIPTION
## 📌 관련 이슈

* #108

---

## 🧹 작업 내용

서버의 `POST /v1/user-events` 계약에 맞춰 프론트를 수정했습니다.

### 계약 비교

| | Before (프론트 가정) | After (서버 확정) |
|---|---|---|
| 경로 | `POST /v1/events` | `POST /v1/user-events` |
| 인증 | 없음 | `Authorization: Bearer` **필수** |
| 앨범 | 개념 없음 | `X-Album-Id` 헤더 **필수** (앨범 스코프 리소스) |
| 이벤트명 | `event` | `name` |
| 권한 | `userRole: UserRole \| null` | `userRole` **필수 enum** (null이면 배치 전체 400) |
| 배치 상한 | 없음 | 요청당 20개 |
| 전송 | `sendBeacon` (헤더 불가) | 헤더 필요 → `fetch(keepalive)` |

### 전송 파이프라인

**Before**
<img width="378" height="486" alt="스크린샷 2026-07-13 오전 8 45 04" src="https://github.com/user-attachments/assets/10b044bb-3658-4b2f-b297-3e86863460e9" />

**After**
<img width="600" height="476" alt="스크린샷 2026-07-13 오전 8 44 44" src="https://github.com/user-attachments/assets/c854c3a3-133f-447b-9c61-63f1e7761740" />

 **flush가 더 이상 버퍼를 통째로 비우지 않는다**는 점이 가장 큰 변화입니다.
- 못 보낸 이벤트는 버퍼에 남고, 앨범이 정해지는 순간 다음 flush에 묻어 나갑니다.
- 별도 큐 없이 기존 버퍼 하나가 전송 큐와 대기실을 겸합니다!