### PR TITLE
[Chore] FE API 응답에 OpenAPI 생성 zod 스키마 검증 적용

### DIFF
--- a/apps/joka-api/src/domain/use-case/ListMedia.ts
+++ b/apps/joka-api/src/domain/use-case/ListMedia.ts
@@ -1,5 +1,6 @@
 import { Nullable } from '@joka/core/src/type';
 import { Actor } from '@joka/domain-actor/src/domain/Actor';
+import type { SortOrderValue } from '@joka/domain-media/src/domain/ListMediaCondition';
 import { Media } from '@joka/domain-media/src/domain/Media';
 
 import { UseCase } from './UseCase';
@@ -19,7 +20,7 @@ export type Response = {
   items: Media[];
   pagination: {
     size: number;
-    order: string;
+    order: SortOrderValue;
     nextCursor: Nullable<string>;
     hasNext: boolean;
   };

--- a/apps/joka-api/src/infrastructure/web/v1/albums.controller.ts
+++ b/apps/joka-api/src/infrastructure/web/v1/albums.controller.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException } from '@joka/core/src/exception';
+import type { ListAlbumsResponses } from '@joka/lib-openapi/src/generated/type/types.gen';
 import { Hono } from 'hono';
 
 import Config from '../../../application/config';
@@ -31,17 +32,16 @@ albums.get('/', async (c) => {
 
   const result = await Config.actorService.list(user, request);
 
-  return c.json(
-    {
-      items: result.items.map((actor) => ({
-        id: actor.album.cid,
-        name: actor.album.name,
-        role: actor.role,
-      })),
-      pagination: result.pagination,
-    },
-    200,
-  );
+  const body: ListAlbumsResponses[200] = {
+    items: result.items.map((actor) => ({
+      id: actor.album.cid,
+      name: actor.album.name,
+      role: actor.role,
+    })),
+    pagination: result.pagination,
+  };
+
+  return c.json(body, 200);
 });
 
 export default albums;

--- a/apps/joka-api/src/infrastructure/web/v1/media.mapper.ts
+++ b/apps/joka-api/src/infrastructure/web/v1/media.mapper.ts
@@ -106,7 +106,7 @@ export const toPaginationResponse = (
   const result: ApiPagination = {
     size: pagination.size,
     sortBy: 'CREATED_AT',
-    order: pagination.order as ApiPagination['order'],
+    order: pagination.order,
     hasNext: pagination.hasNext,
   };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "chromatic": "chromatic"
   },
   "dependencies": {
+    "@joka/lib-openapi": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@sentry/react": "^10.40.0",
@@ -32,6 +33,7 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.5",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/apps/web/src/app/providers/query-client.tsx
+++ b/apps/web/src/app/providers/query-client.tsx
@@ -11,6 +11,9 @@ const RETRYABLE_CLIENT_ERRORS = new Set([408, 429]); // 타임아웃, 레이트�
 // 4xx는 재요청해도 결과가 같다 → 재시도 안 함(408·429만 일시적이라 예외)
 function isRetryable(error: unknown): boolean {
   if (error instanceof ApiError) {
+    // 계약 위반은 재시도 무의미
+    if (error.code === 'CONTRACT') return false;
+
     const { status } = error;
     if (status >= 400 && status < 500) {
       return RETRYABLE_CLIENT_ERRORS.has(status);

--- a/apps/web/src/entities/album/api/queries.ts
+++ b/apps/web/src/entities/album/api/queries.ts
@@ -1,19 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { http } from '@/shared/api';
-
-import type { Album } from '../model/types';
 import { albumKeys } from './keys';
 
-interface AlbumListResponse {
-  items: Album[];
-}
+import { http } from '@/shared/api';
+import { AlbumListSchema } from '@/shared/api/schemas';
 
 export function useAlbums(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: albumKeys.list(),
     queryFn: async () => {
-      const response = await http.get<AlbumListResponse>('/v1/albums');
+      const response = await http.get('/v1/albums', {
+        schema: AlbumListSchema,
+      });
       return response.items;
     },
     staleTime: 30 * 60 * 1000,

--- a/apps/web/src/entities/photo/api/mutations.test.ts
+++ b/apps/web/src/entities/photo/api/mutations.test.ts
@@ -12,6 +12,7 @@ import { selectPhotos } from './queries';
 import type { MediaDto, MediaPagination, Photo } from '../model/types';
 
 import { ApiError } from '@/shared/api/error';
+import { MediaSchema } from '@/shared/api/schemas';
 
 const mocks = vi.hoisted(() => ({
   patch: vi.fn(),
@@ -46,7 +47,6 @@ function mediaDto(description: string): MediaDto {
       size: 10,
       eTag: 'e',
       mimeType: 'image/jpeg',
-      thumbnail: null,
     },
     created: { at: '2026-01-01T00:00:00.000Z', by: photo().createdBy },
   };
@@ -59,7 +59,7 @@ function otherDto(id: string): MediaDto {
 const pagination: MediaPagination = {
   size: 20,
   sortBy: 'CREATED_AT',
-  order: 'DESC',
+  order: 'desc',
   hasNext: false,
 };
 
@@ -101,9 +101,11 @@ describe('buildUpdatePhotoMetaOptions', () => {
     expect(qc.getQueryData<Photo>(photoKeys.detail('p1'))?.description).toBe(
       '바뀐 설명',
     );
-    expect(mocks.patch).toHaveBeenCalledWith('/v1/media/p1', {
-      description: '바뀐 설명',
-    });
+    expect(mocks.patch).toHaveBeenCalledWith(
+      '/v1/media/p1',
+      { description: '바뀐 설명' },
+      { schema: MediaSchema },
+    );
   });
 
   // TODO: RTL 도입 시 활성화

--- a/apps/web/src/entities/photo/api/mutations.ts
+++ b/apps/web/src/entities/photo/api/mutations.ts
@@ -8,10 +8,11 @@ import {
 import { photoKeys } from './keys';
 import { removeMediaFromLists } from './queries';
 import { toPhoto } from '../lib/mapper';
-import type { MediaDto, Photo } from '../model/types';
+import type { Photo } from '../model/types';
 
 import { http } from '@/shared/api';
 import { ApiError } from '@/shared/api/error';
+import { MediaSchema } from '@/shared/api/schemas';
 
 export interface UpdatePhotoMetaVars {
   id: string;
@@ -28,7 +29,9 @@ export function buildUpdatePhotoMetaOptions(
 ): UseMutationOptions<Photo, Error, UpdatePhotoMetaVars, UpdateContext> {
   return {
     mutationFn: ({ id, description }) =>
-      http.patch<MediaDto>(`/v1/media/${id}`, { description }).then(toPhoto),
+      http
+        .patch(`/v1/media/${id}`, { description }, { schema: MediaSchema })
+        .then(toPhoto),
     meta: { operationId: 'updateMedia' },
 
     onMutate: async ({ id, description }) => {

--- a/apps/web/src/entities/photo/api/queries.test.ts
+++ b/apps/web/src/entities/photo/api/queries.test.ts
@@ -20,7 +20,7 @@ function page(
     pagination: {
       size: 20,
       sortBy: 'CREATED_AT',
-      order: 'DESC',
+      order: 'desc',
       hasNext: false,
       ...pagination,
     },
@@ -38,7 +38,6 @@ function dto(id: string): MediaDto {
       size: 1,
       eTag: 'e',
       mimeType: 'image/jpeg',
-      thumbnail: null,
     },
     created: {
       at: '2026-01-01T00:00:00.000Z',
@@ -107,7 +106,11 @@ describe('selectPhotos', () => {
   });
 
   test('content 없는 항목은 제외한다', () => {
-    const draft: MediaDto = { ...dto('d'), state: 'PREPARING', content: null };
+    const draft: MediaDto = {
+      ...dto('d'),
+      state: 'PREPARING',
+      content: undefined,
+    };
     const data = { pages: [page([dto('a'), draft])] };
     const photos = selectPhotos(data);
 

--- a/apps/web/src/entities/photo/api/queries.ts
+++ b/apps/web/src/entities/photo/api/queries.ts
@@ -16,6 +16,7 @@ import type {
 } from '../model/types';
 
 import { buildQuery, http } from '@/shared/api';
+import { MediaListSchema, MediaSchema } from '@/shared/api/schemas';
 import { recordMediaListSlow } from '@/shared/lib/business-ux-logging';
 
 const PAGE_SIZE = 20;
@@ -60,7 +61,7 @@ async function fetchPhotoPage(
   const path = mediaListPath(filters, cursor);
 
   const startedAt = performance.now();
-  const response = await http.get<MediaListResponse>(path);
+  const response = await http.get(path, { schema: MediaListSchema });
   recordMediaListSlow(performance.now() - startedAt, 'listMedia');
 
   return response;
@@ -174,7 +175,7 @@ export function removeMediaFromLists(
 }
 
 async function fetchPhotoDetail(id: string): Promise<Photo> {
-  const dto = await http.get<MediaDto>(`/v1/media/${id}`);
+  const dto = await http.get(`/v1/media/${id}`, { schema: MediaSchema });
   return toPhoto(dto);
 }
 

--- a/apps/web/src/entities/photo/lib/mapper.test.ts
+++ b/apps/web/src/entities/photo/lib/mapper.test.ts
@@ -22,7 +22,6 @@ const content: MediaContent = {
   size: 1234,
   eTag: 'etag',
   mimeType: 'image/jpeg',
-  thumbnail: null,
 };
 
 describe('toPhoto', () => {
@@ -36,7 +35,7 @@ describe('toPhoto', () => {
   });
 
   test('content가 없으면 키 자체를 만들지 않는다', () => {
-    const photo = toPhoto(baseDto({ state: 'PREPARING', content: null }));
+    const photo = toPhoto(baseDto({ state: 'PREPARING', content: undefined }));
 
     expect('imageUrl' in photo).toBe(false);
     expect('downloadUrl' in photo).toBe(false);
@@ -45,7 +44,7 @@ describe('toPhoto', () => {
   });
 
   test('DRAFT 상태(content 없음)도 안전하게 매핑한다', () => {
-    const photo = toPhoto(baseDto({ state: 'DRAFT', content: null }));
+    const photo = toPhoto(baseDto({ state: 'DRAFT', content: undefined }));
 
     expect(photo.state).toBe('DRAFT');
     expect('imageUrl' in photo).toBe(false);

--- a/apps/web/src/entities/photo/model/schema.ts
+++ b/apps/web/src/entities/photo/model/schema.ts
@@ -1,2 +1,0 @@
-// zod schema (선택)
-export {};

--- a/apps/web/src/entities/photo/model/types.ts
+++ b/apps/web/src/entities/photo/model/types.ts
@@ -1,3 +1,11 @@
+import type {
+  MediaContent,
+  MediaDto,
+  MediaListResponse,
+  MediaPagination,
+  MediaThumbnail,
+} from '@/shared/api/schemas';
+
 export type PhotoState = 'DRAFT' | 'PREPARING' | 'COMPLETE';
 
 /**
@@ -42,53 +50,14 @@ export interface Photo {
   createdBy: UserSummary;
 }
 
-export interface MediaLocation {
-  url: string;
-  accessUrl: string;
-}
-
-export interface MediaThumbnail {
-  location: MediaLocation;
-  size: number;
-  eTag: string;
-  mimeType: string;
-  blurhash: string;
-}
-
-export interface MediaContent {
-  location: MediaLocation;
-  size: number;
-  eTag: string;
-  mimeType: string;
-  thumbnail?: MediaThumbnail | null;
-}
-
-export interface MediaCreated {
-  at: string;
-  by: UserSummary;
-}
-
-export interface MediaDto {
-  id: string;
-  description: string;
-  state: PhotoState;
-  content?: MediaContent | null;
-  isFavorite: boolean;
-  created: MediaCreated;
-}
-
-export interface MediaPagination {
-  size: number;
-  sortBy: 'CREATED_AT';
-  order: 'ASC' | 'DESC';
-  nextCursor?: string;
-  hasNext: boolean;
-}
-
-export interface MediaListResponse {
-  items: MediaDto[];
-  pagination: MediaPagination;
-}
+/** 서버 응답(DTO) 타입은 OpenAPI 스펙에서 생성된 스키마에서 파생한다. */
+export type {
+  MediaContent,
+  MediaDto,
+  MediaListResponse,
+  MediaPagination,
+  MediaThumbnail,
+};
 
 /** useInfiniteQuery 캐시 형태 (setQueriesData/getQueriesData용) */
 export interface InfiniteMedia {

--- a/apps/web/src/features/auth/api/queries.ts
+++ b/apps/web/src/features/auth/api/queries.ts
@@ -4,11 +4,12 @@ import { authKeys } from './keys';
 
 import type { User } from '@/entities/user';
 import { http } from '@/shared/api';
+import { MeSchema } from '@/shared/api/schemas';
 
 export function useMe(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: authKeys.me(),
-    queryFn: () => http.get<User>('/v1/me'),
+    queryFn: (): Promise<User> => http.get('/v1/me', { schema: MeSchema }),
     enabled: options?.enabled ?? true,
     staleTime: 30 * 60 * 1000,
     retry: false,

--- a/apps/web/src/features/photo-upload/api/mutations.test.ts
+++ b/apps/web/src/features/photo-upload/api/mutations.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { uploadSinglePhoto } from './mutations';
 import type { UploadQueueItem } from '../model/types';
 
+import { MediaSchema, UploadUrlSchema } from '@/shared/api/schemas';
+
 const mocks = vi.hoisted(() => ({
   httpPost: vi.fn(),
   putToS3: vi.fn(),
@@ -145,7 +147,7 @@ describe('uploadSinglePhoto', () => {
       1,
       '/v1/media',
       { description: 'a.jpg' },
-      undefined,
+      { schema: MediaSchema },
     );
   });
 
@@ -207,13 +209,13 @@ describe('uploadSinglePhoto', () => {
       1,
       '/v1/media',
       { description: '설명' },
-      undefined,
+      { schema: MediaSchema },
     );
     expect(mocks.httpPost).toHaveBeenNthCalledWith(
       2,
       '/v1/media/media-1/upload-urls',
       {},
-      undefined,
+      { schema: UploadUrlSchema },
     );
     expect(mocks.httpPost).toHaveBeenNthCalledWith(
       3,
@@ -274,8 +276,9 @@ describe('uploadSinglePhoto', () => {
       signal: controller.signal,
     });
 
+    // create·upload-urls는 schema도 함께 실리므로 signal 포함 여부만 검증
     for (const call of mocks.httpPost.mock.calls) {
-      expect(call[2]).toEqual({ signal: controller.signal });
+      expect(call[2]).toMatchObject({ signal: controller.signal });
     }
     expect(mocks.putToS3).toHaveBeenCalledWith(
       'https://s3/url',

--- a/apps/web/src/features/photo-upload/api/mutations.ts
+++ b/apps/web/src/features/photo-upload/api/mutations.ts
@@ -3,16 +3,8 @@ import { UploadQueueItem, UploadStep } from '../model/types';
 
 import { http } from '@/shared/api';
 import type { RequestOptions } from '@/shared/api/client';
+import { MediaSchema, UploadUrlSchema } from '@/shared/api/schemas';
 import { createMediaUploadFlow } from '@/shared/lib/media-upload-logging';
-
-interface CreateMediaResponse {
-  id: string;
-  state: string;
-}
-
-interface UploadUrlsResponse {
-  url: string;
-}
 
 export interface UploadCallbacks {
   onStep: (step: UploadStep) => void;
@@ -64,10 +56,10 @@ async function createMedia(
   item: UploadQueueItem,
   reqOptions?: RequestOptions,
 ): Promise<string> {
-  const created = await http.post<CreateMediaResponse>(
+  const created = await http.post(
     '/v1/media',
     { description: item.description.trim() || item.file.name },
-    reqOptions,
+    { ...reqOptions, schema: MediaSchema },
   );
 
   return created.id;
@@ -77,10 +69,10 @@ async function getUploadUrl(
   mediaId: string,
   reqOptions?: RequestOptions,
 ): Promise<string> {
-  const { url } = await http.post<UploadUrlsResponse>(
+  const { url } = await http.post(
     `/v1/media/${mediaId}/upload-urls`,
     {},
-    reqOptions,
+    { ...reqOptions, schema: UploadUrlSchema },
   );
 
   return url;

--- a/apps/web/src/features/photo-upload/api/mutations.ts
+++ b/apps/web/src/features/photo-upload/api/mutations.ts
@@ -2,7 +2,7 @@ import { putToS3, PutToS3Options } from '../lib/s3-uploader';
 import { UploadQueueItem, UploadStep } from '../model/types';
 
 import { http } from '@/shared/api';
-import type { HttpInit } from '@/shared/api/client';
+import type { RequestOptions } from '@/shared/api/client';
 import { createMediaUploadFlow } from '@/shared/lib/media-upload-logging';
 
 interface CreateMediaResponse {
@@ -62,7 +62,7 @@ export async function uploadSinglePhoto(
 
 async function createMedia(
   item: UploadQueueItem,
-  reqOptions?: HttpInit,
+  reqOptions?: RequestOptions,
 ): Promise<string> {
   const created = await http.post<CreateMediaResponse>(
     '/v1/media',
@@ -75,7 +75,7 @@ async function createMedia(
 
 async function getUploadUrl(
   mediaId: string,
-  reqOptions?: HttpInit,
+  reqOptions?: RequestOptions,
 ): Promise<string> {
   const { url } = await http.post<UploadUrlsResponse>(
     `/v1/media/${mediaId}/upload-urls`,
@@ -89,7 +89,7 @@ async function getUploadUrl(
 async function registerContents(
   mediaId: string,
   url: string,
-  reqOptions?: HttpInit,
+  reqOptions?: RequestOptions,
 ): Promise<void> {
   await http.post(`/v1/media/${mediaId}/contents`, { url }, reqOptions);
 }
@@ -97,7 +97,7 @@ async function registerContents(
 async function confirmMedia(
   mediaId: string,
   flow: UploadFlow,
-  reqOptions?: HttpInit,
+  reqOptions?: RequestOptions,
 ): Promise<void> {
   try {
     await http.post(`/v1/media/${mediaId}/confirm`, {}, reqOptions);

--- a/apps/web/src/features/photo-upload/model/runner.ts
+++ b/apps/web/src/features/photo-upload/model/runner.ts
@@ -60,7 +60,6 @@ function buildOptimisticDto(
       size: item.file.size,
       eTag: '',
       mimeType: item.file.type || 'application/octet-stream',
-      thumbnail: null,
     },
   };
 }

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -6,6 +6,7 @@ import {
   attachAlbumHeader,
 } from './interceptors';
 import { createRefresher } from './refresh';
+import { validate, type ResponseSchema } from './response-validation';
 
 import { env } from '@/shared/config/env';
 import { trackApiTiming } from '@/shared/lib/analytics';
@@ -18,18 +19,6 @@ export interface HttpClientOptions {
   refreshPath?: string;
   refresh?: () => Promise<string>;
   onUnauthorized?: () => void;
-}
-
-/**
- * 응답 검증 스키마
- * - zod 스키마가 구조적으로 만족하므로 client는 zod에 직접 의존하지 않는다.
- */
-export interface ResponseSchema<T> {
-  safeParse(
-    data: unknown,
-  ):
-    | { success: true; data: T }
-    | { success: false; error: { issues: unknown[] } };
 }
 
 export interface HttpInit<T = unknown> extends Omit<RequestInit, 'body'> {
@@ -98,23 +87,6 @@ function normalize(init: HttpInit<unknown>): RequestInit {
   };
 }
 
-async function parseResponse(response: Response): Promise<unknown> {
-  if (response.status === 204) {
-    return undefined;
-  }
-
-  const text = await response.text();
-  if (!text) {
-    return undefined;
-  }
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
-}
-
 async function sendRequest(ctx: ApiRequest): Promise<Response> {
   const method = ctx.options.method ?? 'GET';
   const start = performance.now();
@@ -138,6 +110,23 @@ async function sendRequest(ctx: ApiRequest): Promise<Response> {
   }
 }
 
+async function parseResponse(response: Response): Promise<unknown> {
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
 async function failWith(
   response: Response,
   ctx: ApiRequest,
@@ -145,31 +134,6 @@ async function failWith(
 ): Promise<never> {
   const err = await toApiError(response);
   reportApiError(err, { url: ctx.url, ...extra });
-  throw err;
-}
-
-/**
- * 응답이 API 계약(OpenAPI 스펙)과 다르면 계약 위반(CONTRACT)으로 다룬다.
- * - HTTP 자체는 성공(2xx)이므로 실제 status를 그대로 싣고, 성격은 code로 구분한다.
- * - 사용자 문구·재시도 정책은 code로 분기된다.
- */
-function validate<T>(
-  data: unknown,
-  schema: ResponseSchema<T>,
-  ctx: ApiRequest,
-  status: number,
-): T {
-  const parsed = schema.safeParse(data);
-  if (parsed.success) {
-    return parsed.data;
-  }
-
-  const err = new ApiError({ status, code: 'CONTRACT' });
-  reportApiError(err, {
-    url: ctx.url,
-    schemaViolation: true,
-    issues: parsed.error.issues,
-  });
   throw err;
 }
 
@@ -227,7 +191,7 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
 
     const data = await parseResponse(response);
     return init.schema
-      ? validate(data, init.schema, ctx, response.status)
+      ? validate(data, init.schema, ctx.url, response.status)
       : (data as T);
   }
 

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -20,17 +20,46 @@ export interface HttpClientOptions {
   onUnauthorized?: () => void;
 }
 
-export interface HttpInit extends Omit<RequestInit, 'body'> {
-  body?: unknown;
+/**
+ * 응답 검증 스키마
+ * - zod 스키마가 구조적으로 만족하므로 client는 zod에 직접 의존하지 않는다.
+ */
+export interface ResponseSchema<T> {
+  safeParse(
+    data: unknown,
+  ):
+    | { success: true; data: T }
+    | { success: false; error: { issues: unknown[] } };
 }
 
+export interface HttpInit<T = unknown> extends Omit<RequestInit, 'body'> {
+  body?: unknown;
+  /** 넘기면 응답을 런타임 검증하고 T를 추론한다. 생략하면 검증 없이 그대로 캐스팅한다. */
+  schema?: ResponseSchema<T>;
+}
+
+/** 스키마 없이 요청 옵션만 전달할 때 쓴다. 응답 타입과 무관하므로 어떤 호출에도 넘길 수 있다. */
+export type RequestOptions = Omit<HttpInit, 'schema'>;
+
 export interface HttpClient {
-  request<T = unknown>(path: string, init?: HttpInit): Promise<T>;
-  get<T = unknown>(path: string, init?: HttpInit): Promise<T>;
-  post<T = unknown>(path: string, body?: unknown, init?: HttpInit): Promise<T>;
-  put<T = unknown>(path: string, body?: unknown, init?: HttpInit): Promise<T>;
-  patch<T = unknown>(path: string, body?: unknown, init?: HttpInit): Promise<T>;
-  delete<T = unknown>(path: string, init?: HttpInit): Promise<T>;
+  request<T = unknown>(path: string, init?: HttpInit<T>): Promise<T>;
+  get<T = unknown>(path: string, init?: HttpInit<T>): Promise<T>;
+  post<T = unknown>(
+    path: string,
+    body?: unknown,
+    init?: HttpInit<T>,
+  ): Promise<T>;
+  put<T = unknown>(
+    path: string,
+    body?: unknown,
+    init?: HttpInit<T>,
+  ): Promise<T>;
+  patch<T = unknown>(
+    path: string,
+    body?: unknown,
+    init?: HttpInit<T>,
+  ): Promise<T>;
+  delete<T = unknown>(path: string, init?: HttpInit<T>): Promise<T>;
 }
 
 function isRawBody(body: unknown): body is BodyInit {
@@ -42,8 +71,8 @@ function isRawBody(body: unknown): body is BodyInit {
   );
 }
 
-function normalize(init: HttpInit): RequestInit {
-  const { body, credentials, ...rest } = init;
+function normalize(init: HttpInit<unknown>): RequestInit {
+  const { body, credentials, schema: _schema, ...rest } = init;
   const withCredentials: RequestInit = {
     ...rest,
     credentials: credentials ?? 'include',
@@ -119,6 +148,31 @@ async function failWith(
   throw err;
 }
 
+/**
+ * 응답이 API 계약(OpenAPI 스펙)과 다르면 계약 위반(CONTRACT)으로 다룬다.
+ * - HTTP 자체는 성공(2xx)이므로 실제 status를 그대로 싣고, 성격은 code로 구분한다.
+ * - 사용자 문구·재시도 정책은 code로 분기된다.
+ */
+function validate<T>(
+  data: unknown,
+  schema: ResponseSchema<T>,
+  ctx: ApiRequest,
+  status: number,
+): T {
+  const parsed = schema.safeParse(data);
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  const err = new ApiError({ status, code: 'CONTRACT' });
+  reportApiError(err, {
+    url: ctx.url,
+    schemaViolation: true,
+    issues: parsed.error.issues,
+  });
+  throw err;
+}
+
 export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
   const baseURL = options.baseURL ?? DEFAULT_BASE_URL;
   const refresh =
@@ -130,7 +184,7 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
   const onUnauthorized =
     options.onUnauthorized ?? (() => authTokenStore.clear());
 
-  function buildRequest(path: string, init: HttpInit): ApiRequest {
+  function buildRequest(path: string, init: HttpInit<unknown>): ApiRequest {
     return attachAlbumHeader(
       attachAuthHeader({
         url: `${baseURL}${path}`,
@@ -155,7 +209,7 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
 
   async function request<T = unknown>(
     path: string,
-    init: HttpInit = {},
+    init: HttpInit<T> = {},
     isRetry = false,
   ): Promise<T> {
     const ctx = buildRequest(path, init);
@@ -172,7 +226,9 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
     }
 
     const data = await parseResponse(response);
-    return data as T;
+    return init.schema
+      ? validate(data, init.schema, ctx, response.status)
+      : (data as T);
   }
 
   const client: HttpClient = {

--- a/apps/web/src/shared/api/error.ts
+++ b/apps/web/src/shared/api/error.ts
@@ -10,6 +10,7 @@ export type ApiErrorCode =
   | 'CONFLICT'
   | 'VALIDATION'
   | 'SERVER'
+  | 'CONTRACT'
   | 'UNKNOWN';
 
 type ErrorLayer = 'expected' | 'operational' | 'bug';
@@ -50,6 +51,11 @@ const ERROR_CONFIG: Record<
   SERVER: {
     layer: 'operational',
     defaultMessage: '서버 내부 오류가 발생했습니다.',
+  },
+  // 응답이 스펙과 다름(서버 코드 버그) → 재시도 무의미하므로 bug 계층으로 알림
+  CONTRACT: {
+    layer: 'bug',
+    defaultMessage: '응답이 API 계약과 일치하지 않습니다.',
   },
   UNKNOWN: { layer: 'bug', defaultMessage: '알 수 없는 오류가 발생했습니다.' },
 };

--- a/apps/web/src/shared/api/response-validation.ts
+++ b/apps/web/src/shared/api/response-validation.ts
@@ -1,0 +1,38 @@
+import { ApiError, reportApiError } from './error';
+
+/**
+ * 응답 검증 스키마
+ * - zod 스키마가 구조적으로 만족하므로 client는 zod에 직접 의존하지 않는다.
+ */
+export interface ResponseSchema<T> {
+  safeParse(
+    data: unknown,
+  ):
+    | { success: true; data: T }
+    | { success: false; error: { issues: unknown[] } };
+}
+
+/**
+ * 응답이 API 계약(OpenAPI 스펙)과 다르면 계약 위반(CONTRACT)으로 다룬다.
+ * - HTTP 자체는 성공(2xx)이므로 실제 status를 그대로 싣고, 성격은 code로 구분한다.
+ * - 사용자 문구·재시도 정책은 code로 분기된다.
+ */
+export function validate<T>(
+  data: unknown,
+  schema: ResponseSchema<T>,
+  url: string,
+  status: number,
+): T {
+  const parsed = schema.safeParse(data);
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  const err = new ApiError({ status, code: 'CONTRACT' });
+  reportApiError(err, {
+    url,
+    schemaViolation: true,
+    issues: parsed.error.issues,
+  });
+  throw err;
+}

--- a/apps/web/src/shared/api/schemas.ts
+++ b/apps/web/src/shared/api/schemas.ts
@@ -1,0 +1,37 @@
+import {
+  zAlbum,
+  zContent,
+  zGetMyInfoResponse,
+  zListAlbumsResponse,
+  zListMediaResponse,
+  zMedia,
+  zThumbnail,
+} from '@joka/lib-openapi';
+import { z } from 'zod';
+
+// size는 bigint(JSON.stringify 불가)라 number로 좁힌다.
+const zSize = z.coerce.number().int().positive();
+
+const zThumbnailSchema = zThumbnail.extend({ size: zSize });
+const zContentSchema = zContent.extend({
+  size: zSize,
+  thumbnail: z.optional(zThumbnailSchema),
+});
+const zMediaSchema = zMedia.extend({ content: z.optional(zContentSchema) });
+
+export const MediaSchema = zMediaSchema;
+export const MediaListSchema = zListMediaResponse.extend({
+  items: z.array(zMediaSchema),
+});
+export const AlbumListSchema = zListAlbumsResponse;
+export const AlbumSchema = zAlbum;
+export const MeSchema = zGetMyInfoResponse;
+
+export type MediaDto = z.infer<typeof MediaSchema>;
+export type MediaContent = z.infer<typeof zContentSchema>;
+export type MediaThumbnail = z.infer<typeof zThumbnailSchema>;
+export type MediaListResponse = z.infer<typeof MediaListSchema>;
+export type MediaPagination = MediaListResponse['pagination'];
+export type AlbumListResponse = z.infer<typeof AlbumListSchema>;
+export type AlbumDto = z.infer<typeof AlbumSchema>;
+export type MeResponse = z.infer<typeof MeSchema>;

--- a/apps/web/src/shared/api/schemas.ts
+++ b/apps/web/src/shared/api/schemas.ts
@@ -1,6 +1,7 @@
 import {
   zAlbum,
   zContent,
+  zCreateUploadUrlForMediaResponse,
   zGetMyInfoResponse,
   zListAlbumsResponse,
   zListMediaResponse,
@@ -26,6 +27,7 @@ export const MediaListSchema = zListMediaResponse.extend({
 export const AlbumListSchema = zListAlbumsResponse;
 export const AlbumSchema = zAlbum;
 export const MeSchema = zGetMyInfoResponse;
+export const UploadUrlSchema = zCreateUploadUrlForMediaResponse;
 
 export type MediaDto = z.infer<typeof MediaSchema>;
 export type MediaContent = z.infer<typeof zContentSchema>;
@@ -35,3 +37,4 @@ export type MediaPagination = MediaListResponse['pagination'];
 export type AlbumListResponse = z.infer<typeof AlbumListSchema>;
 export type AlbumDto = z.infer<typeof AlbumSchema>;
 export type MeResponse = z.infer<typeof MeSchema>;
+export type UploadUrlResponse = z.infer<typeof UploadUrlSchema>;

--- a/apps/web/src/shared/lib/error-fallback.ts
+++ b/apps/web/src/shared/lib/error-fallback.ts
@@ -6,6 +6,9 @@ import { ApiError } from '@/shared/api/error';
  */
 export function errorFallbackMessage(error: unknown): string {
   if (error instanceof ApiError) {
+    // 계약 위반은 재시도가 무의미하므로 → 재시도 뉘앙스 없이 담백하게 알림
+    if (error.code === 'CONTRACT') return '어라, 뭔가 안 맞아요. 곧 고칠게요';
+
     const isNetworkError =
       error.code === 'NETWORK' ||
       error.code === 'TIMEOUT' ||

--- a/packages/domain-actor/src/domain/ListActorsCondition.ts
+++ b/packages/domain-actor/src/domain/ListActorsCondition.ts
@@ -21,6 +21,8 @@ const SortOrder = {
   DESC: 'desc',
 } as const;
 
+export type SortOrderValue = (typeof SortOrder)[keyof typeof SortOrder];
+
 export class ListActorsCondition {
   static get DefaultLimit() {
     return 20;
@@ -87,7 +89,7 @@ export class ListActorsCondition {
 
 export interface ListAlbumsPagination {
   size: number;
-  order: string;
+  order: SortOrderValue;
   nextCursor: Nullable<string>;
   hasNext: boolean;
 }

--- a/packages/domain-media/src/domain/ListMediaCondition.ts
+++ b/packages/domain-media/src/domain/ListMediaCondition.ts
@@ -26,6 +26,8 @@ const SortOrder = {
   DESC: 'desc',
 } as const;
 
+export type SortOrderValue = (typeof SortOrder)[keyof typeof SortOrder];
+
 // TODO: 일단 최신순 기준으로만 정렬함!
 export class ListMediaCondition {
   static get DefaultLimit() {
@@ -76,7 +78,7 @@ export class ListMediaCondition {
     public readonly limit: number,
     public readonly filter: Filter,
     public readonly cursor: Nullable<Cursor>,
-    public readonly sortOrder: (typeof SortOrder)[keyof typeof SortOrder],
+    public readonly sortOrder: SortOrderValue,
   ) {}
 
   get hasDescendingOrder(): boolean {
@@ -95,7 +97,7 @@ export class ListMediaCondition {
 
 export interface ListMediaPagination {
   size: number;
-  order: string;
+  order: SortOrderValue;
   nextCursor: Nullable<string>;
   hasNext: boolean;
 }

--- a/packages/lib-openapi/docs/api-v1.yml
+++ b/packages/lib-openapi/docs/api-v1.yml
@@ -89,8 +89,8 @@ paths:
           schema:
             type: string
             enum:
-              - ASC
-              - DESC
+              - asc
+              - desc
             minLength: 1
         - name: cursor
           in: query
@@ -381,8 +381,8 @@ paths:
           schema:
             type: string
             enum:
-              - ASC
-              - DESC
+              - asc
+              - desc
             minLength: 1
         - name: cursor
           in: query
@@ -614,8 +614,8 @@ components:
                   order:
                     type: string
                     enum:
-                      - ASC
-                      - DESC
+                      - asc
+                      - desc
                     description: 정렬 순서
                   nextCursor:
                     type: string
@@ -751,12 +751,13 @@ components:
                   order:
                     type: string
                     enum:
-                      - ASC
-                      - DESC
+                      - asc
+                      - desc
                     description: 정렬 순서
                   nextCursor:
                     type: string
                     description: 커서
+                    nullable: true
                   hasNext:
                     type: boolean
                     description: 다음 페이지 존재 여부

--- a/packages/lib-openapi/src/generated/api-v1.d.ts
+++ b/packages/lib-openapi/src/generated/api-v1.d.ts
@@ -437,7 +437,7 @@ export interface components {
                          * @description 정렬 순서
                          * @enum {string}
                          */
-                        order: "ASC" | "DESC";
+                        order: "asc" | "desc";
                         /** @description 커서 */
                         nextCursor?: string;
                         /** @description 다음 페이지 존재 여부 */
@@ -560,9 +560,9 @@ export interface components {
                          * @description 정렬 순서
                          * @enum {string}
                          */
-                        order: "ASC" | "DESC";
+                        order: "asc" | "desc";
                         /** @description 커서 */
-                        nextCursor?: string;
+                        nextCursor?: string | null;
                         /** @description 다음 페이지 존재 여부 */
                         hasNext: boolean;
                     };
@@ -690,7 +690,7 @@ export interface operations {
                 /** @description 정렬 기준 */
                 sortBy?: "CREATED_AT";
                 /** @description 정렬 순서 */
-                order?: "ASC" | "DESC";
+                order?: "asc" | "desc";
                 /** @description 커서 */
                 cursor?: string;
                 /**
@@ -953,7 +953,7 @@ export interface operations {
                 /** @description 목록에 포함될 요소 개수 */
                 size?: string;
                 /** @description 정렬 순서 */
-                order?: "ASC" | "DESC";
+                order?: "asc" | "desc";
                 /** @description 커서 */
                 cursor?: string;
             };

--- a/packages/lib-openapi/src/generated/type/types.gen.ts
+++ b/packages/lib-openapi/src/generated/type/types.gen.ts
@@ -343,7 +343,7 @@ export type ListMediaData = {
         /**
          * 정렬 순서
          */
-        order?: 'ASC' | 'DESC';
+        order?: 'asc' | 'desc';
         /**
          * 커서
          */
@@ -398,7 +398,7 @@ export type ListMediaResponses = {
             /**
              * 정렬 순서
              */
-            order: 'ASC' | 'DESC';
+            order: 'asc' | 'desc';
             /**
              * 커서
              */
@@ -905,7 +905,7 @@ export type ListAlbumsData = {
         /**
          * 정렬 순서
          */
-        order?: 'ASC' | 'DESC';
+        order?: 'asc' | 'desc';
         /**
          * 커서
          */
@@ -940,11 +940,11 @@ export type ListAlbumsResponses = {
             /**
              * 정렬 순서
              */
-            order: 'ASC' | 'DESC';
+            order: 'asc' | 'desc';
             /**
              * 커서
              */
-            nextCursor?: string;
+            nextCursor?: string | null;
             /**
              * 다음 페이지 존재 여부
              */

--- a/packages/lib-openapi/src/generated/type/zod.gen.ts
+++ b/packages/lib-openapi/src/generated/type/zod.gen.ts
@@ -206,8 +206,8 @@ export const zListMediaData = z.object({
             'CREATED_AT'
         ])),
         order: z.optional(z.enum([
-            'ASC',
-            'DESC'
+            'asc',
+            'desc'
         ])),
         cursor: z.optional(z.string().min(1)),
         states: z.optional(z.string().min(1)),
@@ -233,8 +233,8 @@ export const zListMediaResponse = z.object({
             'CREATED_AT'
         ]),
         order: z.enum([
-            'ASC',
-            'DESC'
+            'asc',
+            'desc'
         ]),
         nextCursor: z.optional(z.string().min(1)),
         hasNext: z.boolean()
@@ -400,8 +400,8 @@ export const zListAlbumsData = z.object({
     query: z.optional(z.object({
         size: z.optional(z.string().min(1)).default('20'),
         order: z.optional(z.enum([
-            'ASC',
-            'DESC'
+            'asc',
+            'desc'
         ])),
         cursor: z.optional(z.string().min(1))
     })),
@@ -418,10 +418,13 @@ export const zListAlbumsResponse = z.object({
     pagination: z.object({
         size: z.int(),
         order: z.enum([
-            'ASC',
-            'DESC'
+            'asc',
+            'desc'
         ]),
-        nextCursor: z.optional(z.string()),
+        nextCursor: z.optional(z.union([
+            z.string(),
+            z.null()
+        ])),
         hasNext: z.boolean()
     })
 });

--- a/packages/lib-openapi/test/schemas.test.ts
+++ b/packages/lib-openapi/test/schemas.test.ts
@@ -237,7 +237,7 @@ describe('Zod schemas', () => {
         pagination: {
           size: 20,
           sortBy: 'CREATED_AT' as const,
-          order: 'DESC' as const,
+          order: 'desc' as const,
           nextCursor: 'cursor-abc',
           hasNext: true,
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@joka/lib-openapi':
+        specifier: workspace:*
+        version: link:../../packages/lib-openapi
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -203,6 +206,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.5
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))


### PR DESCRIPTION
## 📌 관련 이슈
* #139 

---

## 🧹 작업 내용
OpenAPI 생성 zod 스키마로 응답을 검증하도록 붙이고, 실제 계약 불일치 2건을 발견·정정.

* **계약 정정 + 재생성**
    * `order` enum을 실제 값 `asc/desc`로, `albums.nextCursor`를 nullable로 정정 후 타입·zod 재생성
* **BE 드리프트 방지**
    * 도메인 `order`를 리터럴 유니온으로 좁히고 매퍼 캐스팅 제거·응답을 생성 타입에 바인딩 → 같은 드리프트 재발 시 BE 컴파일이 깨짐
* **http 클라이언트**: `HttpInit.schema` opt-in 검증 추가(넘기면 검증·타입추론, 생략 시 기존 동작)
* 계약 위반은 전용 `CONTRACT` 코드로 분리
* **FE DTO**: 손수 타입 → 생성 zod의 `z.infer` 파생으로 교체
* **호출부 연결**: media 목록·상세·수정, albums, me, 업로드(createMedia·upload-urls)
* **리팩터**: `client.ts` 구조 정리(응답 검증 분리·실행 흐름 순서) 

---

## 🛠️ 테스트
* [x] 단위 테스트 통과
* [ ] 수동 테스트 완료 (데모 후 QA 예정 )
* [x] 기존 기능 영향 없음 확인 (검증은 opt-in이라 미연결 경로 무변화)

---

## 🔍 고민 / 결정 사항

* **confirm/content 응답 미검증**: FE가 이 응답을 안 쓰므로, 검증하면 결과를 버리면서 502 리스크만 늘어 제외

---

## 💬 참고 사항
> [!NOTE]
> 데모 중에는 머지하지 않습니다(데모는 develop 기준으로 진행)
> 데모 이후 새벽에 머지하고 QA를 돌려볼 예정입니다!