### PR TITLE
[Feat] 즐겨찾기 등록/해제·필터 연동

### DIFF
--- a/apps/web/src/entities/photo/api/keys.ts
+++ b/apps/web/src/entities/photo/api/keys.ts
@@ -1,6 +1,8 @@
 export interface PhotoListFilters {
   sortBy?: 'createdAt' | 'updatedAt';
   order?: 'asc' | 'desc';
+  /** true면 즐겨찾기 사진만 필터/false면 전체. */
+  isFavorite?: boolean;
 }
 
 export const photoKeys = {

--- a/apps/web/src/entities/photo/api/mutations.test.ts
+++ b/apps/web/src/entities/photo/api/mutations.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { photoKeys } from './keys';
 import {
   buildDeletePhotoOptions,
+  buildToggleFavoriteOptions,
   buildUpdatePhotoMetaOptions,
   isAlreadyDeleted,
 } from './mutations';
@@ -14,11 +15,12 @@ import { ApiError } from '@/shared/api/error';
 
 const mocks = vi.hoisted(() => ({
   patch: vi.fn(),
+  put: vi.fn(),
   del: vi.fn(),
 }));
 
 vi.mock('@/shared/api', () => ({
-  http: { patch: mocks.patch, delete: mocks.del },
+  http: { patch: mocks.patch, put: mocks.put, delete: mocks.del },
 }));
 
 function photo(overrides: Partial<Photo> = {}): Photo {
@@ -73,6 +75,13 @@ function runUpdate(qc: QueryClient, vars: { id: string; description: string }) {
 
 function runDelete(qc: QueryClient, id: string) {
   return new MutationObserver(qc, buildDeletePhotoOptions(qc)).mutate(id);
+}
+
+function runToggleFavorite(
+  qc: QueryClient,
+  vars: { id: string; isFavorite: boolean },
+) {
+  return new MutationObserver(qc, buildToggleFavoriteOptions(qc)).mutate(vars);
 }
 
 describe('buildUpdatePhotoMetaOptions', () => {
@@ -213,6 +222,66 @@ describe('buildDeletePhotoOptions', () => {
 
     expect(listIds(qc)).toEqual(['p1', 'p2']);
     expect(qc.getQueryData(photoKeys.detail('p1'))).toBeDefined();
+  });
+});
+
+describe('buildToggleFavoriteOptions', () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    mocks.put.mockReset();
+    mocks.del.mockReset();
+    qc = new QueryClient();
+    qc.setQueryData(photoKeys.detail('p1'), photo({ isFavorite: false }));
+  });
+
+  test('등록(target true)이면 PUT을 호출하고 상세 캐시를 즉시 켠다', async () => {
+    mocks.put.mockResolvedValueOnce(undefined);
+
+    await runToggleFavorite(qc, { id: 'p1', isFavorite: true });
+
+    expect(mocks.put).toHaveBeenCalledWith('/v1/media/p1/favorite');
+    expect(mocks.del).not.toHaveBeenCalled();
+    expect(qc.getQueryData<Photo>(photoKeys.detail('p1'))?.isFavorite).toBe(
+      true,
+    );
+  });
+
+  test('해제(target false)면 DELETE를 호출하고 상세 캐시를 즉시 끈다', async () => {
+    qc.setQueryData(photoKeys.detail('p1'), photo({ isFavorite: true }));
+    mocks.del.mockResolvedValueOnce(undefined);
+
+    await runToggleFavorite(qc, { id: 'p1', isFavorite: false });
+
+    expect(mocks.del).toHaveBeenCalledWith('/v1/media/p1/favorite');
+    expect(mocks.put).not.toHaveBeenCalled();
+    expect(qc.getQueryData<Photo>(photoKeys.detail('p1'))?.isFavorite).toBe(
+      false,
+    );
+  });
+
+  test('실패 시 이전 상태로 롤백한다', async () => {
+    mocks.put.mockRejectedValueOnce(new Error('fail'));
+
+    await expect(
+      runToggleFavorite(qc, { id: 'p1', isFavorite: true }),
+    ).rejects.toThrow('fail');
+
+    expect(qc.getQueryData<Photo>(photoKeys.detail('p1'))?.isFavorite).toBe(
+      false,
+    );
+  });
+
+  test('성공 후 상세와 목록 쿼리를 무효화한다', async () => {
+    mocks.put.mockResolvedValueOnce(undefined);
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+    await runToggleFavorite(qc, { id: 'p1', isFavorite: true });
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: photoKeys.detail('p1'),
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: photoKeys.lists() });
   });
 });
 

--- a/apps/web/src/entities/photo/api/mutations.ts
+++ b/apps/web/src/entities/photo/api/mutations.ts
@@ -66,6 +66,61 @@ export function useUpdatePhotoMetaMutation() {
   return useMutation(buildUpdatePhotoMetaOptions(queryClient));
 }
 
+export interface ToggleFavoriteVars {
+  id: string;
+  isFavorite: boolean;
+}
+
+/**
+ * 즐겨찾기 등록/해제
+ *
+ * - 등록/해제 전용 엔드포인트(PUT/DELETE /media/{id}/favorite)를 목표 상태로 분기해 호출한다.
+ * - 상세 캐시는 낙관적으로 반영하고, 목록은 invalidate로 정합을 맞춘다.
+ */
+export function buildToggleFavoriteOptions(
+  queryClient: QueryClient,
+): UseMutationOptions<void, Error, ToggleFavoriteVars, UpdateContext> {
+  return {
+    mutationFn: ({ id, isFavorite }) =>
+      isFavorite
+        ? http.put(`/v1/media/${id}/favorite`)
+        : http.delete(`/v1/media/${id}/favorite`),
+
+    onMutate: async ({ id, isFavorite }) => {
+      await queryClient.cancelQueries({ queryKey: photoKeys.detail(id) });
+
+      const previous = queryClient.getQueryData<Photo>(photoKeys.detail(id));
+      if (previous) {
+        queryClient.setQueryData<Photo>(photoKeys.detail(id), {
+          ...previous,
+          isFavorite,
+        });
+      }
+
+      return { id, previous };
+    },
+
+    onError: (_error, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          photoKeys.detail(context.id),
+          context.previous,
+        );
+      }
+    },
+
+    onSettled: (_data, _error, { id }) => {
+      queryClient.invalidateQueries({ queryKey: photoKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
+    },
+  };
+}
+
+export function useToggleFavoriteMutation() {
+  const queryClient = useQueryClient();
+  return useMutation(buildToggleFavoriteOptions(queryClient));
+}
+
 /** 404는 "이미 삭제됨"이다. 실패가 아니라 목표 상태에 도달한 것으로 본다(멱등). */
 export function isAlreadyDeleted(error: unknown): boolean {
   return error instanceof ApiError && error.status === 404;

--- a/apps/web/src/entities/photo/api/queries.test.ts
+++ b/apps/web/src/entities/photo/api/queries.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest';
 import { photoKeys } from './keys';
 import {
   findPhotoInListCache,
+  mediaListPath,
   nextCursorOf,
   removeMediaFromLists,
   selectPhotos,
@@ -45,6 +46,32 @@ function dto(id: string): MediaDto {
     },
   };
 }
+
+describe('mediaListPath', () => {
+  test('즐겨찾기 필터가 없으면 isFavorite 쿼리를 붙이지 않는다(전체)', () => {
+    const path = mediaListPath({ order: 'desc' }, undefined);
+
+    expect(path).not.toContain('isFavorite');
+    expect(path).toContain('order=desc');
+    expect(path).toContain('states=COMPLETE');
+  });
+
+  test('isFavorite=true면 isFavorite=true 쿼리를 붙인다', () => {
+    expect(
+      mediaListPath({ order: 'desc', isFavorite: true }, undefined),
+    ).toContain('isFavorite=true');
+  });
+
+  test('isFavorite=false는 전체와 동일하게 파라미터를 생략한다', () => {
+    expect(
+      mediaListPath({ order: 'desc', isFavorite: false }, undefined),
+    ).not.toContain('isFavorite');
+  });
+
+  test('cursor가 있으면 쿼리에 포함한다', () => {
+    expect(mediaListPath({ order: 'asc' }, 'c2')).toContain('cursor=c2');
+  });
+});
 
 describe('nextCursorOf', () => {
   test('hasNext가 true면 nextCursor를 반환한다', () => {

--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -35,16 +35,29 @@ export function selectPhotos(
     .map(toPhoto);
 }
 
-async function fetchPhotoPage(
-  order: 'asc' | 'desc',
+/**
+ * 목록 조회 URL을 만든다.
+ * - 즐겨찾기 필터는 켜졌을 때만 isFavorite=true를 붙인다
+ * - 생략 시 전체 조회한다.
+ */
+export function mediaListPath(
+  filters: { order: 'asc' | 'desc'; isFavorite?: boolean },
   cursor: string | undefined,
-): Promise<MediaListResponse> {
-  const path = `/v1/media${buildQuery({
+): string {
+  return `/v1/media${buildQuery({
     size: PAGE_SIZE,
-    order,
+    order: filters.order,
     states: 'COMPLETE',
+    isFavorite: filters.isFavorite ? 'true' : undefined,
     cursor,
   })}`;
+}
+
+async function fetchPhotoPage(
+  filters: { order: 'asc' | 'desc'; isFavorite?: boolean },
+  cursor: string | undefined,
+): Promise<MediaListResponse> {
+  const path = mediaListPath(filters, cursor);
 
   const startedAt = performance.now();
   const response = await http.get<MediaListResponse>(path);
@@ -209,12 +222,14 @@ export function usePhotosInfinite(
   options?: { enabled?: boolean },
 ) {
   const order = filters?.order ?? 'desc';
+  const isFavorite = filters?.isFavorite;
   const initialCursor: string | undefined = undefined;
 
   return useInfiniteQuery({
     queryKey: photoKeys.list(filters),
     initialPageParam: initialCursor,
-    queryFn: ({ pageParam }) => fetchPhotoPage(order, pageParam),
+    queryFn: ({ pageParam }) =>
+      fetchPhotoPage({ order, ...(isFavorite && { isFavorite }) }, pageParam),
     getNextPageParam: nextCursorOf,
     enabled: options?.enabled ?? true, // 앨범이 준비된 뒤에만 조회
     staleTime: 60_000,

--- a/apps/web/src/entities/photo/index.ts
+++ b/apps/web/src/entities/photo/index.ts
@@ -13,8 +13,10 @@ export {
 export {
   useUpdatePhotoMetaMutation,
   useDeletePhotoMutation,
+  useToggleFavoriteMutation,
   isAlreadyDeleted,
   type UpdatePhotoMetaVars,
+  type ToggleFavoriteVars,
 } from './api/mutations';
 
 export { toPhoto } from './lib/mapper';

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -43,19 +43,21 @@ import { Skeleton } from '@/shared/ui/skeleton';
 import { toast } from '@/shared/ui/toast';
 
 /**
- * 현재 정렬 순서에 맞는 목록 캐시에서 이전/다음 사진 id를 계산한다.
+ * 진입한 목록과 같은 필터의 캐시에서 이전/다음 사진 id를 계산한다.
  *
  * - 목록을 새로 요청하지 않고({ enabled: false }) 이미 로드된 캐시만 읽는다.
- * - 목록을 거쳐 들어온 경우 인접 사진으로 이동할 수 있다.
+ * - favorite은 진입한 목록의 필터를 그대로 따라가, 즐겨찾기 목록에서 들어오면
+ *   인접 이동도 즐겨찾기 안에서만 이뤄진다(전체 목록과 캐시 키가 갈림).
  * - 직접 진입(캐시 없음)이거나 목록에 없는 id면 prev/next 모두 undefined → 버튼 비활성.
  *
  * @param currentId - 현재 보고 있는 사진 id.
+ * @param favorite - 즐겨찾기 필터로 진입했는지.
  * @returns 이전/다음 사진 id. 없으면 각각 undefined.
  */
-function usePrevNext(currentId: string) {
+function usePrevNext(currentId: string, favorite: boolean) {
   const order = usePhotoSortStore((s) => s.order);
   const { data } = usePhotosInfinite(
-    { sortBy: 'createdAt', order },
+    { sortBy: 'createdAt', order, ...(favorite && { isFavorite: true }) },
     { enabled: false },
   );
 
@@ -84,10 +86,21 @@ function readNavSource(state: unknown): string {
   return 'direct';
 }
 
+/** 라우터 state에서 즐겨찾기 목록 진입 여부를 안전하게 읽는다. */
+function readNavFavorite(state: unknown): boolean {
+  return (
+    typeof state === 'object' &&
+    state !== null &&
+    'favorite' in state &&
+    state.favorite === true
+  );
+}
+
 export function PhotoDetailPage() {
   const { id = '' } = useParams<{ id: string }>();
   const { state } = useLocation();
   const source = readNavSource(state);
+  const favorite = readNavFavorite(state);
 
   const albumId = useAlbumStore((s) => s.current?.id);
   const user = useAuthUser();
@@ -95,7 +108,7 @@ export function PhotoDetailPage() {
 
   const query = usePhotoDetail(id, { enabled: !!albumId && !!id });
   const photo = query.data;
-  const { prevId, nextId } = usePrevNext(id);
+  const { prevId, nextId } = usePrevNext(id, favorite);
   const refreshPhotoUrls = useRefreshPhotoUrls();
 
   useEffect(() => {
@@ -142,8 +155,8 @@ export function PhotoDetailPage() {
           />
         )}
 
-        <NavArrow direction="prev" targetId={prevId} />
-        <NavArrow direction="next" targetId={nextId} />
+        <NavArrow direction="prev" targetId={prevId} favorite={favorite} />
+        <NavArrow direction="next" targetId={nextId} favorite={favorite} />
       </div>
 
       <ErrorBoundary fallback={(error) => <MetaErrorFallback error={error} />}>
@@ -213,9 +226,11 @@ function FavoriteButton({ photo }: { photo: Photo }) {
 function NavArrow({
   direction,
   targetId,
+  favorite,
 }: {
   direction: 'prev' | 'next';
   targetId: string | undefined;
+  favorite: boolean;
 }) {
   const navigate = useNavigate();
   const isPrev = direction === 'prev';
@@ -228,7 +243,9 @@ function NavArrow({
       disabled={!targetId}
       onClick={() =>
         targetId &&
-        navigate(`/photos/${targetId}`, { state: { source: 'nav' } })
+        navigate(`/photos/${targetId}`, {
+          state: { source: 'nav', favorite },
+        })
       }
       className={cn(
         'absolute top-1/2 -translate-y-1/2 rounded-full bg-black/40 text-white hover:bg-black/60 hover:text-white',

--- a/apps/web/src/pages/photo-detail/ui/page.tsx
+++ b/apps/web/src/pages/photo-detail/ui/page.tsx
@@ -13,6 +13,7 @@ import {
   usePhotoDetail,
   usePhotosInfinite,
   useRefreshPhotoUrls,
+  useToggleFavoriteMutation,
   type Photo,
 } from '@/entities/photo';
 import {
@@ -176,22 +177,36 @@ function DetailHeader({
         <X className="size-6" />
       </Button>
       <div className="flex items-center gap-1">
-        {/* TODO: 즐겨찾기 토글 API + 뮤테이션 연결 (현재 시각 스텁) */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="rounded-full"
-          aria-label="즐겨찾기"
-          aria-pressed={photo.isFavorite}
-        >
-          <Heart
-            className={photo.isFavorite ? 'fill-primary text-primary' : ''}
-          />
-        </Button>
+        <FavoriteButton photo={photo} />
         <DownloadButton photo={photo} variant="ghost" size="icon" />
         {canWrite && <DeletePhotoButton photo={photo} />}
       </div>
     </div>
+  );
+}
+
+function FavoriteButton({ photo }: { photo: Photo }) {
+  const mutation = useToggleFavoriteMutation();
+
+  const handleToggle = () => {
+    mutation.mutate(
+      { id: photo.id, isFavorite: !photo.isFavorite },
+      { onError: () => toast.error('즐겨찾기 변경에 실패했어요.') },
+    );
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="rounded-full"
+      aria-label="즐겨찾기"
+      aria-pressed={photo.isFavorite}
+      disabled={mutation.isPending}
+      onClick={handleToggle}
+    >
+      <Heart className={photo.isFavorite ? 'fill-primary text-primary' : ''} />
+    </Button>
   );
 }
 

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -193,7 +193,9 @@ export function PhotoListPage() {
                 key={photo.id}
                 photo={photo}
                 onOpen={(id) =>
-                  navigate(`/photos/${id}`, { state: { source: 'grid' } })
+                  navigate(`/photos/${id}`, {
+                    state: { source: 'grid', favorite },
+                  })
                 }
               />
             )}

--- a/apps/web/src/pages/photo-list/ui/page.tsx
+++ b/apps/web/src/pages/photo-list/ui/page.tsx
@@ -108,13 +108,15 @@ export function PhotoListPage() {
   const enabled = useSelectEnabled();
   const selectedIds = useSelectedIds();
 
+  const [favorite, setFavorite] = useState(false);
+
   const albumId = useAlbumStore((s) => s.current?.id);
 
   const albumsQuery = useAlbums();
   const albumsSettled = albumsQuery.isSuccess || albumsQuery.isError;
 
   const query = usePhotosInfinite(
-    { sortBy: 'createdAt', order },
+    { sortBy: 'createdAt', order, ...(favorite && { isFavorite: true }) },
     { enabled: !!albumId },
   );
   const photos = selectPhotos(query.data);
@@ -161,7 +163,10 @@ export function PhotoListPage() {
       className={`mx-auto max-w-5xl space-y-4 px-4 pt-4 ${enabled ? 'pb-24' : ''}`}
     >
       <div className="flex items-center justify-between gap-3 px-2">
-        <FilterTabs />
+        <FilterTabs
+          active={favorite ? 'favorite' : 'all'}
+          onChange={(key) => setFavorite(key === 'favorite')}
+        />
         <SortSheet />
       </div>
 
@@ -205,14 +210,19 @@ export function PhotoListPage() {
 }
 
 const TABS = [
-  { key: 'all', label: '전체', ready: true },
-  { key: 'favorite', label: '즐겨찾기', ready: false },
+  { key: 'all', label: '전체' },
+  { key: 'favorite', label: '즐겨찾기' },
 ] as const;
 
-// TODO: 즐겨찾기 필터 API 연결 (연결되면 ready: true + active를 상태로 변경, 안내 토스트 제거)
-function FilterTabs() {
-  const active = 'all';
+type FilterKey = (typeof TABS)[number]['key'];
 
+function FilterTabs({
+  active,
+  onChange,
+}: {
+  active: FilterKey;
+  onChange: (key: FilterKey) => void;
+}) {
   return (
     <nav className="flex items-center gap-8" aria-label="사진 필터">
       {TABS.map((tab) => {
@@ -222,13 +232,10 @@ function FilterTabs() {
             key={tab.key}
             type="button"
             aria-current={isActive ? 'page' : undefined}
-            onClick={() => {
-              if (!tab.ready) toast.info('즐겨찾기는 준비 중이에요.');
-            }}
+            onClick={() => onChange(tab.key)}
             className={cn(
               'text-[22px] tracking-tight',
               isActive ? 'text-primary' : 'text-foreground',
-              !tab.ready && 'opacity-25',
             )}
           >
             {tab.label}

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -28,6 +28,7 @@ export interface HttpClient {
   request<T = unknown>(path: string, init?: HttpInit): Promise<T>;
   get<T = unknown>(path: string, init?: HttpInit): Promise<T>;
   post<T = unknown>(path: string, body?: unknown, init?: HttpInit): Promise<T>;
+  put<T = unknown>(path: string, body?: unknown, init?: HttpInit): Promise<T>;
   patch<T = unknown>(path: string, body?: unknown, init?: HttpInit): Promise<T>;
   delete<T = unknown>(path: string, init?: HttpInit): Promise<T>;
 }
@@ -179,6 +180,7 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
     get: (path, init) => request(path, { ...init, method: 'GET' }),
     post: (path, body, init) =>
       request(path, { ...init, method: 'POST', body }),
+    put: (path, body, init) => request(path, { ...init, method: 'PUT', body }),
     patch: (path, body, init) =>
       request(path, { ...init, method: 'PATCH', body }),
     delete: (path, init) => request(path, { ...init, method: 'DELETE' }),


### PR DESCRIPTION
## 📌 관련 이슈
* #7
---
## 🧹 작업 내용
BE에 준비된 즐겨찾기 API를 FE 두 지점에 연동함.
* **등록/해제 토글 (사진 상세)**
    * `PUT`/`DELETE /media/{id}/favorite`를 목표 상태에 따라 분기 호출하는 뮤테이션을 추가 
    * 상세 캐시는 낙관적으로 반영하고 실패 시 롤백하며, 상세·목록 invalidate로 정합을 맞춤. 
    * 하트 버튼에 onClick 연결, pending 중 비활성화, 실패 토스트 연결
* **즐겨찾기 필터 (사진 목록)**
    * `listMedia`의 `isFavorite` 쿼리 파라미터를 필터 탭에 연결 
    * 기존 `ready` 스텁과 "준비 중" 토스트는 제거하고 탭을 실제 상태로 전환
    * 상세 좌우 이동(prev/next)도 진입한 목록 필터를 따라가도록 라우터 state로 필터 전달
* **공통**: 등록 API가 `PUT`이라 http 클라이언트에 `put` 메서드를 추가
---
## 🛠️ 테스트
* [x] 단위 테스트 통과 (토글 4케이스 + `mediaListPath` 직렬화 4케이스 추가)
* [ ] 수동 테스트
---
## 🔍 고민 / 결정 사항
* **필터 인지 내비게이션**
    * 상세 prev/next가 항상 "전체" 캐시를 읽던 걸, 그리드 진입·좌우 이동 시 `state.favorite`를 실어 넘겨 진입한 목록과 같은 필터 캐시를 읽게 함(전체/즐겨찾기 캐시 키가 갈리므로)
---
## 💬 참고 사항
> [!NOTE]
> `.yml` 파일의 계약 경로는 `/media/{cid}/favorite`인데 path 파라미터명은 `mediaId`라 확인해보면 좋을 것 같음.